### PR TITLE
# MOVE - /lib/appbase/include/channel_interface -> src/plugins/channe…

### DIFF
--- a/src/plugins/block_producer_plugin/include/block_producer_plugin.hpp
+++ b/src/plugins/block_producer_plugin/include/block_producer_plugin.hpp
@@ -4,7 +4,7 @@
 
 #include "application.hpp"
 #include "plugin.hpp"
-#include "channel_interface.hpp"
+#include "../../channel_interface/include/channel_interface.hpp"
 #include "../../net_plugin/include/net_plugin.hpp"
 #include "../../../../lib/log/include/log.hpp"
 

--- a/src/plugins/channel_interface/include/channel_interface.hpp
+++ b/src/plugins/channel_interface/include/channel_interface.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include "../../../include/json.hpp"
-#include "../../../src/plugins/net_plugin/config/include/message.hpp"
-#include "channel.hpp"
+#include "../../net_plugin/config/include/message.hpp"
+#include "../../../../lib/appbase/include/channel.hpp"
 #include <vector>
 
 using namespace gruut::net_plugin;

--- a/src/plugins/net_plugin/include/msg_handler.hpp
+++ b/src/plugins/net_plugin/include/msg_handler.hpp
@@ -4,7 +4,7 @@
 #include "../config/include/message.hpp"
 #include "../config/include/network_config.hpp"
 #include "../../../gruut-utils/src/lz4_compressor.hpp"
-#include "channel_interface.hpp"
+#include "../../channel_interface/include/channel_interface.hpp"
 
 using namespace grpc;
 using namespace std;

--- a/src/plugins/net_plugin/include/net_plugin.hpp
+++ b/src/plugins/net_plugin/include/net_plugin.hpp
@@ -4,7 +4,7 @@
 #include <memory>
 
 #include "application.hpp"
-#include "channel_interface.hpp"
+#include "../../channel_interface/include/channel_interface.hpp"
 #include "plugin.hpp"
 
 #include "../../../../lib/log/include/log.hpp"

--- a/src/plugins/net_plugin/rpc_services/rpc_services.cpp
+++ b/src/plugins/net_plugin/rpc_services/rpc_services.cpp
@@ -1,7 +1,7 @@
 #include "include/rpc_services.hpp"
 
 #include "application.hpp"
-#include "channel_interface.hpp"
+#include "../../channel_interface/include/channel_interface.hpp"
 #include "../include/msg_handler.hpp"
 
 #include <exception>


### PR DESCRIPTION
…l_interface

## Change description
- `channel_interface.hpp` code refer to `net_plugin/**/message.hpp`.
- It is inappropriate that the independent library code includes specific plugin code.
- Move into the plugin directory