### PR TITLE
 # EDIT - Message header sender id type

### DIFF
--- a/src/plugins/channel_interface/include/channel_interface.hpp
+++ b/src/plugins/channel_interface/include/channel_interface.hpp
@@ -12,13 +12,13 @@ using namespace std;
 struct InNetMsg {
   MessageType type;
   nlohmann::json body;
-  id_type sender_id;
+  sender_id_type sender_id;
 };
 
 struct OutNetMsg {
   MessageType type;
   nlohmann::json body;
-  vector<id_type> receivers;
+  vector<sender_id_type> receivers;
 };
 
 namespace appbase::incoming {

--- a/src/plugins/net_plugin/config/include/message.hpp
+++ b/src/plugins/net_plugin/config/include/message.hpp
@@ -36,9 +36,11 @@ using message_version_type = uint8_t;
 
 constexpr int CHAIN_ID_TYPE_SIZE = 8;
 constexpr int WORLD_ID_TYPE_SIZE = 8;
+constexpr int SENDER_ID_TYPE_SIZE = 32;
+
 using world_id_type = std::array<uint8_t, WORLD_ID_TYPE_SIZE>;
 using localchain_id_type = std::array<uint8_t, CHAIN_ID_TYPE_SIZE>;
-using id_type = std::string;
+using sender_id_type = std::array<uint8_t, SENDER_ID_TYPE_SIZE>;
 
 constexpr int IDENTIFIER_LENGTH = 1;
 constexpr int VERSION_LENGTH = 1;
@@ -47,7 +49,6 @@ constexpr int MAC_TYPE_LENGTH = 1;
 constexpr int SERIALIZATION_TYPE_LENGTH = 1;
 constexpr int DUMMY_LENGTH = 1;
 constexpr int MSG_LENGTH_SIZE = 4;
-constexpr int SENDER_ID_TYPE_SIZE = 32;
 
 constexpr int HEADER_LENGTH = IDENTIFIER_LENGTH + VERSION_LENGTH + MSG_TYPE_LENGTH + MAC_TYPE_LENGTH + SERIALIZATION_TYPE_LENGTH +
                               DUMMY_LENGTH + MSG_LENGTH_SIZE + WORLD_ID_TYPE_SIZE + CHAIN_ID_TYPE_SIZE + SENDER_ID_TYPE_SIZE;
@@ -66,7 +67,7 @@ struct MessageHeader {
   std::array<uint8_t, MSG_LENGTH_SIZE> total_length;
   world_id_type world_id;
   localchain_id_type local_chain_id;
-  id_type sender_id;
+  sender_id_type sender_id;
 };
 
 enum class MsgEntryType { BASE64, TIMESTAMP, TIMESTAMP_NOW, HEX, STRING, UINT, BOOL, ARRAYOFOBJECT, ARRAYOFSTRING };

--- a/src/plugins/net_plugin/include/msg_handler.hpp
+++ b/src/plugins/net_plugin/include/msg_handler.hpp
@@ -16,7 +16,7 @@ namespace net_plugin {
 
 class MessageHandler {
 public:
-  optional<InNetMsg> genInternalMsg(MessageType msg_type, std::string &id) {
+  optional<InNetMsg> genInternalMsg(MessageType msg_type, string &id) {
     nlohmann::json msg_body;
 
     switch (msg_type) {
@@ -24,7 +24,9 @@ public:
       msg_body["sID"] = id;
       msg_body["time"] = TimeUtil::now();
       msg_body["msg"] = "disconnected with signer";
-      return InNetMsg{msg_body, msg_type, id};
+      sender_id_type sender_id;
+      copy(id.begin(), id.end(), sender_id.begin());
+      return InNetMsg{msg_body, msg_type, sender_id};
     }
 
     default:

--- a/src/plugins/net_plugin/net_plugin.cpp
+++ b/src/plugins/net_plugin/net_plugin.cpp
@@ -9,6 +9,7 @@
 #include "../../../lib/gruut-utils/src/random_number_generator.hpp"
 #include "../../../lib/gruut-utils/src/sha256.hpp"
 #include "../../../lib/gruut-utils/src/time_util.hpp"
+#include "../../../lib/gruut-utils/src/type_converter.hpp"
 
 #include <boost/asio/steady_timer.hpp>
 #include <exception>
@@ -305,8 +306,9 @@ public:
           }
         }
       } else {
-        for (auto &receiver : out_msg.receivers) {
-          auto hashed_id = Hash<160>::sha1(receiver);
+        for (auto &receiver_id_arr : out_msg.receivers) {
+          auto receiver_id = TypeConverter::arrayToString<SENDER_ID_TYPE_SIZE>(receiver_id_arr);
+          auto hashed_id = Hash<160>::sha1(receiver_id);
           auto node = routing_table->findNode(hashed_id);
           if (node.has_value()) {
             auto stub = genStub<GruutGeneralService::Stub, GruutGeneralService>(node.value().getChannelPtr());
@@ -317,8 +319,8 @@ public:
     } else if (checkSignerMsgType(out_msg.type)) {
       auto packed_msg = packMsg(out_msg);
 
-      for (auto &receiver_id : out_msg.receivers) {
-
+      for (auto &receiver_id_arr : out_msg.receivers) {
+        auto receiver_id = TypeConverter::arrayToString<SENDER_ID_TYPE_SIZE>(receiver_id_arr);
         SignerRpcInfo signer_rpc_info = signer_conn_table->getRpcInfo(receiver_id);
         if (signer_rpc_info.send_msg == nullptr)
           continue;


### PR DESCRIPTION
- message header의 sender_id를 std::string -> std::array로 변경
- string의 경우 가변 길이 이므로 struct로 casting 하는 과정에서 문제가
생길 수 도 있으므로 고정길이인 array로 수정