### PR TITLE
# FIX - Bad access exception in `NetPlugin`

### DIFF
--- a/src/plugins/net_plugin/net_plugin.cpp
+++ b/src/plugins/net_plugin/net_plugin.cpp
@@ -49,8 +49,11 @@ public:
   unique_ptr<boost::asio::steady_timer> net_message_check_timer;
 
   ~NetPluginImpl() {
-    server->Shutdown();
-    completion_queue->Shutdown();
+    if(server != nullptr)
+      server->Shutdown();
+
+    if(completion_queue != nullptr)
+      completion_queue->Shutdown();
   }
 
   void initialize() {


### PR DESCRIPTION
### Cause
- There is a case that pointer `server` and `completion_queue` are accessed although they are not initialized.
  + `registerPlugins`
  + `plugin->setProgramOptions`
  + `plugin->parseProgramOptions`
  + if program options is not invalid or early exit(in case that the program is executed with `-h` option), registered plugins are freed.
- `NetPlugin`'s members must be explicitly desconstructed because the plugin rely on `grpc` library.