### PR TITLE
EDIT - network plugin 

### DIFF
--- a/src/plugins/net_plugin/kademlia/include/node.hpp
+++ b/src/plugins/net_plugin/kademlia/include/node.hpp
@@ -54,7 +54,10 @@ namespace gruut {
       }
 
       bool isAlive() const {
-        return (m_channel_ptr != nullptr) && (m_channel_ptr->GetState(false) == grpc_connectivity_state::GRPC_CHANNEL_CONNECTING);
+        auto channel_stat = m_channel_ptr->GetState(false);
+        return (m_channel_ptr != nullptr) &&
+        (channel_stat != grpc_connectivity_state::GRPC_CHANNEL_TRANSIENT_FAILURE) &&
+            (channel_stat != grpc_connectivity_state::GRPC_CHANNEL_SHUTDOWN);
       }
 
       HashedIdType distanceTo(Node const &node) const { return distanceTo(node.getIdHash()); }

--- a/src/plugins/net_plugin/kademlia/include/node.hpp
+++ b/src/plugins/net_plugin/kademlia/include/node.hpp
@@ -9,6 +9,7 @@
 #include <memory>
 #include <chrono>
 #include <string>
+#include <grpcpp/grpcpp.h>
 #include <grpcpp/channel.h>
 #include <grpc/impl/codegen/connectivity_state.h>
 
@@ -55,9 +56,7 @@ namespace gruut {
 
       bool isAlive() const {
         auto channel_stat = m_channel_ptr->GetState(false);
-        return (m_channel_ptr != nullptr) &&
-        (channel_stat != grpc_connectivity_state::GRPC_CHANNEL_TRANSIENT_FAILURE) &&
-            (channel_stat != grpc_connectivity_state::GRPC_CHANNEL_SHUTDOWN);
+        return (m_channel_ptr != nullptr) && (channel_stat == grpc_connectivity_state::GRPC_CHANNEL_READY);
       }
 
       HashedIdType distanceTo(Node const &node) const { return distanceTo(node.getIdHash()); }
@@ -66,7 +65,16 @@ namespace gruut {
         return m_id_hash ^ hash;
       }
 
+      void openChannel() {
+        if(m_channel_ptr != nullptr)
+          return;
+        auto credential = grpc::InsecureChannelCredentials();
+        m_channel_ptr = grpc::CreateChannel(m_endpoint.address + ":" + m_endpoint.port, credential);
+      }
+
       void incFailuresCount() { ++m_failed_requests_count; }
+
+      std::shared_ptr<grpc::Channel> getChannelPtr() { return m_channel_ptr; }
 
       HashedIdType &getIdHash() { return m_id_hash; }
 

--- a/src/plugins/net_plugin/kademlia/kbucket.cpp
+++ b/src/plugins/net_plugin/kademlia/kbucket.cpp
@@ -28,9 +28,11 @@ namespace gruut {
               [&node](Node &bucket_node) { return (bucket_node == node); });
       if (found != m_nodes.end()) {
         m_nodes.erase(found);
+
+        node.openChannel();
         m_nodes.emplace_back(std::move(node));
       } else if (!full()) {
-
+        node.openChannel();
         m_nodes.emplace_back(std::move(node));
       } else {
 
@@ -70,6 +72,7 @@ namespace gruut {
 
       if (!m_replacement_nodes.empty()) {
 
+        m_replacement_nodes.back().openChannel();
         m_nodes.emplace_back(std::move(m_replacement_nodes.back()));
         m_replacement_nodes.pop_back();
       }

--- a/src/plugins/net_plugin/kademlia/routing.cpp
+++ b/src/plugins/net_plugin/kademlia/routing.cpp
@@ -68,7 +68,6 @@ namespace gruut {
       auto bucket = m_buckets.begin();
       std::advance(bucket, bucket_index);
 
-
       bool check = bucket->addNode(std::move(peer));
 
       m_buckets_mutex.unlock();
@@ -130,7 +129,6 @@ namespace gruut {
               m_buckets_mutex.unlock();
               return true;
             } else {
-              bn->initFailuresCount();
               return false;
             }
           }


### PR DESCRIPTION
# 수정사항
- Node 객체의 isAlive() 수정
  * Test 사항
  * Channel open 시 : IDLE
  * Rpc 요청 보낸 후 : READY
  * Channel close (rpc server 강제 종료) : IDLE -> CONNECTING -> TRANSIENT_FAILURE


- queryNeighborNodes 에서 query를 보낼 Node와 연결된 channel을 이용해 stub를 생성하도록 함

- findNeighbors 수정
   * peerTimedOut 시 failureCount가 제한수에 도달 했을때 해당 Node를 삭제하고 아닐 시 다시 query를 보내도록 함. 성공시에는 failureCount를 0으로 초기화


- 새로운 Node를 Routing Table에 삽입할 때  해당 Node와 Channel을 열도록 함. 
만약, 해당 kBucket이 가득 찼을때는 replacement_list(replacement_nodes)에 보관한다. 이때는 채널을 만들지 않음. kbucket에 Node가 삭제되어 자리가 나면, replacement_list에서 가져와 자릴 채운다. 이때 Channel을 열도록 함.