### PR TITLE
# FIX - Nothing to add in the routing table.

### DIFF
--- a/src/plugins/net_plugin/kademlia/include/kbucket.hpp
+++ b/src/plugins/net_plugin/kademlia/include/kbucket.hpp
@@ -101,7 +101,7 @@ public:
 
   Node const &leastRecentlySeenNode() const { return m_nodes.front(); }
 
-  std::vector<Node> selectAliveNodes();
+  std::vector<Node> selectAliveNodes(bool force = false);
 
   void removeDeadNodes();
 

--- a/src/plugins/net_plugin/kademlia/include/routing.hpp
+++ b/src/plugins/net_plugin/kademlia/include/routing.hpp
@@ -56,7 +56,6 @@ public:
 
   RoutingTable(Node node, std::size_t ksize);
 
-
   RoutingTable(const RoutingTable &) = delete;
 
   RoutingTable &operator=(const RoutingTable &) = delete;
@@ -127,15 +126,11 @@ public:
 
 private:
 
-  void addInitialBucket() { m_buckets.push_front(KBucket(m_my_node, 0, m_ksize)); }
-
   Node m_my_node;
 
   std::size_t m_ksize;
 
   std::deque<KBucket> m_buckets;
-
-  std::unordered_map<IdType, IpEndpoint> m_node_table;
 
   std::mutex m_buckets_mutex;
 };

--- a/src/plugins/net_plugin/kademlia/kbucket.cpp
+++ b/src/plugins/net_plugin/kademlia/kbucket.cpp
@@ -133,10 +133,10 @@ namespace gruut {
       }
     };
 
