### PR TITLE
# EDIT - the scripts to run and kill multiple nodes on local environment & setting deadline when `FindNode` is called

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ _deps
 # Config
 config.ini
 config*.ini
+
+# History
+.history

--- a/scripts/kill-multiple-nodes.sh
+++ b/scripts/kill-multiple-nodes.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+ps | grep config | awk '{print $1}' | xargs kill -9

--- a/scripts/run-multiple-nodes.sh
+++ b/scripts/run-multiple-nodes.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+../build/gruut -c ../config1.ini &
+../build/gruut -c ../config2.ini &
+../build/gruut -c ../config3.ini &
+../build/gruut -c ../config4.ini &
+../build/gruut -c ../config5.ini &
+../build/gruut -c ../config6.ini &
+../build/gruut -c ../config7.ini &
+../build/gruut -c ../config8.ini &
+../build/gruut -c ../config9.ini &
+../build/gruut -c ../config10.ini &

--- a/src/plugins/net_plugin/net_plugin.cpp
+++ b/src/plugins/net_plugin/net_plugin.cpp
@@ -22,6 +22,7 @@ using namespace net_plugin;
 const auto CONNECTION_CHECK_PERIOD = std::chrono::seconds(30);
 const auto NET_MESSAGE_CHECK_PERIOD = std::chrono::milliseconds(1);
 constexpr unsigned int KBUCKET_SIZE = 20;
+constexpr auto FIND_NODE_TIMEOUT = std::chrono::milliseconds(100);
 
 class NetPluginImpl {
 public:
@@ -211,6 +212,10 @@ public:
 
     ClientContext context;
     Neighbors neighbors;
+
+    std::chrono::time_point deadline = std::chrono::system_clock::now() + FIND_NODE_TIMEOUT;
+    context.set_deadline(deadline);
+
     grpc::Status status = stub->FindNode(&context, target, &neighbors);
 
     vector<Node> neighbor_list;


### PR DESCRIPTION
### Description
- It is a flaw that `FindNode` blocks infinitely if the response wouldn't be returned.
- `set_deadline` prevents the thread from blocking.