### PR TITLE
# REFACTOR - fix open/closed principle violation

### DIFF
--- a/lib/appbase/application.cpp
+++ b/lib/appbase/application.cpp
@@ -34,21 +34,18 @@ bool Application::initializeImpl() {
   return true;
 }
 
-void Application::setProgramOptions() {
+void Application::setProgramOptions(po::options_description &plugin_cfg_opts) {
   po::options_description app_cfg_opts("Application Config Options");
   po::options_description app_cli_opts("Application Command Line Options");
 
   app_cfg_opts.add_options()("plugin", po::value<vector<string>>()->composing(), "You can specify multiple times.");
 
-  app_cfg_opts.add_options()("p2p-address", po::value<string>()->composing());
-  app_cfg_opts.add_options()("tracker-address", po::value<string>()->composing());
-
-  app_cfg_opts.add_options()("genesis-block", po::value<string>()->composing());
-
   app_cli_opts.add_options()("config-path,c", po::value<string>()->default_value("config.ini"),
                              "Configuration file path (relative/absolute file path)")("help,h", "Print help message");
 
   program_options->config_options.add(app_cfg_opts);
+  program_options->config_options.add(plugin_cfg_opts);
+
   program_options->options_description.add(app_cfg_opts);
   program_options->options_description.add(app_cli_opts);
 }

--- a/lib/appbase/include/application.hpp
+++ b/lib/appbase/include/application.hpp
@@ -29,11 +29,16 @@ public:
   template <class... Plugins>
   bool initialize(int argc, char **argv) {
     try {
-      setProgramOptions();
+      registerPlugins<Plugins...>();
+
+      po::options_description plugin_cfg_opts("Plugin Config Options");
+      for (auto &[_, plugin] : app_plugins_map) {
+        plugin->setProgramOptions(plugin_cfg_opts);
+      }
+
+      setProgramOptions(plugin_cfg_opts);
       if (!parseProgramOptions(argc, argv))
         return false;
-
-      registerPlugins<Plugins...>();
 
       return initializeImpl();
     } catch (exception &e) {
@@ -82,7 +87,7 @@ public:
 private:
   bool initializeImpl();
 
-  void setProgramOptions();
+  void setProgramOptions(po::options_description &);
 
   template <typename Plugin>
   void registerPlugin() {

--- a/lib/appbase/include/plugin.hpp
+++ b/lib/appbase/include/plugin.hpp
@@ -29,6 +29,8 @@ public:
 
   virtual void registerDependencies() = 0;
 
+  virtual void setProgramOptions(options_description&) = 0;
+
   virtual plugin_state getState() const = 0;
 
   virtual ~AbstractPlugin() = default;
@@ -58,6 +60,10 @@ public:
   }
 
   void shutdown() override {}
+
+  void setProgramOptions(options_description& cfg) override {
+    static_cast<Impl *>(this)->setProgramOptions(cfg);
+  }
 
   virtual plugin_state getState() const override {
     return state;

--- a/src/plugins/block_producer_plugin/include/block_producer_plugin.hpp
+++ b/src/plugins/block_producer_plugin/include/block_producer_plugin.hpp
@@ -27,6 +27,10 @@ public:
     logger::INFO("BlockProducerPlugin Shutdown");
   }
 
+  void setProgramOptions(po::options_description &) {
+    // do nothing
+  }
+
 private:
 };
 } // namespace gruut

--- a/src/plugins/chain_plugin/chain_plugin.cpp
+++ b/src/plugins/chain_plugin/chain_plugin.cpp
@@ -39,6 +39,10 @@ void ChainPlugin::pluginInitialize(const boost::program_options::variables_map &
   }
 }
 
+void ChainPlugin::setProgramOptions(options_description &cfg) {
+  cfg.add_options()("genesis-block", boost::program_options::value<string>()->composing());
+}
+
 ChainPlugin::~ChainPlugin() {
   impl.reset();
 }

--- a/src/plugins/chain_plugin/include/chain_plugin.hpp
+++ b/src/plugins/chain_plugin/include/chain_plugin.hpp
@@ -2,6 +2,7 @@
 
 #include <boost/filesystem.hpp>
 #include <boost/program_options/variables_map.hpp>
+#include <boost/program_options/options_description.hpp>
 
 #include "../../../../lib/log/include/log.hpp"
 #include "../../channel_interface/include/channel_interface.hpp"
@@ -27,6 +28,8 @@ public:
   void pluginShutdown() {
     logger::INFO("ChainPlugin Shutdown");
   }
+
+  void setProgramOptions(options_description &cfg) override;
 
 private:
   std::unique_ptr<class ChainPluginImpl> impl;

--- a/src/plugins/net_plugin/include/net_plugin.hpp
+++ b/src/plugins/net_plugin/include/net_plugin.hpp
@@ -2,6 +2,7 @@
 
 #include <iostream>
 #include <memory>
+#include <boost/program_options/options_description.hpp>
 
 #include "../../channel_interface/include/channel_interface.hpp"
 #include "application.hpp"
@@ -28,6 +29,8 @@ public:
   void pluginShutdown() {
     logger::INFO("NetPlugin Shutdown");
   }
+
+  void setProgramOptions(options_description &cfg) override;
 
 private:
   std::unique_ptr<class NetPluginImpl> impl;

--- a/src/plugins/net_plugin/net_plugin.cpp
+++ b/src/plugins/net_plugin/net_plugin.cpp
@@ -387,6 +387,11 @@ public:
 
 NetPlugin::NetPlugin() : impl(new NetPluginImpl()) {}
 
+void NetPlugin::setProgramOptions(options_description &cfg) {
+  cfg.add_options()("p2p-address", po::value<string>()->composing());
+  cfg.add_options()("tracker-address", po::value<string>()->composing());
+}
+
 void NetPlugin::pluginInitialize(const variables_map &options) {
   logger::INFO("NetPlugin Initialize");
 


### PR DESCRIPTION
## Description
- There is no reason that change `Application` class in adding new plugin options.
- Even though some plugins are not used, the options related to unused plugins are initialized.
- `setProgramOptions` is called and only related options are initialized in each plugin.