### PR TITLE
 # EDIT - id-type

### DIFF
--- a/src/plugins/channel_interface/include/channel_interface.hpp
+++ b/src/plugins/channel_interface/include/channel_interface.hpp
@@ -8,17 +8,18 @@
 using namespace gruut::net_plugin;
 using namespace std;
 
+using b58_id_type = string;
 // TODO: need to separate data structure and channel.
 struct InNetMsg {
   MessageType type;
   nlohmann::json body;
-  sender_id_type sender_id;
+  b58_id_type sender_id;
 };
 
 struct OutNetMsg {
   MessageType type;
   nlohmann::json body;
-  vector<sender_id_type> receivers;
+  vector<b58_id_type> receivers;
 };
 
 namespace appbase::incoming {

--- a/src/plugins/net_plugin/config/include/network_type.hpp
+++ b/src/plugins/net_plugin/config/include/network_type.hpp
@@ -15,7 +15,7 @@ struct IpEndpoint {
   }
 };
 
-using user_id_type = std::string;
+using b58_user_id_type = std::string;
 using net_id_type = std::string;    // Network virtual id type
 using hashed_net_id_type = Hash160; // Network hashed virtual id type
 

--- a/src/plugins/net_plugin/include/msg_handler.hpp
+++ b/src/plugins/net_plugin/include/msg_handler.hpp
@@ -16,17 +16,16 @@ namespace net_plugin {
 
 class MessageHandler {
 public:
-  optional<InNetMsg> genInternalMsg(MessageType msg_type, string &id) {
+  optional<InNetMsg> genInternalMsg(MessageType msg_type, b58_id_type &b58_id) {
     nlohmann::json msg_body;
 
     switch (msg_type) {
     case MessageType::MSG_LEAVE: {
-      msg_body["sID"] = id;
+      msg_body["sID"] = b58_id;
       msg_body["time"] = TimeUtil::now();
       msg_body["msg"] = "disconnected with signer";
-      sender_id_type sender_id;
-      copy(id.begin(), id.end(), sender_id.begin());
-      return InNetMsg{msg_body, msg_type, sender_id};
+
+      return InNetMsg{msg_body, msg_type, b58_id};
     }
 
     default:

--- a/src/plugins/net_plugin/kademlia/include/routing.hpp
+++ b/src/plugins/net_plugin/kademlia/include/routing.hpp
@@ -122,12 +122,12 @@ public:
 
   std::optional<Node> findNode(const hashed_net_id_type &hashed_id);
 
-  std::optional<Node> findNode(const user_id_type &id);
+  std::optional<Node> findNode(const b58_user_id_type &id);
 
   size_t getBucketIndexFor(const hashed_net_id_type &node) const;
 
-  void mapId(const user_id_type &user_id, const net_id_type &net_id);
-  void unmapId(const user_id_type &user_id);
+  void mapId(const b58_user_id_type &b58_user_id, const net_id_type &net_id);
+  void unmapId(const b58_user_id_type &b58_user_id);
   void unmapId(const hashed_net_id_type &hashed_net_id);
 private:
   Node m_my_node;
@@ -135,7 +135,7 @@ private:
   std::size_t m_ksize;
 
   std::deque<KBucket> m_buckets;
-  std::unordered_map<user_id_type, hashed_net_id_type> m_id_mapping_table;
+  std::unordered_map<b58_user_id_type, hashed_net_id_type> m_id_mapping_table;
 
   std::mutex m_id_map_mutex;
   std::mutex m_buckets_mutex;

--- a/src/plugins/net_plugin/kademlia/routing.cpp
+++ b/src/plugins/net_plugin/kademlia/routing.cpp
@@ -151,7 +151,7 @@ std::optional<Node> RoutingTable::findNode(const hashed_net_id_type &hashed_id) 
   return {};
 }
 
-std::optional<Node> RoutingTable::findNode(const user_id_type &id) {
+std::optional<Node> RoutingTable::findNode(const b58_user_id_type &id) {
   if(m_id_mapping_table.count(id) > 0){
     return findNode(m_id_mapping_table[id]);
   }
@@ -213,22 +213,22 @@ Done:
   return neighbors;
 }
 
-void RoutingTable::mapId(const user_id_type &user_id, const net_id_type &net_id) {
+void RoutingTable::mapId(const b58_user_id_type &b58_user_id, const net_id_type &net_id) {
   std::lock_guard<std::mutex> guard(m_id_map_mutex);
-  m_id_mapping_table.try_emplace(user_id, Hash<160>::sha1(net_id));
+  m_id_mapping_table.try_emplace(b58_user_id, Hash<160>::sha1(net_id));
   m_id_map_mutex.unlock();
 }
-void RoutingTable::unmapId(const user_id_type &user_id) {
-  if (m_id_mapping_table.count(user_id) > 0) {
+void RoutingTable::unmapId(const b58_user_id_type &b58_user_id) {
+  if (m_id_mapping_table.count(b58_user_id) > 0) {
     std::lock_guard<std::mutex> guard(m_id_map_mutex);
-    m_id_mapping_table.erase(user_id);
+    m_id_mapping_table.erase(b58_user_id);
     m_id_map_mutex.unlock();
   }
 }
 void RoutingTable::unmapId(const hashed_net_id_type &dead_hashed_id) {
-  for (auto &[user_id, net_hased_id] : m_id_mapping_table) {
+  for (auto &[b58_user_id, net_hased_id] : m_id_mapping_table) {
     if (net_hased_id == dead_hashed_id) {
-      unmapId(user_id);
+      unmapId(b58_user_id);
       return;
     }
   }

--- a/src/plugins/net_plugin/net_plugin.cpp
+++ b/src/plugins/net_plugin/net_plugin.cpp
@@ -313,23 +313,21 @@ public:
           }
         }
       } else {
-        for (auto &receiver_id_arr : out_msg.receivers) {
-          auto receiver_id = TypeConverter::arrayToString<SENDER_ID_TYPE_SIZE>(receiver_id_arr);
-          auto node = routing_table->findNode(receiver_id);
+        for (auto &b58_receiver_id : out_msg.receivers) {
+          auto node = routing_table->findNode(b58_receiver_id);
           if (node.has_value()) {
             auto stub = genStub<GruutGeneralService::Stub, GruutGeneralService>(node.value().getChannelPtr());
             auto status = stub->GeneralService(&context, request, &msg_status);
           } else {
-            routing_table->unmapId(receiver_id);
+            routing_table->unmapId(b58_receiver_id);
           }
         }
       }
     } else if (checkSignerMsgType(out_msg.type)) {
       auto packed_msg = packMsg(out_msg);
 
-      for (auto &receiver_id_arr : out_msg.receivers) {
-        auto receiver_id = TypeConverter::arrayToString<SENDER_ID_TYPE_SIZE>(receiver_id_arr);
-        SignerRpcInfo signer_rpc_info = signer_conn_table->getRpcInfo(receiver_id);
+      for (auto &b58_receiver_id : out_msg.receivers) {
+        SignerRpcInfo signer_rpc_info = signer_conn_table->getRpcInfo(b58_receiver_id);
         if (signer_rpc_info.send_msg == nullptr)
           continue;
 

--- a/src/plugins/net_plugin/rpc_services/rpc_services.cpp
+++ b/src/plugins/net_plugin/rpc_services/rpc_services.cpp
@@ -122,9 +122,9 @@ void GeneralService::proceed() {
           if (input_msg_type == MessageType::MSG_BLOCK || input_msg_type == MessageType::MSG_TX ||
               input_msg_type == MessageType::MSG_REQ_BLOCK) {
 
-            auto user_id = TypeConverter::arrayToString<SENDER_ID_TYPE_SIZE>(input_data.value().sender_id);
+            auto b58_user_id = TypeConverter::encodeBase<58>(input_data.value().sender_id);
             auto net_id = m_context.client_metadata().find("net_id")->second;
-            m_routing_table->mapId(user_id, string(net_id.data()));
+            m_routing_table->mapId(b58_user_id, string(net_id.data()));
           }
 
           auto &in_msg_channel = app().getChannel<incoming::channels::network::channel_type>();
@@ -176,7 +176,8 @@ optional<InNetMsg> GeneralService::parseMessage(string &packed_msg, Status &retu
   }
 
   return_rpc_status = Status::OK;
-  return InNetMsg{msg_header->message_type, json_body, msg_header->sender_id};
+  auto b58_sender_id = TypeConverter::encodeBase<58>(msg_header->sender_id);
+  return InNetMsg{msg_header->message_type, json_body, b58_sender_id};
 }
 
 MessageHeader* GeneralService::parseHeader(string &raw_header) {


### PR DESCRIPTION
- Message의 body에 적혀있는 id들은 base58 형태로 encoding 되어있음.
- 일반적인 id 형태로 plugin간 데이터를 주고 받으면 잦은 타입 변환이 일어날 수 있음.
- 이를 완화하기 위해 내부에서 주고받는 id 형태를 base58 형태로 수정.

 ### 수정사항
- channel interface 의 InNetMsg / OutNetMsg 의 사용하는 id-type name
변경
- Routing table의 id-mapping-table에서 base58 id를 key로 사용하도록 수정