### PR TITLE
# EDIT - ID type & name in Net plugin 

### DIFF
--- a/src/plugins/net_plugin/config/include/message.hpp
+++ b/src/plugins/net_plugin/config/include/message.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "network_type.hpp"
+
 #include <array>
 #include <grpcpp/impl/codegen/status.h>
 #include <string>
@@ -60,13 +62,13 @@ constexpr uint8_t NOT_USED = 0x00;
 struct InNetMsg {
   MessageType type;
   nlohmann::json body;
-  sender_id_type sender_id;
+  b58_user_id_type sender_id;
 };
 
 struct OutNetMsg {
   MessageType type;
   nlohmann::json body;
-  std::vector<sender_id_type> receivers;
+  std::vector<b58_user_id_type> receivers;
 };
 
 struct MessageHeader {

--- a/src/plugins/net_plugin/config/include/network_type.hpp
+++ b/src/plugins/net_plugin/config/include/network_type.hpp
@@ -16,6 +16,7 @@ struct IpEndpoint {
 };
 
 using user_id_type = std::string;
+using b58_user_id_type = std::string;
 using net_id_type = std::string;    // Network virtual id type
 using hashed_net_id_type = Hash160; // Network hashed virtual id type
 

--- a/src/plugins/net_plugin/include/message_builder.hpp
+++ b/src/plugins/net_plugin/include/message_builder.hpp
@@ -27,11 +27,9 @@ public:
     msg_body["sID"] = from;
     msg_body["time"] = TimeUtil::now();
     msg_body["msg"] = "disconnected with signer";
-    sender_id_type to;
-    copy(from.begin(), from.end(), to.begin());
 
     incoming_msg.body = msg_body;
-    incoming_msg.sender_id = to;
+    incoming_msg.sender_id = from;
 
     return incoming_msg;
   }

--- a/src/plugins/net_plugin/kademlia/include/routing.hpp
+++ b/src/plugins/net_plugin/kademlia/include/routing.hpp
@@ -122,12 +122,12 @@ public:
 
   std::optional<Node> findNode(const hashed_net_id_type &hashed_id);
 
-  std::optional<Node> findNode(const user_id_type &id);
+  std::optional<Node> findNode(const b58_user_id_type &id);
 
   size_t getBucketIndexFor(const hashed_net_id_type &node) const;
 
-  void mapId(const user_id_type &user_id, const net_id_type &net_id);
-  void unmapId(const user_id_type &user_id);
+  void mapId(const b58_user_id_type &b58_user_id, const net_id_type &net_id);
+  void unmapId(const b58_user_id_type &b58_user_id);
   void unmapId(const hashed_net_id_type &hashed_net_id);
 private:
   Node m_my_node;
@@ -135,7 +135,7 @@ private:
   std::size_t m_ksize;
 
   std::deque<KBucket> m_buckets;
-  std::unordered_map<user_id_type, hashed_net_id_type> m_id_mapping_table;
+  std::unordered_map<b58_user_id_type, hashed_net_id_type> m_id_mapping_table;
 
   std::mutex m_id_map_mutex;
   std::mutex m_buckets_mutex;

--- a/src/plugins/net_plugin/kademlia/routing.cpp
+++ b/src/plugins/net_plugin/kademlia/routing.cpp
@@ -151,7 +151,7 @@ std::optional<Node> RoutingTable::findNode(const hashed_net_id_type &hashed_id) 
   return {};
 }
 
