### PR TITLE
# FEATURE - user id & net id mapping

### DIFF
--- a/src/plugins/net_plugin/config/include/network_type.hpp
+++ b/src/plugins/net_plugin/config/include/network_type.hpp
@@ -15,8 +15,8 @@ struct IpEndpoint {
   }
 };
 
-using IdType = std::string;   // 32bytes ID
-using HashedIdType = Hash160; // 32bytes ID를 hash160
+using net_id_type = std::string;   // Network virtual id type
+using hashed_net_id_type = Hash160; // Network hashed virtual id type
 
 using BroadcastMsgTable = std::unordered_map<std::string, uint64_t>;
 } // namespace net_plugin

--- a/src/plugins/net_plugin/config/include/network_type.hpp
+++ b/src/plugins/net_plugin/config/include/network_type.hpp
@@ -15,7 +15,8 @@ struct IpEndpoint {
   }
 };
 
-using net_id_type = std::string;   // Network virtual id type
+using user_id_type = std::string;
+using net_id_type = std::string;    // Network virtual id type
 using hashed_net_id_type = Hash160; // Network hashed virtual id type
 
 using BroadcastMsgTable = std::unordered_map<std::string, uint64_t>;

--- a/src/plugins/net_plugin/kademlia/include/kbucket.hpp
+++ b/src/plugins/net_plugin/kademlia/include/kbucket.hpp
@@ -97,7 +97,7 @@ public:
 
   std::chrono::seconds timeSinceLastUpdated() const;
 