-    std::vector<Node> KBucket::selectAliveNodes() {
+    std::vector<Node> KBucket::selectAliveNodes(bool force_to_select_all) {
       std::vector<Node> alive_nodes = {};
-      std::copy_if(m_nodes.begin(), m_nodes.end(), std::back_inserter(alive_nodes), [](auto &n) {
-        return n.isAlive();
+      std::copy_if(m_nodes.begin(), m_nodes.end(), std::back_inserter(alive_nodes), [force_to_select_all](auto &n) {
+        return force_to_select_all || n.isAlive();
       });
 
       return alive_nodes;

--- a/src/plugins/net_plugin/kademlia/routing.cpp
+++ b/src/plugins/net_plugin/kademlia/routing.cpp
@@ -21,7 +21,7 @@ namespace gruut {
 
     RoutingTable::RoutingTable(Node node, std::size_t ksize)
             : m_my_node(std::move(node)), m_ksize(ksize) {
-      addInitialBucket();
+      m_buckets.emplace_front(KBucket(m_my_node, 0, m_ksize));
     }
 
     std::size_t RoutingTable::nodesCount() const {
@@ -54,13 +54,11 @@ namespace gruut {
     }
 
     bool RoutingTable::addPeer(Node &&peer) {
-
       if (m_my_node == peer) {
         return true;
       }
 
       peer.initFailuresCount();
-      m_node_table[peer.getId()] = peer.getEndpoint();
 
       std::lock_guard<std::mutex> lock(m_buckets_mutex);
 

--- a/src/plugins/net_plugin/net_plugin.cpp
+++ b/src/plugins/net_plugin/net_plugin.cpp
@@ -6,12 +6,15 @@
 #include <unordered_map>
 #include <future>
 #include <boost/asio/steady_timer.hpp>
+#include <exception>
+#include <stdexcept>
 
 namespace gruut {
   using namespace std;
   using namespace net_plugin;
 
   const auto CONNECTION_CHECK_PERIOD = std::chrono::seconds(30);
+  const auto NET_MESSAGE_CHECK_PERIOD = std::chrono::milliseconds(1);
 
   class NetPluginImpl {
   public:
@@ -19,9 +22,8 @@ namespace gruut {
     KademliaService::AsyncService kademlia_service;
 
     string p2p_address;
-    string tracker_address;
 
-    vector<string> peer_addr_list;
+    string tracker_address;
 
     unique_ptr<Server> server;
     unique_ptr<ServerCompletionQueue> completion_queue;
@@ -31,6 +33,7 @@ namespace gruut {
     shared_ptr<BroadcastMsgTable> broadcast_check_table;
 
     unique_ptr<boost::asio::steady_timer> connection_check_timer;
+    unique_ptr<boost::asio::steady_timer> net_message_check_timer;
 
     ~NetPluginImpl() {
       server->Shutdown();
@@ -43,6 +46,7 @@ namespace gruut {
       registerServices();
 
       connection_check_timer = make_unique<boost::asio::steady_timer>(app().getIoContext());
+      net_message_check_timer = make_unique<boost::asio::steady_timer>(app().getIoContext());
     }
 
     void initializeRoutingTable() {
@@ -78,8 +82,33 @@ namespace gruut {
     }
 
     void start() {
+      monitorCompletionQueue();
       getPeersFromTracker();
       startConnectionMonitors();
+    }
+
+    void monitorCompletionQueue() {
+      net_message_check_timer->expires_from_now(NET_MESSAGE_CHECK_PERIOD);
+      net_message_check_timer->async_wait([this](boost::system::error_code ec) {
+        if(!ec) {
+          void *tag;
+          bool ok;
+
+          gpr_timespec deadline;
+          deadline.clock_type = GPR_TIMESPAN;
+          deadline.tv_sec = 0;
+          deadline.tv_nsec = 5;
+
+          auto queue_state = completion_queue->AsyncNext(&tag, &ok, deadline);
+          if(ok && queue_state == CompletionQueue::NextStatus::GOT_EVENT) {
+            static_cast<CallData *>(tag)->proceed();
+          }
+        } else {
+          logger::ERROR("Error from net_message_check_timer: {}", ec.message());
+        }
+
+        monitorCompletionQueue();
+      });
     }
 
     void getPeersFromTracker() {
@@ -87,7 +116,7 @@ namespace gruut {
         logger::INFO("Start to get peers list from tracker");
 
         auto [addr, port] = getHostAndPort(tracker_address);
-        auto [_, my_port] = getHostAndPort(p2p_address);
+        auto [my_host, my_port] = getHostAndPort(p2p_address);
 
         HttpClient http_client(addr, port);
 
@@ -97,8 +126,14 @@ namespace gruut {
           auto peers = json::parse(res);
 
           if(!json::is_empty(peers)) {
-            for(auto peer : peers) {
-              peer_addr_list.push_back(peer);
+            for(auto& peer : peers) {
+              auto [peer_host, peer_port] = getHostAndPort(peer);
+              auto id = peer_host + ":" + peer_port;
+
+              if(id != getMyId()) {
+                Node node = Node(Hash<160>::sha1(id), id, peer_host, peer_port);
+                routing_table->addPeer(move(node));
+              }
             }
           }
         }
@@ -122,9 +157,9 @@ namespace gruut {
 
       for (auto &bucket : *routing_table) {
         if (!bucket.empty()) {
-          bucket.removeDeadNodes();
-          auto nodes = bucket.selectAliveNodes();
-
+          // TODO(FIX IT): 'removeDeadNodes' flushes all nodes in the table. Because The connection is not established immediately after opening the channel(the channel state would be 'GRPC_CHANNEL_CONNECTING or GRPC_CHANNEL_IDLE.)
+          //bucket.removeDeadNodes();
+          auto nodes = bucket.selectAliveNodes(true);
           async(launch::async, &NetPluginImpl::findNeighbors, this, nodes);
         }
       }
@@ -161,11 +196,13 @@ namespace gruut {
 
       Target target;
       target.set_target_id(target_id);
-      target.set_sender_id(p2p_address);
-      target.set_sender_address(receiver_addr);
-      target.set_sender_port(receiver_port);
-      target.set_time_stamp(0);
+      target.set_sender_id(getMyId());
 
+      auto [host, port] = getHostAndPort(p2p_address);
+      target.set_sender_address(host);
+      target.set_sender_port(port);
+      target.set_time_stamp(0);
+      
       ClientContext context;
       Neighbors neighbors;
       grpc::Status status = stub->FindNode(&context, target, &neighbors);
@@ -173,10 +210,17 @@ namespace gruut {
       vector<Node> neighbor_list;
       for (int i = 0; i < neighbors.neighbors_size(); i++) {
         const auto &node = neighbors.neighbors(i);
-        neighbor_list.emplace_back(Node(Hash<160>::sha1(node.node_id()), node.node_id(), node.address(), node.port()));
+
+        if(getMyId() != node.node_id()) {
+          neighbor_list.emplace_back(Node(Hash<160>::sha1(node.node_id()), node.node_id(), node.address(), node.port()));
+        }
       }
 
       return NeighborsData{neighbor_list, neighbors.time_stamp(), status};
+    }
+
+    string getMyId() {
+      return p2p_address;
     }
 
     pair<string, string> getHostAndPort(const string addr) {

--- a/src/plugins/net_plugin/rpc_services/include/rpc_services.hpp
+++ b/src/plugins/net_plugin/rpc_services/include/rpc_services.hpp
@@ -108,7 +108,7 @@ public:
   FindNode(KademliaService::AsyncService *service,
   			ServerCompletionQueue *cq,
   			std::shared_ptr<RoutingTable> routing_table)
-  			: m_responder(&m_context), m_routing_table(std::move(routing_table)) {
+  			: m_responder(&m_context), m_routing_table(routing_table) {
 
     m_service = service;
     m_completion_queue = cq;

--- a/src/plugins/net_plugin/rpc_services/rpc_services.cpp
+++ b/src/plugins/net_plugin/rpc_services/rpc_services.cpp
@@ -77,17 +77,6 @@ namespace gruut {
                                 .count());
 
                 m_broadcast_check_table->insert({msg_id, now});
-
-                // TODO: Not used code.
-                //std::vector<IpEndpoint> node_addr_list;
-                ////selecting random node in each kBuckets
-                //for (auto bucket = m_routing_table->begin(); bucket != m_routing_table->end(); bucket++) {
-                //  auto &node = bucket->selectRandomNode();
-                //  node_addr_list.push_back(node.getEndpoint());
-                //}
-                //
-                //RpcClient sender;
-                //sender.sendToMerger(node_addr_list, packed_msg, m_request.message_id(), true);
               }
             }
 
@@ -121,7 +110,6 @@ namespace gruut {
     }
 
     void FindNode::proceed() {
-
       switch (m_receive_status) {
         case RpcCallStatus::CREATE: {
           m_receive_status = RpcCallStatus::PROCESS;
@@ -156,7 +144,6 @@ namespace gruut {
           Status rpc_status = Status::OK;
           m_receive_status = RpcCallStatus::FINISH;
           m_responder.Finish(m_reply, Status::OK, this);
-
         }
           break;
 


### PR DESCRIPTION
## Cause
- After the routing table is initialized, the peer list getting from a tracker is updated, which makes peers open the channel but it takes time to make sure that the connection has been established.
- `removeDeadNodes` removes all nodes that try to connect other peer or is not ready to connect because of the network state.
- So newly added nodes would be removed because they are CONNECTING or IDLE state.
- There were no codes to comsume the completion queue.

## Solution
- Comsume the completion queue per one millisecond periodically(monitorCompletionQueue)
- Get the all nodes regardless of the node state. (selectAliveNodes)
- Remove dead codes.