### PR TITLE
# EDIT - relocate `peer.initFailuresCount`

### DIFF
--- a/src/plugins/net_plugin/kademlia/routing.cpp
+++ b/src/plugins/net_plugin/kademlia/routing.cpp
@@ -56,10 +56,10 @@ namespace gruut {
     bool RoutingTable::addPeer(Node &&peer) {
 
       if (m_my_node == peer) {
-
         return true;
       }
 
+      peer.initFailuresCount();
       m_node_table[peer.getId()] = peer.getEndpoint();
 
       std::lock_guard<std::mutex> lock(m_buckets_mutex);

--- a/src/plugins/net_plugin/net_plugin.cpp
+++ b/src/plugins/net_plugin/net_plugin.cpp
@@ -112,7 +112,6 @@ namespace gruut {
           }
         } else {
           for (auto &neighbor : recv_data.neighbors) {
-            neighbor.initFailuresCount();
             routing_table->addPeer(move(neighbor));
           }
         }


### PR DESCRIPTION
## Description
- `NetPluginImpl` do not need to know that peer have to initialize failure counter.
- Remove`neighbor.initFailuresCount()` in `net_plugin.cpp` to reduce the dependency.