-  bool canHoldNode(const HashedIdType &node) const;
+  bool canHoldNode(const hashed_net_id_type &node) const;
 
   std::string sharedPrefix() const {
     return m_prefix.to_string().substr(0, m_prefix_size);

--- a/src/plugins/net_plugin/kademlia/include/kbucket.hpp
+++ b/src/plugins/net_plugin/kademlia/include/kbucket.hpp
@@ -115,7 +115,7 @@ public:
 
   std::vector<Node> selectRandomAliveNodes(int num_of_node = PARALLELISM_ALPHA);
 
-  void removeDeadNodes();
+  std::optional<std::vector<Hash160>> removeDeadNodes();
 
   bool addNode(Node &&node);
 

--- a/src/plugins/net_plugin/kademlia/include/node.hpp
+++ b/src/plugins/net_plugin/kademlia/include/node.hpp
@@ -26,10 +26,10 @@ constexpr unsigned int NODE_FAILED_COMMS_BEFORE_STALE = 2;
 
 class Node {
 public:
-  Node(HashedIdType const &id_hash, IdType const &id, std::string const &ip_address, std::string const &port_number)
+  Node(hashed_net_id_type const &id_hash, net_id_type const &id, std::string const &ip_address, std::string const &port_number)
       : m_id_hash{id_hash}, m_id{id}, m_endpoint{ip_address, port_number} {}
 
-  Node(HashedIdType const &id_hash, IdType const &id, std::string const &ip_address, std::string const &port_number,
+  Node(hashed_net_id_type const &id_hash, net_id_type const &id, std::string const &ip_address, std::string const &port_number,
        std::shared_ptr<grpc::Channel> c)
       : m_id_hash{id_hash}, m_id{id}, m_endpoint{ip_address, port_number}, m_channel_ptr(c) {}
 
@@ -37,11 +37,11 @@ public:
     return (lhs.getIdHash() == rhs.getIdHash()) && (lhs.getEndpoint() == rhs.getEndpoint());
   }
 
-  HashedIdType const &getIdHash() const {
+  hashed_net_id_type const &getIdHash() const {
     return m_id_hash;
   }
 
-  IdType const &getId() const {
+  net_id_type const &getId() const {
     return m_id;
   }
 
@@ -71,11 +71,11 @@ public:
     return false;
   }
 
-  HashedIdType distanceTo(Node const &node) const {
+  hashed_net_id_type distanceTo(Node const &node) const {
     return distanceTo(node.getIdHash());
   }
 
-  HashedIdType distanceTo(Hash160 const &hash) const {
+  hashed_net_id_type distanceTo(Hash160 const &hash) const {
     return m_id_hash ^ hash;
   }
 
@@ -115,11 +115,11 @@ public:
     return m_channel_ptr;
   }
 
-  HashedIdType &getIdHash() {
+  hashed_net_id_type &getIdHash() {
     return m_id_hash;
   }
 
-  IdType &getId() {
+  net_id_type &getId() {
     return m_id;
   }
 
@@ -128,8 +128,8 @@ public:
   }
 
 private:
-  IdType m_id;
-  HashedIdType m_id_hash;
+  net_id_type m_id;
+  hashed_net_id_type m_id_hash;
   IpEndpoint m_endpoint;
   std::shared_ptr<grpc::Channel> m_channel_ptr;
 
@@ -139,15 +139,15 @@ private:
   std::chrono::steady_clock::time_point m_last_seen_time;
 };
 
-inline HashedIdType distance(Node const &a, Node const &b) {
+inline hashed_net_id_type distance(Node const &a, Node const &b) {
   return a.distanceTo(b);
 }
 
-inline HashedIdType distance(Node const &node, Hash160 const &hash) {
+inline hashed_net_id_type distance(Node const &node, Hash160 const &hash) {
   return node.distanceTo(hash);
 }
 
-inline HashedIdType distance(HashedIdType const &ida, HashedIdType const &idb) {
+inline hashed_net_id_type distance(hashed_net_id_type const &ida, hashed_net_id_type const &idb) {
   return ida ^ idb;
 }
 

--- a/src/plugins/net_plugin/kademlia/include/routing.hpp
+++ b/src/plugins/net_plugin/kademlia/include/routing.hpp
@@ -126,8 +126,8 @@ public:
 
   size_t getBucketIndexFor(const hashed_net_id_type &node) const;
 
-  void mapId(const user_id_type &real_id, const net_id_type &net_id);
-  void unmapId(const user_id_type &real_id);
+  void mapId(const user_id_type &user_id, const net_id_type &net_id);
+  void unmapId(const user_id_type &user_id);
   void unmapId(const hashed_net_id_type &hashed_net_id);
 private:
   Node m_my_node;

--- a/src/plugins/net_plugin/kademlia/include/routing.hpp
+++ b/src/plugins/net_plugin/kademlia/include/routing.hpp
@@ -122,17 +122,22 @@ public:
 
   std::optional<Node> findNode(const hashed_net_id_type &hashed_id);
 
-  std::optional<Node> findNode(net_id_type &&id);
+  std::optional<Node> findNode(const user_id_type &id);
 
   size_t getBucketIndexFor(const hashed_net_id_type &node) const;
 
+  void mapId(const user_id_type &real_id, const net_id_type &net_id);
+  void unmapId(const user_id_type &real_id);
+  void unmapId(const hashed_net_id_type &hashed_net_id);
 private:
   Node m_my_node;
 
   std::size_t m_ksize;
 
   std::deque<KBucket> m_buckets;
+  std::unordered_map<user_id_type, hashed_net_id_type> m_id_mapping_table;
 
+  std::mutex m_id_map_mutex;
   std::mutex m_buckets_mutex;
 };
 

--- a/src/plugins/net_plugin/kademlia/include/routing.hpp
+++ b/src/plugins/net_plugin/kademlia/include/routing.hpp
@@ -114,17 +114,17 @@ public:
 
   bool peerTimedOut(Node const &peer);
 
-  std::vector<Node> findNeighbors(HashedIdType const &id) {
+  std::vector<Node> findNeighbors(hashed_net_id_type const &id) {
     return findNeighbors(id, m_ksize);
   };
 
-  std::vector<Node> findNeighbors(HashedIdType const &id, std::size_t max_number);
+  std::vector<Node> findNeighbors(hashed_net_id_type const &id, std::size_t max_number);
 
-  std::optional<Node> findNode(const HashedIdType &hashed_id);
+  std::optional<Node> findNode(const hashed_net_id_type &hashed_id);
 
-  std::optional<Node> findNode(IdType &&id);
+  std::optional<Node> findNode(net_id_type &&id);
 
-  size_t getBucketIndexFor(const HashedIdType &node) const;
+  size_t getBucketIndexFor(const hashed_net_id_type &node) const;
 
 private:
   Node m_my_node;

--- a/src/plugins/net_plugin/kademlia/kbucket.cpp
+++ b/src/plugins/net_plugin/kademlia/kbucket.cpp
@@ -71,7 +71,7 @@ void KBucket::removeNode(KBucket::iterator &node_iter) {
   }
 }
 
-bool KBucket::canHoldNode(const HashedIdType &node) const {
+bool KBucket::canHoldNode(const hashed_net_id_type &node) const {
 
   auto id_bits = node.toBitSet();
   auto last_bit = KEYSIZE_BITS - m_prefix_size;

--- a/src/plugins/net_plugin/kademlia/routing.cpp
+++ b/src/plugins/net_plugin/kademlia/routing.cpp
@@ -213,22 +213,22 @@ Done:
   return neighbors;
 }
 
-void RoutingTable::mapId(const user_id_type &real_id, const net_id_type &net_id) {
+void RoutingTable::mapId(const user_id_type &user_id, const net_id_type &net_id) {
   std::lock_guard<std::mutex> guard(m_id_map_mutex);
-  m_id_mapping_table.try_emplace(real_id, Hash<160>::sha1(net_id));
+  m_id_mapping_table.try_emplace(user_id, Hash<160>::sha1(net_id));
   m_id_map_mutex.unlock();
 }
-void RoutingTable::unmapId(const user_id_type &real_id) {
-  if (m_id_mapping_table.count(real_id) > 0) {
+void RoutingTable::unmapId(const user_id_type &user_id) {
+  if (m_id_mapping_table.count(user_id) > 0) {
     std::lock_guard<std::mutex> guard(m_id_map_mutex);
-    m_id_mapping_table.erase(real_id);
+    m_id_mapping_table.erase(user_id);
     m_id_map_mutex.unlock();
   }
 }
 void RoutingTable::unmapId(const hashed_net_id_type &dead_hashed_id) {
-  for (auto &[real_id, net_hased_id] : m_id_mapping_table) {
+  for (auto &[user_id, net_hased_id] : m_id_mapping_table) {
     if (net_hased_id == dead_hashed_id) {
-      unmapId(real_id);
+      unmapId(user_id);
       return;
     }
   }

--- a/src/plugins/net_plugin/kademlia/routing.cpp
+++ b/src/plugins/net_plugin/kademlia/routing.cpp
@@ -40,7 +40,7 @@ bool RoutingTable::empty() const {
   return m_buckets.front().empty();
 }
 
-std::size_t RoutingTable::getBucketIndexFor(const HashedIdType &node) const {
+std::size_t RoutingTable::getBucketIndexFor(const hashed_net_id_type &node) const {
 
   auto num_buckets = m_buckets.size();
 
@@ -138,11 +138,11 @@ bool RoutingTable::peerTimedOut(Node const &peer) {
   return false;
 }
 
-std::optional<Node> RoutingTable::findNode(IdType &&id) {
+std::optional<Node> RoutingTable::findNode(net_id_type &&id) {
   return findNode(Hash<160>::sha1(id));
 }
 
-std::optional<Node> RoutingTable::findNode(const HashedIdType &hashed_id) {
+std::optional<Node> RoutingTable::findNode(const hashed_net_id_type &hashed_id) {
   auto bucket_index = getBucketIndexFor(hashed_id);
   auto bucket = m_buckets.begin();
   std::advance(bucket, bucket_index);
@@ -155,7 +155,7 @@ std::optional<Node> RoutingTable::findNode(const HashedIdType &hashed_id) {
   return {};
 }
 
-std::vector<Node> RoutingTable::findNeighbors(HashedIdType const &id, std::size_t max_number) {
+std::vector<Node> RoutingTable::findNeighbors(hashed_net_id_type const &id, std::size_t max_number) {
   std::vector<Node> neighbors;
   auto count = 0U;
 

--- a/src/plugins/net_plugin/net_plugin.cpp
+++ b/src/plugins/net_plugin/net_plugin.cpp
@@ -38,8 +38,6 @@ public:
 
   string tracker_address;
 
-  string network_id;
-
   unique_ptr<Server> server;
   unique_ptr<ServerCompletionQueue> completion_queue;
 
@@ -67,8 +65,7 @@ public:
   void initializeRoutingTable() {
     auto [host, port] = getHostAndPort(p2p_address);
 
-    network_id = host;
-    Node my_node(Hash<160>::sha1(network_id), network_id, host, port);
+    Node my_node(Hash<160>::sha1(p2p_address), p2p_address, host, port);
     routing_table = make_shared<RoutingTable>(my_node, KBUCKET_SIZE);
   }
 
@@ -268,7 +265,7 @@ public:
   }
 
   string getMyNetId() {
-    return network_id;
+    return p2p_address;
   }
 
   pair<string, string> getHostAndPort(const string addr) {
@@ -290,6 +287,7 @@ public:
       ClientContext context;
       std::chrono::time_point deadline = std::chrono::system_clock::now() + GENERAL_SERVICE_TIMEOUT;
       context.set_deadline(deadline);
+      context.AddMetadata("net_id", getMyNetId());
 
       MsgStatus msg_status;
 

--- a/src/plugins/net_plugin/net_plugin.cpp
+++ b/src/plugins/net_plugin/net_plugin.cpp
@@ -38,6 +38,8 @@ public:
 
   string tracker_address;
 
+  string network_id;
+
   unique_ptr<Server> server;
   unique_ptr<ServerCompletionQueue> completion_queue;
 
@@ -65,8 +67,8 @@ public:
   void initializeRoutingTable() {
     auto [host, port] = getHostAndPort(p2p_address);
 
-    auto id = p2p_address;
-    Node my_node(Hash<160>::sha1(id), id, host, port);
+    network_id = host;
+    Node my_node(Hash<160>::sha1(network_id), network_id, host, port);
     routing_table = make_shared<RoutingTable>(my_node, KBUCKET_SIZE);
   }
 
@@ -140,9 +142,9 @@ public:
         if (!json::is_empty(peers)) {
           for (auto &peer : peers) {
             auto [peer_host, peer_port] = getHostAndPort(peer);
-            auto id = peer_host + ":" + peer_port;
+            auto id = peer_host;
 
-            if (id != getMyId()) {
+            if (id != getMyNetId()) {
               Node node = Node(Hash<160>::sha1(id), id, peer_host, peer_port);
               routing_table->addPeer(move(node));
             }
@@ -169,7 +171,12 @@ public:
 
     for (auto &bucket : *routing_table) {
       if (!bucket.empty()) {
-        bucket.removeDeadNodes();
+        auto dead_node_ids = bucket.removeDeadNodes();
+        if (dead_node_ids.has_value()) {
+          for (auto &dead_hashed_id : dead_node_ids.value()) {
+            routing_table->unmapId(dead_hashed_id);
+          }
+        }
         auto nodes = bucket.selectAliveNodes(false);
         async(launch::async, &NetPluginImpl::findNeighbors, this, nodes);
       }
@@ -227,13 +234,13 @@ public:
     return TService::NewStub(channel);
   }
 
-  NeighborsData queryNeighborNodes(const string &receiver_addr, const string &receiver_port, const IdType &target_id,
+  NeighborsData queryNeighborNodes(const string &receiver_addr, const string &receiver_port, const net_id_type &target_id,
                                    shared_ptr<grpc::Channel> channel) {
     auto stub = genStub<KademliaService::Stub, KademliaService>(channel);
 
     Target target;
     target.set_target_id(target_id);
-    target.set_sender_id(getMyId());
+    target.set_sender_id(getMyNetId());
 
     auto [host, port] = getHostAndPort(p2p_address);
     target.set_sender_address(host);
@@ -252,7 +259,7 @@ public:
     for (int i = 0; i < neighbors.neighbors_size(); i++) {
       const auto &node = neighbors.neighbors(i);
 
-      if (getMyId() != node.node_id()) {
+      if (getMyNetId() != node.node_id()) {
         neighbor_list.emplace_back(Node(Hash<160>::sha1(node.node_id()), node.node_id(), node.address(), node.port()));
       }
     }
@@ -260,8 +267,8 @@ public:
     return NeighborsData{neighbor_list, neighbors.time_stamp(), status};
   }
 
-  string getMyId() {
-    return p2p_address;
+  string getMyNetId() {
+    return network_id;
   }
 
   pair<string, string> getHostAndPort(const string addr) {
@@ -299,7 +306,6 @@ public:
           if (!bucket.empty()) {
             auto nodes = bucket.selectRandomAliveNodes(PARALLELISM_ALPHA);
             for (auto &n : nodes) {
-
               auto stub = genStub<GruutGeneralService::Stub, GruutGeneralService>(n.getChannelPtr());
               auto status = stub->GeneralService(&context, request, &msg_status);
             }
@@ -308,11 +314,12 @@ public:
       } else {
         for (auto &receiver_id_arr : out_msg.receivers) {
           auto receiver_id = TypeConverter::arrayToString<SENDER_ID_TYPE_SIZE>(receiver_id_arr);
-          auto hashed_id = Hash<160>::sha1(receiver_id);
-          auto node = routing_table->findNode(hashed_id);
+          auto node = routing_table->findNode(receiver_id);
           if (node.has_value()) {
             auto stub = genStub<GruutGeneralService::Stub, GruutGeneralService>(node.value().getChannelPtr());
             auto status = stub->GeneralService(&context, request, &msg_status);
+          } else {
+            routing_table->unmapId(receiver_id);
           }
         }
       }

--- a/src/plugins/net_plugin/rpc_services/rpc_services.cpp
+++ b/src/plugins/net_plugin/rpc_services/rpc_services.cpp
@@ -122,11 +122,9 @@ void GeneralService::proceed() {
           if (input_msg_type == MessageType::MSG_BLOCK || input_msg_type == MessageType::MSG_TX ||
               input_msg_type == MessageType::MSG_REQ_BLOCK) {
 
-            auto real_id = TypeConverter::arrayToString<SENDER_ID_TYPE_SIZE>(input_data.value().sender_id);
-            vector<string> splitted;
-            string address = m_context.peer(); // protocol(ipv4/ipv6) : ip : port
-            boost::split(splitted, address, boost::is_any_of(":"), boost::token_compress_on);
-            m_routing_table->mapId(real_id, splitted[1]);
+            auto user_id = TypeConverter::arrayToString<SENDER_ID_TYPE_SIZE>(input_data.value().sender_id);
+            auto net_id = m_context.client_metadata().find("net_id")->second;
+            m_routing_table->mapId(user_id, string(net_id.data()));
           }
 
           auto &in_msg_channel = app().getChannel<incoming::channels::network::channel_type>();


### PR DESCRIPTION
- 실제 사용하는 id와 network를 유지하는데 사용하는 id는 같을 필요가
없으며, network를 유지하는데 이용하는 id는 정책에 의하여 변경 될 수
있습니다. (현재 network id는 ip를 이용하도록 함)
- 실제 id는 network routing table을 유지하는데 이용할 필요는 없습니다.
- 따라서 ~~real-id~~  user-id 와 net-id를 mapping 시킬 table이 필요

### 추가사항
  * unordered_map -> id mapping table
  * unmapId, mapId 함수 추가

### 변경사항
  ~~* GeneralService rpc 요청을 받았을때, `context->peer()`에서 ip 주소를
읽어와 id mapping table을 세팅 (현재 network id 는 ip 주소를 사용함)~~
  * GeneralService rpc 요청을 할때 ClientContext에 `net_id`를 metadata에 세팅하여 보내고 ServerContext에서 해당 metadata를 읽어와 id mapping table을 세팅 하도록 함.
  * `KBucket::removeDeadNodes`에서 return 값으로 daed node의 hashed_net_id 리스트를
반환하도록 함
  * `refreshBuckets`시 연결이 끊어진 node에 대해 mapping된 id를 삭제함.
  * `sendMessage` 시 보낼 곳을 찾지 못하면, id_mapping_table에서 삭제

 ### 기타 수정사항
- Network단에서만 사용하는 id type 이름 변경