-std::optional<Node> RoutingTable::findNode(const user_id_type &id) {
+std::optional<Node> RoutingTable::findNode(const b58_user_id_type &id) {
   if(m_id_mapping_table.count(id) > 0){
     return findNode(m_id_mapping_table[id]);
   }
@@ -213,22 +213,22 @@ Done:
   return neighbors;
 }
 
-void RoutingTable::mapId(const user_id_type &user_id, const net_id_type &net_id) {
+void RoutingTable::mapId(const b58_user_id_type &b58_user_id, const net_id_type &net_id) {
   std::lock_guard<std::mutex> guard(m_id_map_mutex);
-  m_id_mapping_table.try_emplace(user_id, Hash<160>::sha1(net_id));
+  m_id_mapping_table.try_emplace(b58_user_id, Hash<160>::sha1(net_id));
   m_id_map_mutex.unlock();
 }
-void RoutingTable::unmapId(const user_id_type &user_id) {
-  if (m_id_mapping_table.count(user_id) > 0) {
+void RoutingTable::unmapId(const b58_user_id_type &b58_user_id) {
+  if (m_id_mapping_table.count(b58_user_id) > 0) {
     std::lock_guard<std::mutex> guard(m_id_map_mutex);
-    m_id_mapping_table.erase(user_id);
+    m_id_mapping_table.erase(b58_user_id);
     m_id_map_mutex.unlock();
   }
 }
 void RoutingTable::unmapId(const hashed_net_id_type &dead_hashed_id) {
-  for (auto &[user_id, net_hased_id] : m_id_mapping_table) {
+  for (auto &[b58_user_id, net_hased_id] : m_id_mapping_table) {
     if (net_hased_id == dead_hashed_id) {
-      unmapId(user_id);
+      unmapId(b58_user_id);
       return;
     }
   }

--- a/src/plugins/net_plugin/net_plugin.cpp
+++ b/src/plugins/net_plugin/net_plugin.cpp
@@ -315,23 +315,21 @@ public:
           }
         }
       } else {
-        for (auto &receiver_id_arr : out_msg.receivers) {
-          auto receiver_id = TypeConverter::arrayToString<SENDER_ID_TYPE_SIZE>(receiver_id_arr);
-          auto node = routing_table->findNode(receiver_id);
+        for (auto &b58_receiver_id : out_msg.receivers) {
+          auto node = routing_table->findNode(b58_receiver_id);
           if (node.has_value()) {
             auto stub = genStub<GruutMergerService::Stub, GruutMergerService>(node.value().getChannelPtr());
             auto status = stub->MergerService(&context, request, &msg_status);
           } else {
-            routing_table->unmapId(receiver_id);
+            routing_table->unmapId(b58_receiver_id);
           }
         }
       }
     } else if (checkSignerMsgType(out_msg.type)) {
       auto packed_msg = packMsg(out_msg);
 
-      for (auto &receiver_id_arr : out_msg.receivers) {
-        auto receiver_id = TypeConverter::arrayToString<SENDER_ID_TYPE_SIZE>(receiver_id_arr);
-        SignerRpcInfo signer_rpc_info = signer_conn_table->getRpcInfo(receiver_id);
+      for (auto &b58_receiver_id : out_msg.receivers) {
+        SignerRpcInfo signer_rpc_info = signer_conn_table->getRpcInfo(b58_receiver_id);
         if (signer_rpc_info.send_msg == nullptr)
           continue;
 

--- a/src/plugins/net_plugin/rpc_services/include/rpc_services.hpp
+++ b/src/plugins/net_plugin/rpc_services/include/rpc_services.hpp
@@ -57,7 +57,7 @@ public:
   }
 
 private:
-  string m_signer_id_b64;
+  string m_signer_id_b58;
   GruutSignerService::AsyncService *m_service;
   Identity m_request;
   ServerAsyncReaderWriter<ReplyMsg, Identity> m_stream;

--- a/src/plugins/net_plugin/rpc_services/rpc_services.cpp
+++ b/src/plugins/net_plugin/rpc_services/rpc_services.cpp
@@ -109,16 +109,16 @@ void OpenChannelWithSigner::proceed() {
   } break;
 
   case RpcCallStatus::PROCESS: {
-    m_signer_id_b64 = m_request.sender();
+    m_signer_id_b58 = m_request.sender();
     m_receive_status = RpcCallStatus::WAIT;
-    m_signer_table->setReplyMsg(m_signer_id_b64, &m_stream, this);
+    m_signer_table->setRpcInfo(m_signer_id_b58, &m_stream, this);
 
   } break;
 
   case RpcCallStatus::WAIT: {
     if (m_context.IsCancelled()) {
-      auto internal_msg = MessageBuilder::build<MessageType::MSG_LEAVE>(m_signer_id_b64);
-      m_signer_table->eraseRpcInfo(m_signer_id_b64);
+      auto internal_msg = MessageBuilder::build<MessageType::MSG_LEAVE>(m_signer_id_b58);
+      m_signer_table->eraseRpcInfo(m_signer_id_b58);
       auto &in_msg_channel = app().getChannel<incoming::channels::network::channel_type>();
       in_msg_channel.publish(internal_msg);
       delete this;

--- a/src/plugins/net_plugin/rpc_services/rpc_services.cpp
+++ b/src/plugins/net_plugin/rpc_services/rpc_services.cpp
@@ -53,7 +53,7 @@ public:
     InNetMsg in_msg;
     in_msg.type = msg_header->message_type;
     in_msg.body = json_body;
-    in_msg.sender_id = msg_header->sender_id;
+    in_msg.sender_id = TypeConverter::encodeBase<58>(msg_header->sender_id);
 
     return in_msg;
   }
@@ -225,9 +225,9 @@ void MergerService::proceed() {
         if (input_msg_type == MessageType::MSG_BLOCK || input_msg_type == MessageType::MSG_TX ||
             input_msg_type == MessageType::MSG_REQ_BLOCK) {
 
-          auto user_id = TypeConverter::arrayToString<SENDER_ID_TYPE_SIZE>(input_data.value().sender_id);
+          auto b58_user_id = TypeConverter::encodeBase<58>(input_data.value().sender_id);
           auto net_id = m_context.client_metadata().find("net_id")->second;
-          m_routing_table->mapId(user_id, string(net_id.data()));
+          m_routing_table->mapId(b58_user_id, string(net_id.data()));
         }
 
         auto &in_msg_channel = app().getChannel<incoming::channels::network::channel_type>();


### PR DESCRIPTION
- Message body에 있는 id 값들은 base58 형태입니다.
- plugin 간 통신에서 일반적인 id 를 전송하게되면 type converting이 빈번하게 일어날 수 있습니다.

### 수정사항
- InNetMsg / OutNetMsg 의 id type 수정 ( array -> string ( base58 ) )
- Routing table의 id mapping table의 id 관련 변수명 수정 (id mapping table에서는 key base58 str id 사용)
- Signer connection table에서 id 관련 변수명 b64 -> b58 수정
