### PR TITLE
# ADD - channel connection check & remove dead node

### DIFF
--- a/src/plugins/net_plugin/kademlia/include/kbucket.hpp
+++ b/src/plugins/net_plugin/kademlia/include/kbucket.hpp
@@ -96,14 +96,14 @@ public:
   std::string sharedPrefix() const {
 	return m_prefix.to_string().substr(0, m_prefix_size);
   }
-  //@}
-
 
   Node &sendConvRequest() { return m_nodes.front(); }
 
   Node const &leastRecentlySeenNode() const { return m_nodes.front(); }
 
-	std::vector<Node> selectAliveNodes();
+  std::vector<Node> selectAliveNodes();
+
+  void removeDeadNodes();
 
   bool addNode(Node &&node);
 

--- a/src/plugins/net_plugin/kademlia/include/node.hpp
+++ b/src/plugins/net_plugin/kademlia/include/node.hpp
@@ -70,6 +70,7 @@ namespace gruut {
           return;
         auto credential = grpc::InsecureChannelCredentials();
         m_channel_ptr = grpc::CreateChannel(m_endpoint.address + ":" + m_endpoint.port, credential);
+        m_channel_ptr->GetState(true);
       }
 
       void incFailuresCount() { ++m_failed_requests_count; }

--- a/src/plugins/net_plugin/kademlia/kbucket.cpp
+++ b/src/plugins/net_plugin/kademlia/kbucket.cpp
@@ -142,6 +142,11 @@ namespace gruut {
       return alive_nodes;
     }
 
+    void KBucket::removeDeadNodes() {
+      m_nodes.erase(std::remove_if(m_nodes.begin(), m_nodes.end(),[](auto &n){ return !n.isAlive(); }),
+          m_nodes.end());
+    }
+
     bool KBucket::empty() const { return m_nodes.empty(); }
 
     bool KBucket::full() const { return m_nodes.size() == m_ksize; }

--- a/src/plugins/net_plugin/net_plugin.cpp
+++ b/src/plugins/net_plugin/net_plugin.cpp
@@ -91,6 +91,7 @@ namespace gruut {
 
       for (auto &bucket : *routing_table) {
         if (!bucket.empty()) {
+          bucket.removeDeadNodes();
           auto nodes = bucket.selectAliveNodes();
 
           async(launch::async, &NetPluginImpl::findNeighbors, this, nodes);


### PR DESCRIPTION
# 문제 사항
- 종전에 channel만 단순히 open 하였을 시 handshaking은 하지 않고 IDLE 상태만 유지 하는 것 확인
# 추가사항
- `GetState(boolean )` 에서 channel이 IDLE 일때 `true` 값을 주게 되면 handshaking을 시도함 (TEST 하여 확인하였음.)
- `openChannel` 시 `GetState(true)` 를 호출 하도록 함.
- 참고 : https://grpc.io/grpc/cpp/classgrpc_1_1_channel.html#a646d7a9d01f22037a72092d3a0bf159c
  - If the channel is in IDLE and try_to_connect is set to true, try to connect.

- kBucket 객체에 `removeDeadNode` 추가 
- `GRPC_CHANNEL_READY` 아니라면  kBucket에서 해당 Node를 지우도록 함.
- `refreshBucket` 에서 해당 함수를 부르도록 함.