### PR TITLE
# FEATURE - Signer Pool Manager

### DIFF
--- a/src/plugins/net_plugin/config/include/message.hpp
+++ b/src/plugins/net_plugin/config/include/message.hpp
@@ -84,6 +84,19 @@ struct MessageHeader {
   sender_id_type sender_id;
 };
 
+enum class ErrorMsgType : int {
+  UNKNOWN = 0,
+  MERGER_BOOTSTRAP = 11,
+  ECDH_ILLEGAL_ACCESS = 21,
+  ECDH_MAX_SIGNER_POOL = 22,
+  ECDH_TIMEOUT = 23,
+  ECDH_INVALID_SIG = 24,
+  ECDH_INVALID_PK = 25,
+  TIME_SYNC = 61,
+  BSYNC_NO_BLOCK = 88,
+  NO_SUCH_BLOCK = 89
+};
+
 enum class MsgEntryType { BASE64, TIMESTAMP, TIMESTAMP_NOW, HEX, STRING, UINT, BOOL, ARRAYOFOBJECT, ARRAYOFSTRING };
 
 enum class MsgEntryLength : int {

--- a/src/plugins/net_plugin/config/include/network_config.hpp
+++ b/src/plugins/net_plugin/config/include/network_config.hpp
@@ -11,7 +11,7 @@ constexpr unsigned int PARALLELISM_ALPHA = 3;
 constexpr auto GENERAL_SERVICE_TIMEOUT = std::chrono::milliseconds(100);
 
 // TODO : MERGER의 ID를 GA로 받아 올 수 있을때 사용치 않을것. (ID : TEST-MERGER-ID-1TEST-MERGER-ID-1 )
-const std::string ID_BASE64 = "VEVTVC1NRVJHRVItSUQtMVRFU1QtTUVSR0VSLUlELTE=";
+const std::string MY_ID_BASE58 = "6fxZPb2whbwVGUGSSwFW1FnmtqMaXptz8wq7A3dgLyG4";
 const std::string MY_ID = "TEST-MERGER-ID-1TEST-MERGER-ID-1"; // 32bytes
 // TODO : LOCAL CHAIN ID / WORLD ID 에 대해서 정해진 바가 없어 임시 사용 수정될 것.
 const std::string LOCAL_CHAIN_ID = "LCHAINID"; // 8bytes

--- a/src/plugins/net_plugin/include/message_builder.hpp
+++ b/src/plugins/net_plugin/include/message_builder.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
+#include "../../../../lib/gruut-utils/src/hmac_key_maker.hpp"
 #include "../../../../lib/gruut-utils/src/time_util.hpp"
 #include "../../../../lib/json/include/json.hpp"
 #include "../../channel_interface/include/channel_interface.hpp"
+#include "../config/include/network_config.hpp"
 #include "msg_schema.hpp"
 
 #include <optional>
@@ -17,21 +19,56 @@ namespace net_plugin {
 
 class MessageBuilder {
 public:
-  template <MessageType T, typename = enable_if_t<T == MessageType::MSG_LEAVE>>
-  static auto build(string from) {
-    InNetMsg incoming_msg;
-
-    incoming_msg.type = MessageType::MSG_LEAVE;
+  template <MessageType T, typename = enable_if_t<T == MessageType::MSG_CHALLENGE>>
+  static auto build(const string &b58_recv_id, const string &merger_nonce) {
+    OutNetMsg msg_challenge;
     nlohmann::json msg_body;
 
-    msg_body["sID"] = from;
     msg_body["time"] = TimeUtil::now();
-    msg_body["msg"] = "disconnected with signer";
+    msg_body["user"] = b58_recv_id;
+    msg_body["merger"] = MY_ID_BASE58;
+    msg_body["mn"] = merger_nonce;
 
-    incoming_msg.body = msg_body;
-    incoming_msg.sender_id = from;
+    msg_challenge.type = MessageType::MSG_CHALLENGE;
+    msg_challenge.body = msg_body;
+    msg_challenge.receivers = {b58_recv_id};
 
-    return incoming_msg;
+    return msg_challenge;
+  }
+
+  template <MessageType T, typename = enable_if_t<T == MessageType::MSG_RESPONSE_2>>
+  static auto build(const string &b58_recv_id, const string &dhx, const string &dhy, const string &cert, const string &sig) {
+    OutNetMsg msg_response2;
+    nlohmann::json msg_body;
+
+    msg_body["time"] = TimeUtil::now();
+    msg_body["dh"]["x"] = dhx;
+    msg_body["dh"]["y"] = dhy;
+    msg_body["merger"]["id"] = MY_ID_BASE58;
+    msg_body["merger"]["cert"] = cert;
+    msg_body["merger"]["sig"] = sig;
+
+    msg_response2.type = MessageType::MSG_RESPONSE_2;
+    msg_response2.body = msg_body;
+    msg_response2.receivers = {b58_recv_id};
+
+    return msg_response2;
+  }
+
+  template <MessageType T, typename = enable_if_t<T == MessageType::MSG_ACCEPT>>
+  static auto build(const string &b58_recv_id) {
+    OutNetMsg msg_accept;
+    nlohmann::json msg_body;
+
+    msg_body["time"] = TimeUtil::now();
+    msg_body["user"] = b58_recv_id;
+    msg_body["val"] = true;
+
+    msg_accept.type = MessageType::MSG_ACCEPT;
+    msg_accept.body = msg_body;
+    msg_accept.receivers = {b58_recv_id};
+
+    return msg_accept;
   }
 };
 

--- a/src/plugins/net_plugin/include/message_packer.hpp
+++ b/src/plugins/net_plugin/include/message_packer.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "../../../lib/gruut-utils/src/lz4_compressor.hpp"
+#include "../config/include/message.hpp"
+
+namespace gruut {
+namespace net_plugin {
+
+using namespace std;
+
+class MessagePacker {
+public:
+  static string packMessage(OutNetMsg &out_msg) {
+    // TODO : serialized-body must be determined by serialization algo type
+    string json_dump = out_msg.body.dump();
+    string serialized_body = LZ4Compressor::compressData(json_dump);
+    string header = makeHeader(serialized_body.size(), out_msg.type, SerializationAlgorithmType::LZ4);
+
+    return (header + serialized_body);
+  }
+
+private:
+  static string makeHeader(int serialized_json_size, MessageType msg_type, SerializationAlgorithmType serialization_algo_type) {
+    MessageHeader msg_header;
+    msg_header.identifier = IDENTIFIER;
+    msg_header.version = VERSION;
+    msg_header.message_type = msg_type;
+    if (msg_type == MessageType::MSG_ACCEPT || msg_type == MessageType::MSG_REQ_SSIG)
+      msg_header.mac_algo_type = MACAlgorithmType::HMAC;
+    else
+      msg_header.mac_algo_type = MACAlgorithmType::NONE;
+
+    msg_header.serialization_algo_type = serialization_algo_type;
+    msg_header.dummy = NOT_USED;
+
+    int total_length = HEADER_LENGTH + serialized_json_size;
+
+    for (int i = MSG_LENGTH_SIZE; i > 0; i--) {
+      msg_header.total_length[i] |= total_length;
+      total_length >>= 8;
+    }
+    msg_header.total_length[0] |= total_length;
+
+    copy(begin(WORLD_ID), end(WORLD_ID), begin(msg_header.world_id));
+    copy(begin(LOCAL_CHAIN_ID), end(LOCAL_CHAIN_ID), begin(msg_header.local_chain_id));
+    copy(begin(MY_ID), end(MY_ID), begin(msg_header.sender_id));
+
+    auto header_ptr = reinterpret_cast<uint8_t *>(&msg_header);
+    auto serialized_header = string(header_ptr, header_ptr + sizeof(msg_header));
+
+    return serialized_header;
+  }
+};
+
+} // namespace net_plugin
+} // namespace gruut

--- a/src/plugins/net_plugin/include/signer_conn_table.hpp
+++ b/src/plugins/net_plugin/include/signer_conn_table.hpp
@@ -16,7 +16,7 @@ using namespace std;
 
 struct SignerRpcInfo {
   void *tag_identity;
-  ServerAsyncReaderWriter<ReplyMsg, Identity> *send_msg;
+  ServerAsyncReaderWriter<Request, Identity> *send_msg;
 };
 
 class SignerConnTable {
@@ -33,7 +33,7 @@ public:
 
   ~SignerConnTable() = default;
 
-  void setRpcInfo(const string &recv_id_b58, ServerAsyncReaderWriter<ReplyMsg, Identity> *reply_rpc, void *tag) {
+  void setRpcInfo(const string &recv_id_b58, ServerAsyncReaderWriter<Request, Identity> *reply_rpc, void *tag) {
     lock_guard<std::mutex> lock(m_mutex);
     m_signer_list[recv_id_b58].send_msg = reply_rpc;
     m_signer_list[recv_id_b58].tag_identity = tag;

--- a/src/plugins/net_plugin/include/signer_pool_manager.hpp
+++ b/src/plugins/net_plugin/include/signer_pool_manager.hpp
@@ -1,0 +1,202 @@
+#pragma once
+
+#include "../../../../lib/gruut-utils/src/hmac_key_maker.hpp"
+#include "../../../../lib/gruut-utils/src/random_number_generator.hpp"
+#include "../../../../lib/gruut-utils/src/time_util.hpp"
+#include "../../../../lib/gruut-utils/src/type_converter.hpp"
+#include "../../../../lib/json/include/json.hpp"
+#include "../../../../lib/log/include/log.hpp"
+#include "../config/include/message.hpp"
+#include "../config/include/network_config.hpp"
+#include "message_builder.hpp"
+
+#include <algorithm>
+#include <atomic>
+#include <mutex>
+#include <optional>
+#include <random>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace gruut {
+
+using namespace net_plugin;
+using namespace std;
+
+constexpr uint64_t JOIN_TIMEOUT_SEC = 10;
+constexpr int MAX_SIGNER = 200;
+
+struct Signer {
+  string user_id;
+  vector<uint8_t> hmac_key;
+};
+
+struct JoinTempData {
+  string merger_nonce;
+  string signer_pk_cert;
+  vector<uint8_t> shared_sk;
+  uint64_t start_time;
+};
+
+using TempSignerPool = unordered_map<string, JoinTempData>;
+
+class SignerPool {
+public:
+  SignerPool() = default;
+  SignerPool(const SignerPool &) = delete;
+  SignerPool(const SignerPool &&) = delete;
+  SignerPool &operator=(const SignerPool &) = delete;
+
+  void pushSigner(const string &b58_user_id, vector<uint8_t> &hmac_key) {
+    Signer new_signer;
+    new_signer.user_id = TypeConverter::decodeBase<58>(b58_user_id);
+    new_signer.hmac_key = hmac_key;
+
+    lock_guard<std::mutex> guard(push_mutex);
+    signer_pool[b58_user_id] = new_signer;
+    push_mutex.unlock();
+  }
+
+  bool eraseSigner(const string &b58_user_id) {
+    if (signer_pool.count(b58_user_id) > 0) {
+      lock_guard<std::mutex> guard(push_mutex);
+      signer_pool.erase(b58_user_id);
+      push_mutex.unlock();
+      return true;
+    }
+    return false;
+  }
+
+  const size_t size() {
+    return signer_pool.size();
+  }
+
+  optional<vector<uint8_t>> getHmacKey(const string &b58_user_id) {
+    if (signer_pool.count(b58_user_id) > 0)
+      return signer_pool[b58_user_id].hmac_key;
+    return {};
+  }
+
+  bool full() {
+    return MAX_SIGNER >= signer_pool.size();
+  }
+
+private:
+  unordered_map<string, Signer> signer_pool;
+  std::mutex push_mutex;
+  std::mutex set_mutex;
+};
+
+class SignerPoolManager {
+public:
+  SignerPoolManager() = default;
+  SignerPoolManager(const SignerPoolManager &) = delete;
+  SignerPoolManager(SignerPoolManager &&) = default;
+  SignerPoolManager &operator=(SignerPoolManager &&) = default;
+
+  OutNetMsg handleMsg(InNetMsg &msg) {
+    string recv_id_b58 = msg.sender_id;
+
+    switch (msg.type) {
+    case MessageType::MSG_JOIN: {
+      if (!isJoinable()) {
+        logger::ERROR("[ECDH] Signer pool is full");
+        throw ErrorMsgType::ECDH_MAX_SIGNER_POOL;
+      }
+
+      auto signer_id_in_body = json::get<string>(msg.body, "signer");
+      if (signer_id_in_body.value() == msg.sender_id) {
+        logger::ERROR("[ECDH] Message header and body id are different");
+        throw ErrorMsgType::ECDH_ILLEGAL_ACCESS;
+      }
+
+      temp_signer_pool[msg.sender_id].start_time = TimeUtil::nowBigInt();
+      auto merger_nonce = TypeConverter::encodeBase<64>((RandomNumGenerator::randomize(32)));
+      temp_signer_pool[msg.sender_id].merger_nonce = merger_nonce;
+
+      auto msg_challenge = MessageBuilder::build<MessageType::MSG_CHALLENGE>(recv_id_b58, merger_nonce);
+      return msg_challenge;
+    }
+
+    case MessageType::MSG_RESPONSE_1: {
+      if (temp_signer_pool.find(msg.sender_id) == temp_signer_pool.end()) {
+        logger::ERROR("[ECDH] Illegal Trial");
+        throw ErrorMsgType::ECDH_ILLEGAL_ACCESS;
+      }
+      if (isTimeout(msg.sender_id)) {
+        logger::ERROR("[ECDH] Join timeout");
+        throw ErrorMsgType::ECDH_TIMEOUT;
+      }
+
+      // TODO : verify signer signature;
+
+      temp_signer_pool[msg.sender_id].signer_pk_cert = json::get<string>(msg.body["user"], "pk").value();
+
+      HmacKeyMaker key_maker;
+      auto [dhx, dhy] = key_maker.getPublicKey();
+
+      auto signer_dhx = json::get<string>(msg.body["dh"], "x").value();
+      auto signer_dhy = json::get<string>(msg.body["dh"], "y").value();
+      auto shared_sk_bytes = key_maker.getSharedSecretKey(signer_dhx, signer_dhy, 32);
+
+      if (shared_sk_bytes.empty()) {
+        logger::ERROR("[ECDH] Failed to generate SSK (invalid PK)");
+        throw ErrorMsgType::ECDH_INVALID_PK;
+      }
+
+      temp_signer_pool[msg.sender_id].shared_sk = shared_sk_bytes;
+
+      // TODO : need to set merger_cert and signature;
+      auto msg_response2 = MessageBuilder::build<MessageType::MSG_RESPONSE_2>(recv_id_b58, dhx, dhy, "", "");
+
+      return msg_response2;
+    }
+
+    case MessageType::MSG_SUCCESS: {
+      if (isTimeout(msg.sender_id)) {
+        logger::ERROR("[ECDH] Join timeout");
+        throw ErrorMsgType::ECDH_TIMEOUT;
+      }
+
+      signer_pool.pushSigner(recv_id_b58, temp_signer_pool[recv_id_b58].shared_sk);
+      temp_signer_pool.erase(recv_id_b58);
+
+      // TODO : signer join event should be notified to `Block producer`
+
+      auto msg_accept = MessageBuilder::build<MessageType::MSG_ACCEPT>(recv_id_b58);
+      return msg_accept;
+    }
+    default: {
+      logger::ERROR("[ECDH] Unknown message");
+      throw ErrorMsgType::UNKNOWN;
+    }
+    }
+  }
+
+  void removeSigner(const string &b58_signer_id) {
+    signer_pool.eraseSigner(b58_signer_id);
+  }
+  void removeTempSigner(const string &b58_signer_id) {
+    if (temp_signer_pool.count(b58_signer_id) > 0)
+      temp_signer_pool.erase(b58_signer_id);
+  }
+
+  optional<vector<uint8_t>> getHmacKey(const string &b58_signer_id) {
+    return signer_pool.getHmacKey(b58_signer_id);
+  }
+
+private:
+  bool isJoinable() {
+    return signer_pool.full();
+  }
+
+  bool isTimeout(const string &b58_signer_id) {
+    return (TimeUtil::nowBigInt() - temp_signer_pool[b58_signer_id].start_time) > JOIN_TIMEOUT_SEC;
+  }
+
+  SignerPool signer_pool;
+  TempSignerPool temp_signer_pool;
+};
+
+} // namespace gruut

--- a/src/plugins/net_plugin/include/signer_pool_manager.hpp
+++ b/src/plugins/net_plugin/include/signer_pool_manager.hpp
@@ -117,7 +117,6 @@ public:
       auto msg_challenge = MessageBuilder::build<MessageType::MSG_CHALLENGE>(recv_id_b58, merger_nonce);
       return msg_challenge;
     }
-
     case MessageType::MSG_RESPONSE_1: {
       if (temp_signer_pool.find(msg.sender_id) == temp_signer_pool.end()) {
         logger::ERROR("[ECDH] Illegal Trial");
@@ -151,7 +150,6 @@ public:
 
       return msg_response2;
     }
-
     case MessageType::MSG_SUCCESS: {
       if (isTimeout(msg.sender_id)) {
         logger::ERROR("[ECDH] Join timeout");

--- a/src/plugins/net_plugin/include/signer_pool_manager.hpp
+++ b/src/plugins/net_plugin/include/signer_pool_manager.hpp
@@ -85,7 +85,6 @@ public:
 private:
   unordered_map<string, Signer> signer_pool;
   std::mutex push_mutex;
-  std::mutex set_mutex;
 };
 
 class SignerPoolManager {

--- a/src/plugins/net_plugin/net_plugin.cpp
+++ b/src/plugins/net_plugin/net_plugin.cpp
@@ -3,9 +3,10 @@
 #include "config/include/network_config.hpp"
 #include "include/http_client.hpp"
 #include "include/message_builder.hpp"
+#include "include/message_packer.hpp"
 #include "rpc_services/include/rpc_services.hpp"
 
-#include "../../../lib/gruut-utils/src/lz4_compressor.hpp"
+#include "../../../lib/gruut-utils/src/hmac.hpp"
 #include "../../../lib/gruut-utils/src/random_number_generator.hpp"
 #include "../../../lib/gruut-utils/src/sha256.hpp"
 #include "../../../lib/gruut-utils/src/time_util.hpp"
@@ -42,6 +43,7 @@ public:
   unique_ptr<Server> server;
   unique_ptr<ServerCompletionQueue> completion_queue;
 
+  shared_ptr<SignerPoolManager> signer_pool_manager;
   shared_ptr<SignerConnTable> signer_conn_table;
   shared_ptr<RoutingTable> routing_table;
   shared_ptr<BroadcastMsgTable> broadcast_check_table;
@@ -93,8 +95,8 @@ public:
     signer_conn_table = make_shared<SignerConnTable>();
     broadcast_check_table = make_shared<BroadcastMsgTable>();
 
-    new OpenChannelWithSigner(&signer_service, completion_queue.get(), signer_conn_table);
-    new SignerService(&signer_service, completion_queue.get());
+    new OpenChannelWithSigner(&signer_service, completion_queue.get(), signer_conn_table, signer_pool_manager);
+    new SignerService(&signer_service, completion_queue.get(), signer_pool_manager);
     new MergerService(&merger_service, completion_queue.get(), routing_table, broadcast_check_table);
     new FindNode(&kademlia_service, completion_queue.get(), routing_table);
   }
@@ -283,9 +285,11 @@ public:
   }
 
   void sendMessage(OutNetMsg &out_msg) {
+
+    auto packed_msg = MessagePacker::packMessage(out_msg);
+
     if (checkMergerMsgType(out_msg.type)) {
       bool is_broadcast(out_msg.receivers.empty());
-      auto packed_msg = packMsg(out_msg);
 
       grpc_merger::RequestMsg request;
       request.set_message(packed_msg);
@@ -328,64 +332,24 @@ public:
         }
       }
     } else if (checkSignerMsgType(out_msg.type)) {
-      auto packed_msg = packMsg(out_msg);
-
       for (auto &b58_receiver_id : out_msg.receivers) {
         SignerRpcInfo signer_rpc_info = signer_conn_table->getRpcInfo(b58_receiver_id);
         if (signer_rpc_info.send_msg == nullptr)
           continue;
 
-        if (out_msg.type == MessageType::MSG_ACCEPT || out_msg.type == MessageType::MSG_REQ_SSIG) {
-
-          // TODO : generate HMAC using packed msg and then attach to packed msg
+        if (out_msg.type == MessageType::MSG_REQ_SSIG) {
+          auto hmac_key = signer_pool_manager->getHmacKey(b58_receiver_id);
+          if (!hmac_key.has_value())
+            continue;
+          auto hmac = Hmac::generateHMAC(packed_msg, hmac_key.value());
+          packed_msg += string(hmac.begin(), hmac.end());
         }
-
         auto tag = static_cast<Identity *>(signer_rpc_info.tag_identity);
-        ReplyMsg reply;
-        reply.set_message(packed_msg);
-        signer_rpc_info.send_msg->Write(reply, tag);
+        Request req;
+        req.set_message(packed_msg);
+        signer_rpc_info.send_msg->Write(req, tag);
       }
     }
-  }
-
-  string packMsg(OutNetMsg &out_msg) {
-    // TODO : serialized-body must be determined by serialization algo type
-    string json_dump = out_msg.body.dump();
-    string serialized_body = LZ4Compressor::compressData(json_dump);
-    string header = makeHeader(serialized_body.size(), out_msg.type, SerializationAlgorithmType::LZ4);
-
-    return (header + serialized_body);
-  }
-
-  string makeHeader(int serialized_json_size, MessageType msg_type, SerializationAlgorithmType serialization_algo_type) {
-    MessageHeader msg_header;
-    msg_header.identifier = IDENTIFIER;
-    msg_header.version = VERSION;
-    msg_header.message_type = msg_type;
-    if (msg_type == MessageType::MSG_ACCEPT || msg_type == MessageType::MSG_REQ_SSIG)
-      msg_header.mac_algo_type = MACAlgorithmType::HMAC;
-    else
-      msg_header.mac_algo_type = MACAlgorithmType::NONE;
-
-    msg_header.serialization_algo_type = serialization_algo_type;
-    msg_header.dummy = NOT_USED;
-
-    int total_length = HEADER_LENGTH + serialized_json_size;
-
-    for (int i = MSG_LENGTH_SIZE; i > 0; i--) {
-      msg_header.total_length[i] |= total_length;
-      total_length >>= 8;
-    }
-    msg_header.total_length[0] |= total_length;
-
-    std::copy(std::begin(WORLD_ID), std::end(WORLD_ID), std::begin(msg_header.world_id));
-    std::copy(std::begin(LOCAL_CHAIN_ID), std::end(LOCAL_CHAIN_ID), std::begin(msg_header.local_chain_id));
-    std::copy(std::begin(MY_ID), std::end(MY_ID), std::begin(msg_header.sender_id));
-
-    auto header_ptr = reinterpret_cast<uint8_t *>(&msg_header);
-    auto serialized_header = std::string(header_ptr, header_ptr + sizeof(msg_header));
-
-    return serialized_header;
   }
 
   bool checkMergerMsgType(MessageType msg_type) {
@@ -393,8 +357,7 @@ public:
   }
 
   bool checkSignerMsgType(MessageType msg_type) {
-    return (msg_type == MessageType::MSG_CHALLENGE || msg_type == MessageType::MSG_RESPONSE_2 || msg_type == MessageType::MSG_ACCEPT ||
-            msg_type == MessageType::MSG_REQ_SSIG);
+    return msg_type == MessageType::MSG_REQ_SSIG;
   }
 };
 

--- a/src/plugins/net_plugin/rpc_services/include/rpc_services.hpp
+++ b/src/plugins/net_plugin/rpc_services/include/rpc_services.hpp
@@ -85,6 +85,7 @@ private:
   ServerAsyncResponseWriter<Reply> m_responder;
 
   shared_ptr<SignerPoolManager> m_signer_pool_manager;
+  grpc::Status verifyHMAC(string_view packed_msg, vector<uint8_t> &hmac_key);
   void proceed() override;
 };
 

--- a/src/plugins/net_plugin/rpc_services/include/rpc_services.hpp
+++ b/src/plugins/net_plugin/rpc_services/include/rpc_services.hpp
@@ -8,7 +8,8 @@
 
 #include "../../../channel_interface/include/channel_interface.hpp"
 #include "../../config/include/network_type.hpp"
-#include "../../include/signer_conn_manager.hpp"
+#include "../../include/signer_conn_table.hpp"
+#include "../../include/signer_pool_manager.hpp"
 #include "../../kademlia/include/node.hpp"
 #include "../../kademlia/include/routing.hpp"
 
@@ -46,8 +47,9 @@ protected:
 
 class OpenChannelWithSigner final : public CallData {
 public:
-  OpenChannelWithSigner(GruutSignerService::AsyncService *service, ServerCompletionQueue *cq, shared_ptr<SignerConnTable> signer_table)
-      : m_stream(&m_context), m_signer_table(move(signer_table)) {
+  OpenChannelWithSigner(GruutSignerService::AsyncService *service, ServerCompletionQueue *cq, shared_ptr<SignerConnTable> signer_conn_table,
+                        shared_ptr<SignerPoolManager> signer_pool_manager)
+      : m_stream(&m_context), m_signer_conn_table(move(signer_conn_table)), m_signer_pool_manager(move(signer_pool_manager)) {
 
     m_service = service;
     m_completion_queue = cq;
@@ -60,15 +62,17 @@ private:
   string m_signer_id_b58;
   GruutSignerService::AsyncService *m_service;
   Identity m_request;
-  ServerAsyncReaderWriter<ReplyMsg, Identity> m_stream;
+  ServerAsyncReaderWriter<Request, Identity> m_stream;
 
-  shared_ptr<SignerConnTable> m_signer_table;
+  shared_ptr<SignerConnTable> m_signer_conn_table;
+  shared_ptr<SignerPoolManager> m_signer_pool_manager;
   void proceed() override;
 };
 
 class SignerService final : public CallData {
 public:
-  SignerService(GruutSignerService::AsyncService *service, ServerCompletionQueue *cq) : m_responder(&m_context) {
+  SignerService(GruutSignerService::AsyncService *service, ServerCompletionQueue *cq, shared_ptr<SignerPoolManager> signer_pool_manager)
+      : m_responder(&m_context), m_signer_pool_manager(move(signer_pool_manager)) {
     m_service = service;
     m_completion_queue = cq;
     m_receive_status = RpcCallStatus::CREATE;
@@ -76,10 +80,11 @@ public:
 
 private:
   GruutSignerService::AsyncService *m_service;
-  grpc_signer::RequestMsg m_request;
-  grpc_signer::MsgStatus m_reply;
-  ServerAsyncResponseWriter<grpc_signer::MsgStatus> m_responder;
+  Request m_request;
+  Reply m_reply;
+  ServerAsyncResponseWriter<Reply> m_responder;
 
+  shared_ptr<SignerPoolManager> m_signer_pool_manager;
   void proceed() override;
 };
 

--- a/src/plugins/net_plugin/rpc_services/protos/include/signer_service.grpc.pb.h
+++ b/src/plugins/net_plugin/rpc_services/protos/include/signer_service.grpc.pb.h
@@ -34,56 +34,56 @@ class GruutSignerService final {
   class StubInterface {
    public:
     virtual ~StubInterface() {}
-    std::unique_ptr< ::grpc::ClientReaderWriterInterface< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>> OpenChannel(::grpc::ClientContext* context) {
-      return std::unique_ptr< ::grpc::ClientReaderWriterInterface< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>>(OpenChannelRaw(context));
+    std::unique_ptr< ::grpc::ClientReaderWriterInterface< ::grpc_signer::Identity, ::grpc_signer::Request>> OpenChannel(::grpc::ClientContext* context) {
+      return std::unique_ptr< ::grpc::ClientReaderWriterInterface< ::grpc_signer::Identity, ::grpc_signer::Request>>(OpenChannelRaw(context));
     }
-    std::unique_ptr< ::grpc::ClientAsyncReaderWriterInterface< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>> AsyncOpenChannel(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq, void* tag) {
-      return std::unique_ptr< ::grpc::ClientAsyncReaderWriterInterface< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>>(AsyncOpenChannelRaw(context, cq, tag));
+    std::unique_ptr< ::grpc::ClientAsyncReaderWriterInterface< ::grpc_signer::Identity, ::grpc_signer::Request>> AsyncOpenChannel(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderWriterInterface< ::grpc_signer::Identity, ::grpc_signer::Request>>(AsyncOpenChannelRaw(context, cq, tag));
     }
-    std::unique_ptr< ::grpc::ClientAsyncReaderWriterInterface< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>> PrepareAsyncOpenChannel(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncReaderWriterInterface< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>>(PrepareAsyncOpenChannelRaw(context, cq));
+    std::unique_ptr< ::grpc::ClientAsyncReaderWriterInterface< ::grpc_signer::Identity, ::grpc_signer::Request>> PrepareAsyncOpenChannel(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderWriterInterface< ::grpc_signer::Identity, ::grpc_signer::Request>>(PrepareAsyncOpenChannelRaw(context, cq));
     }
-    virtual ::grpc::Status SignerService(::grpc::ClientContext* context, const ::grpc_signer::RequestMsg& request, ::grpc_signer::MsgStatus* response) = 0;
-    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::MsgStatus>> AsyncSignerService(::grpc::ClientContext* context, const ::grpc_signer::RequestMsg& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::MsgStatus>>(AsyncSignerServiceRaw(context, request, cq));
+    virtual ::grpc::Status SignerService(::grpc::ClientContext* context, const ::grpc_signer::Request& request, ::grpc_signer::Reply* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::Reply>> AsyncSignerService(::grpc::ClientContext* context, const ::grpc_signer::Request& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::Reply>>(AsyncSignerServiceRaw(context, request, cq));
     }
-    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::MsgStatus>> PrepareAsyncSignerService(::grpc::ClientContext* context, const ::grpc_signer::RequestMsg& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::MsgStatus>>(PrepareAsyncSignerServiceRaw(context, request, cq));
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::Reply>> PrepareAsyncSignerService(::grpc::ClientContext* context, const ::grpc_signer::Request& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::Reply>>(PrepareAsyncSignerServiceRaw(context, request, cq));
     }
   private:
-    virtual ::grpc::ClientReaderWriterInterface< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>* OpenChannelRaw(::grpc::ClientContext* context) = 0;
-    virtual ::grpc::ClientAsyncReaderWriterInterface< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>* AsyncOpenChannelRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq, void* tag) = 0;
-    virtual ::grpc::ClientAsyncReaderWriterInterface< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>* PrepareAsyncOpenChannelRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq) = 0;
-    virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::MsgStatus>* AsyncSignerServiceRaw(::grpc::ClientContext* context, const ::grpc_signer::RequestMsg& request, ::grpc::CompletionQueue* cq) = 0;
-    virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::MsgStatus>* PrepareAsyncSignerServiceRaw(::grpc::ClientContext* context, const ::grpc_signer::RequestMsg& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientReaderWriterInterface< ::grpc_signer::Identity, ::grpc_signer::Request>* OpenChannelRaw(::grpc::ClientContext* context) = 0;
+    virtual ::grpc::ClientAsyncReaderWriterInterface< ::grpc_signer::Identity, ::grpc_signer::Request>* AsyncOpenChannelRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq, void* tag) = 0;
+    virtual ::grpc::ClientAsyncReaderWriterInterface< ::grpc_signer::Identity, ::grpc_signer::Request>* PrepareAsyncOpenChannelRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::Reply>* AsyncSignerServiceRaw(::grpc::ClientContext* context, const ::grpc_signer::Request& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_signer::Reply>* PrepareAsyncSignerServiceRaw(::grpc::ClientContext* context, const ::grpc_signer::Request& request, ::grpc::CompletionQueue* cq) = 0;
   };
   class Stub final : public StubInterface {
    public:
     Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channel);
-    std::unique_ptr< ::grpc::ClientReaderWriter< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>> OpenChannel(::grpc::ClientContext* context) {
-      return std::unique_ptr< ::grpc::ClientReaderWriter< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>>(OpenChannelRaw(context));
+    std::unique_ptr< ::grpc::ClientReaderWriter< ::grpc_signer::Identity, ::grpc_signer::Request>> OpenChannel(::grpc::ClientContext* context) {
+      return std::unique_ptr< ::grpc::ClientReaderWriter< ::grpc_signer::Identity, ::grpc_signer::Request>>(OpenChannelRaw(context));
     }
-    std::unique_ptr<  ::grpc::ClientAsyncReaderWriter< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>> AsyncOpenChannel(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq, void* tag) {
-      return std::unique_ptr< ::grpc::ClientAsyncReaderWriter< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>>(AsyncOpenChannelRaw(context, cq, tag));
+    std::unique_ptr<  ::grpc::ClientAsyncReaderWriter< ::grpc_signer::Identity, ::grpc_signer::Request>> AsyncOpenChannel(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderWriter< ::grpc_signer::Identity, ::grpc_signer::Request>>(AsyncOpenChannelRaw(context, cq, tag));
     }
-    std::unique_ptr<  ::grpc::ClientAsyncReaderWriter< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>> PrepareAsyncOpenChannel(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncReaderWriter< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>>(PrepareAsyncOpenChannelRaw(context, cq));
+    std::unique_ptr<  ::grpc::ClientAsyncReaderWriter< ::grpc_signer::Identity, ::grpc_signer::Request>> PrepareAsyncOpenChannel(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderWriter< ::grpc_signer::Identity, ::grpc_signer::Request>>(PrepareAsyncOpenChannelRaw(context, cq));
     }
-    ::grpc::Status SignerService(::grpc::ClientContext* context, const ::grpc_signer::RequestMsg& request, ::grpc_signer::MsgStatus* response) override;
-    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_signer::MsgStatus>> AsyncSignerService(::grpc::ClientContext* context, const ::grpc_signer::RequestMsg& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_signer::MsgStatus>>(AsyncSignerServiceRaw(context, request, cq));
+    ::grpc::Status SignerService(::grpc::ClientContext* context, const ::grpc_signer::Request& request, ::grpc_signer::Reply* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_signer::Reply>> AsyncSignerService(::grpc::ClientContext* context, const ::grpc_signer::Request& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_signer::Reply>>(AsyncSignerServiceRaw(context, request, cq));
     }
-    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_signer::MsgStatus>> PrepareAsyncSignerService(::grpc::ClientContext* context, const ::grpc_signer::RequestMsg& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_signer::MsgStatus>>(PrepareAsyncSignerServiceRaw(context, request, cq));
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_signer::Reply>> PrepareAsyncSignerService(::grpc::ClientContext* context, const ::grpc_signer::Request& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_signer::Reply>>(PrepareAsyncSignerServiceRaw(context, request, cq));
     }
 
    private:
     std::shared_ptr< ::grpc::ChannelInterface> channel_;
-    ::grpc::ClientReaderWriter< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>* OpenChannelRaw(::grpc::ClientContext* context) override;
-    ::grpc::ClientAsyncReaderWriter< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>* AsyncOpenChannelRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq, void* tag) override;
-    ::grpc::ClientAsyncReaderWriter< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>* PrepareAsyncOpenChannelRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq) override;
-    ::grpc::ClientAsyncResponseReader< ::grpc_signer::MsgStatus>* AsyncSignerServiceRaw(::grpc::ClientContext* context, const ::grpc_signer::RequestMsg& request, ::grpc::CompletionQueue* cq) override;
-    ::grpc::ClientAsyncResponseReader< ::grpc_signer::MsgStatus>* PrepareAsyncSignerServiceRaw(::grpc::ClientContext* context, const ::grpc_signer::RequestMsg& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientReaderWriter< ::grpc_signer::Identity, ::grpc_signer::Request>* OpenChannelRaw(::grpc::ClientContext* context) override;
+    ::grpc::ClientAsyncReaderWriter< ::grpc_signer::Identity, ::grpc_signer::Request>* AsyncOpenChannelRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq, void* tag) override;
+    ::grpc::ClientAsyncReaderWriter< ::grpc_signer::Identity, ::grpc_signer::Request>* PrepareAsyncOpenChannelRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::grpc_signer::Reply>* AsyncSignerServiceRaw(::grpc::ClientContext* context, const ::grpc_signer::Request& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::grpc_signer::Reply>* PrepareAsyncSignerServiceRaw(::grpc::ClientContext* context, const ::grpc_signer::Request& request, ::grpc::CompletionQueue* cq) override;
     const ::grpc::internal::RpcMethod rpcmethod_OpenChannel_;
     const ::grpc::internal::RpcMethod rpcmethod_SignerService_;
   };
@@ -93,8 +93,8 @@ class GruutSignerService final {
    public:
     Service();
     virtual ~Service();
-    virtual ::grpc::Status OpenChannel(::grpc::ServerContext* context, ::grpc::ServerReaderWriter< ::grpc_signer::ReplyMsg, ::grpc_signer::Identity>* stream);
-    virtual ::grpc::Status SignerService(::grpc::ServerContext* context, const ::grpc_signer::RequestMsg* request, ::grpc_signer::MsgStatus* response);
+    virtual ::grpc::Status OpenChannel(::grpc::ServerContext* context, ::grpc::ServerReaderWriter< ::grpc_signer::Request, ::grpc_signer::Identity>* stream);
+    virtual ::grpc::Status SignerService(::grpc::ServerContext* context, const ::grpc_signer::Request* request, ::grpc_signer::Reply* response);
   };
   template <class BaseClass>
   class WithAsyncMethod_OpenChannel : public BaseClass {
@@ -108,11 +108,11 @@ class GruutSignerService final {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status OpenChannel(::grpc::ServerContext* context, ::grpc::ServerReaderWriter< ::grpc_signer::ReplyMsg, ::grpc_signer::Identity>* stream)  override {
+    ::grpc::Status OpenChannel(::grpc::ServerContext* context, ::grpc::ServerReaderWriter< ::grpc_signer::Request, ::grpc_signer::Identity>* stream)  override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    void RequestOpenChannel(::grpc::ServerContext* context, ::grpc::ServerAsyncReaderWriter< ::grpc_signer::ReplyMsg, ::grpc_signer::Identity>* stream, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+    void RequestOpenChannel(::grpc::ServerContext* context, ::grpc::ServerAsyncReaderWriter< ::grpc_signer::Request, ::grpc_signer::Identity>* stream, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
       ::grpc::Service::RequestAsyncBidiStreaming(0, context, stream, new_call_cq, notification_cq, tag);
     }
   };
@@ -128,11 +128,11 @@ class GruutSignerService final {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status SignerService(::grpc::ServerContext* context, const ::grpc_signer::RequestMsg* request, ::grpc_signer::MsgStatus* response) override {
+    ::grpc::Status SignerService(::grpc::ServerContext* context, const ::grpc_signer::Request* request, ::grpc_signer::Reply* response) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    void RequestSignerService(::grpc::ServerContext* context, ::grpc_signer::RequestMsg* request, ::grpc::ServerAsyncResponseWriter< ::grpc_signer::MsgStatus>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+    void RequestSignerService(::grpc::ServerContext* context, ::grpc_signer::Request* request, ::grpc::ServerAsyncResponseWriter< ::grpc_signer::Reply>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
       ::grpc::Service::RequestAsyncUnary(1, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
@@ -149,7 +149,7 @@ class GruutSignerService final {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status OpenChannel(::grpc::ServerContext* context, ::grpc::ServerReaderWriter< ::grpc_signer::ReplyMsg, ::grpc_signer::Identity>* stream)  override {
+    ::grpc::Status OpenChannel(::grpc::ServerContext* context, ::grpc::ServerReaderWriter< ::grpc_signer::Request, ::grpc_signer::Identity>* stream)  override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
@@ -166,7 +166,7 @@ class GruutSignerService final {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status SignerService(::grpc::ServerContext* context, const ::grpc_signer::RequestMsg* request, ::grpc_signer::MsgStatus* response) override {
+    ::grpc::Status SignerService(::grpc::ServerContext* context, const ::grpc_signer::Request* request, ::grpc_signer::Reply* response) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
@@ -183,7 +183,7 @@ class GruutSignerService final {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status OpenChannel(::grpc::ServerContext* context, ::grpc::ServerReaderWriter< ::grpc_signer::ReplyMsg, ::grpc_signer::Identity>* stream)  override {
+    ::grpc::Status OpenChannel(::grpc::ServerContext* context, ::grpc::ServerReaderWriter< ::grpc_signer::Request, ::grpc_signer::Identity>* stream)  override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
@@ -203,7 +203,7 @@ class GruutSignerService final {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status SignerService(::grpc::ServerContext* context, const ::grpc_signer::RequestMsg* request, ::grpc_signer::MsgStatus* response) override {
+    ::grpc::Status SignerService(::grpc::ServerContext* context, const ::grpc_signer::Request* request, ::grpc_signer::Reply* response) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
@@ -218,18 +218,18 @@ class GruutSignerService final {
    public:
     WithStreamedUnaryMethod_SignerService() {
       ::grpc::Service::MarkMethodStreamed(1,
-        new ::grpc::internal::StreamedUnaryHandler< ::grpc_signer::RequestMsg, ::grpc_signer::MsgStatus>(std::bind(&WithStreamedUnaryMethod_SignerService<BaseClass>::StreamedSignerService, this, std::placeholders::_1, std::placeholders::_2)));
+        new ::grpc::internal::StreamedUnaryHandler< ::grpc_signer::Request, ::grpc_signer::Reply>(std::bind(&WithStreamedUnaryMethod_SignerService<BaseClass>::StreamedSignerService, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_SignerService() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable regular version of this method
-    ::grpc::Status SignerService(::grpc::ServerContext* context, const ::grpc_signer::RequestMsg* request, ::grpc_signer::MsgStatus* response) override {
+    ::grpc::Status SignerService(::grpc::ServerContext* context, const ::grpc_signer::Request* request, ::grpc_signer::Reply* response) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     // replace default version of method with streamed unary
-    virtual ::grpc::Status StreamedSignerService(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::grpc_signer::RequestMsg,::grpc_signer::MsgStatus>* server_unary_streamer) = 0;
+    virtual ::grpc::Status StreamedSignerService(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::grpc_signer::Request,::grpc_signer::Reply>* server_unary_streamer) = 0;
   };
   typedef WithStreamedUnaryMethod_SignerService<Service > StreamedUnaryService;
   typedef Service SplitStreamedService;

--- a/src/plugins/net_plugin/rpc_services/protos/include/signer_service.pb.h
+++ b/src/plugins/net_plugin/rpc_services/protos/include/signer_service.pb.h
@@ -39,7 +39,7 @@ namespace protobuf_signer_5fservice_2eproto {
 struct TableStruct {
   static const ::google::protobuf::internal::ParseTableField entries[];
   static const ::google::protobuf::internal::AuxillaryParseTableField aux[];
-  static const ::google::protobuf::internal::ParseTable schema[4];
+  static const ::google::protobuf::internal::ParseTable schema[3];
   static const ::google::protobuf::internal::FieldMetadata field_metadata[];
   static const ::google::protobuf::internal::SerializationTable serialization_table[];
   static const ::google::protobuf::uint32 offsets[];
@@ -50,48 +50,49 @@ namespace grpc_signer {
 class Identity;
 class IdentityDefaultTypeInternal;
 extern IdentityDefaultTypeInternal _Identity_default_instance_;
-class MsgStatus;
-class MsgStatusDefaultTypeInternal;
-extern MsgStatusDefaultTypeInternal _MsgStatus_default_instance_;
-class ReplyMsg;
-class ReplyMsgDefaultTypeInternal;
-extern ReplyMsgDefaultTypeInternal _ReplyMsg_default_instance_;
-class RequestMsg;
-class RequestMsgDefaultTypeInternal;
-extern RequestMsgDefaultTypeInternal _RequestMsg_default_instance_;
+class Reply;
+class ReplyDefaultTypeInternal;
+extern ReplyDefaultTypeInternal _Reply_default_instance_;
+class Request;
+class RequestDefaultTypeInternal;
+extern RequestDefaultTypeInternal _Request_default_instance_;
 }  // namespace grpc_signer
 namespace google {
 namespace protobuf {
 template<> ::grpc_signer::Identity* Arena::CreateMaybeMessage<::grpc_signer::Identity>(Arena*);
-template<> ::grpc_signer::MsgStatus* Arena::CreateMaybeMessage<::grpc_signer::MsgStatus>(Arena*);
-template<> ::grpc_signer::ReplyMsg* Arena::CreateMaybeMessage<::grpc_signer::ReplyMsg>(Arena*);
-template<> ::grpc_signer::RequestMsg* Arena::CreateMaybeMessage<::grpc_signer::RequestMsg>(Arena*);
+template<> ::grpc_signer::Reply* Arena::CreateMaybeMessage<::grpc_signer::Reply>(Arena*);
+template<> ::grpc_signer::Request* Arena::CreateMaybeMessage<::grpc_signer::Request>(Arena*);
 }  // namespace protobuf
 }  // namespace google
 namespace grpc_signer {
 
-enum MsgStatus_Status {
-  MsgStatus_Status_SUCCESS = 0,
-  MsgStatus_Status_INVALID = 1,
-  MsgStatus_Status_INTERNAL = 2,
-  MsgStatus_Status_DUPLICATED = 3,
-  MsgStatus_Status_MsgStatus_Status_INT_MIN_SENTINEL_DO_NOT_USE_ = ::google::protobuf::kint32min,
-  MsgStatus_Status_MsgStatus_Status_INT_MAX_SENTINEL_DO_NOT_USE_ = ::google::protobuf::kint32max
+enum Reply_Status {
+  Reply_Status_UNKOWN = 0,
+  Reply_Status_SUCCESS = 1,
+  Reply_Status_HEADER_INVALID = 2,
+  Reply_Status_INTERNAL = 3,
+  Reply_Status_ECDH_ILLEGAL_ACCESS = 21,
+  Reply_Status_ECDH_MAX_SIGNER_POOL = 22,
+  Reply_Status_ECDH_TIMEOUT = 23,
+  Reply_Status_ECDH_INVALID_SIG = 24,
+  Reply_Status_ECDH_INVALID_PK = 25,
+  Reply_Status_Reply_Status_INT_MIN_SENTINEL_DO_NOT_USE_ = ::google::protobuf::kint32min,
+  Reply_Status_Reply_Status_INT_MAX_SENTINEL_DO_NOT_USE_ = ::google::protobuf::kint32max
 };
-bool MsgStatus_Status_IsValid(int value);
-const MsgStatus_Status MsgStatus_Status_Status_MIN = MsgStatus_Status_SUCCESS;
-const MsgStatus_Status MsgStatus_Status_Status_MAX = MsgStatus_Status_DUPLICATED;
-const int MsgStatus_Status_Status_ARRAYSIZE = MsgStatus_Status_Status_MAX + 1;
+bool Reply_Status_IsValid(int value);
+const Reply_Status Reply_Status_Status_MIN = Reply_Status_UNKOWN;
+const Reply_Status Reply_Status_Status_MAX = Reply_Status_ECDH_INVALID_PK;
+const int Reply_Status_Status_ARRAYSIZE = Reply_Status_Status_MAX + 1;
 
-const ::google::protobuf::EnumDescriptor* MsgStatus_Status_descriptor();
-inline const ::std::string& MsgStatus_Status_Name(MsgStatus_Status value) {
+const ::google::protobuf::EnumDescriptor* Reply_Status_descriptor();
+inline const ::std::string& Reply_Status_Name(Reply_Status value) {
   return ::google::protobuf::internal::NameOfEnum(
-    MsgStatus_Status_descriptor(), value);
+    Reply_Status_descriptor(), value);
 }
-inline bool MsgStatus_Status_Parse(
-    const ::std::string& name, MsgStatus_Status* value) {
-  return ::google::protobuf::internal::ParseNamedEnum<MsgStatus_Status>(
-    MsgStatus_Status_descriptor(), name, value);
+inline bool Reply_Status_Parse(
+    const ::std::string& name, Reply_Status* value) {
+  return ::google::protobuf::internal::ParseNamedEnum<Reply_Status>(
+    Reply_Status_descriptor(), name, value);
 }
 // ===================================================================
 
@@ -206,24 +207,24 @@ class Identity : public ::google::protobuf::Message /* @@protoc_insertion_point(
 };
 // -------------------------------------------------------------------
 
-class ReplyMsg : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:grpc_signer.ReplyMsg) */ {
+class Request : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:grpc_signer.Request) */ {
  public:
-  ReplyMsg();
-  virtual ~ReplyMsg();
+  Request();
+  virtual ~Request();
 
-  ReplyMsg(const ReplyMsg& from);
+  Request(const Request& from);
 
-  inline ReplyMsg& operator=(const ReplyMsg& from) {
+  inline Request& operator=(const Request& from) {
     CopyFrom(from);
     return *this;
   }
   #if LANG_CXX11
-  ReplyMsg(ReplyMsg&& from) noexcept
-    : ReplyMsg() {
+  Request(Request&& from) noexcept
+    : Request() {
     *this = ::std::move(from);
   }
 
-  inline ReplyMsg& operator=(ReplyMsg&& from) noexcept {
+  inline Request& operator=(Request&& from) noexcept {
     if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
       if (this != &from) InternalSwap(&from);
     } else {
@@ -233,34 +234,34 @@ class ReplyMsg : public ::google::protobuf::Message /* @@protoc_insertion_point(
   }
   #endif
   static const ::google::protobuf::Descriptor* descriptor();
-  static const ReplyMsg& default_instance();
+  static const Request& default_instance();
 
   static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
-  static inline const ReplyMsg* internal_default_instance() {
-    return reinterpret_cast<const ReplyMsg*>(
-               &_ReplyMsg_default_instance_);
+  static inline const Request* internal_default_instance() {
+    return reinterpret_cast<const Request*>(
+               &_Request_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
     1;
 
-  void Swap(ReplyMsg* other);
-  friend void swap(ReplyMsg& a, ReplyMsg& b) {
+  void Swap(Request* other);
+  friend void swap(Request& a, Request& b) {
     a.Swap(&b);
   }
 
   // implements Message ----------------------------------------------
 
-  inline ReplyMsg* New() const final {
-    return CreateMaybeMessage<ReplyMsg>(NULL);
+  inline Request* New() const final {
+    return CreateMaybeMessage<Request>(NULL);
   }
 
-  ReplyMsg* New(::google::protobuf::Arena* arena) const final {
-    return CreateMaybeMessage<ReplyMsg>(arena);
+  Request* New(::google::protobuf::Arena* arena) const final {
+    return CreateMaybeMessage<Request>(arena);
   }
   void CopyFrom(const ::google::protobuf::Message& from) final;
   void MergeFrom(const ::google::protobuf::Message& from) final;
-  void CopyFrom(const ReplyMsg& from);
-  void MergeFrom(const ReplyMsg& from);
+  void CopyFrom(const Request& from);
+  void MergeFrom(const Request& from);
   void Clear() final;
   bool IsInitialized() const final;
 
@@ -277,7 +278,7 @@ class ReplyMsg : public ::google::protobuf::Message /* @@protoc_insertion_point(
   void SharedCtor();
   void SharedDtor();
   void SetCachedSize(int size) const final;
-  void InternalSwap(ReplyMsg* other);
+  void InternalSwap(Request* other);
   private:
   inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
     return NULL;
@@ -307,7 +308,7 @@ class ReplyMsg : public ::google::protobuf::Message /* @@protoc_insertion_point(
   ::std::string* release_message();
   void set_allocated_message(::std::string* message);
 
-  // @@protoc_insertion_point(class_scope:grpc_signer.ReplyMsg)
+  // @@protoc_insertion_point(class_scope:grpc_signer.Request)
  private:
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
@@ -317,24 +318,24 @@ class ReplyMsg : public ::google::protobuf::Message /* @@protoc_insertion_point(
 };
 // -------------------------------------------------------------------
 
-class RequestMsg : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:grpc_signer.RequestMsg) */ {
+class Reply : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:grpc_signer.Reply) */ {
  public:
-  RequestMsg();
-  virtual ~RequestMsg();
+  Reply();
+  virtual ~Reply();
 
-  RequestMsg(const RequestMsg& from);
+  Reply(const Reply& from);
 
-  inline RequestMsg& operator=(const RequestMsg& from) {
+  inline Reply& operator=(const Reply& from) {
     CopyFrom(from);
     return *this;
   }
   #if LANG_CXX11
-  RequestMsg(RequestMsg&& from) noexcept
-    : RequestMsg() {
+  Reply(Reply&& from) noexcept
+    : Reply() {
     *this = ::std::move(from);
   }
 
-  inline RequestMsg& operator=(RequestMsg&& from) noexcept {
+  inline Reply& operator=(Reply&& from) noexcept {
     if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
       if (this != &from) InternalSwap(&from);
     } else {
@@ -344,34 +345,34 @@ class RequestMsg : public ::google::protobuf::Message /* @@protoc_insertion_poin
   }
   #endif
   static const ::google::protobuf::Descriptor* descriptor();
-  static const RequestMsg& default_instance();
+  static const Reply& default_instance();
 
   static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
-  static inline const RequestMsg* internal_default_instance() {
-    return reinterpret_cast<const RequestMsg*>(
-               &_RequestMsg_default_instance_);
+  static inline const Reply* internal_default_instance() {
+    return reinterpret_cast<const Reply*>(
+               &_Reply_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
     2;
 
-  void Swap(RequestMsg* other);
-  friend void swap(RequestMsg& a, RequestMsg& b) {
+  void Swap(Reply* other);
+  friend void swap(Reply& a, Reply& b) {
     a.Swap(&b);
   }
 
   // implements Message ----------------------------------------------
 
-  inline RequestMsg* New() const final {
-    return CreateMaybeMessage<RequestMsg>(NULL);
+  inline Reply* New() const final {
+    return CreateMaybeMessage<Reply>(NULL);
   }
 
-  RequestMsg* New(::google::protobuf::Arena* arena) const final {
-    return CreateMaybeMessage<RequestMsg>(arena);
+  Reply* New(::google::protobuf::Arena* arena) const final {
+    return CreateMaybeMessage<Reply>(arena);
   }
   void CopyFrom(const ::google::protobuf::Message& from) final;
   void MergeFrom(const ::google::protobuf::Message& from) final;
-  void CopyFrom(const RequestMsg& from);
-  void MergeFrom(const RequestMsg& from);
+  void CopyFrom(const Reply& from);
+  void MergeFrom(const Reply& from);
   void Clear() final;
   bool IsInitialized() const final;
 
@@ -388,7 +389,7 @@ class RequestMsg : public ::google::protobuf::Message /* @@protoc_insertion_poin
   void SharedCtor();
   void SharedDtor();
   void SetCachedSize(int size) const final;
-  void InternalSwap(RequestMsg* other);
+  void InternalSwap(Reply* other);
   private:
   inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
     return NULL;
@@ -402,150 +403,49 @@ class RequestMsg : public ::google::protobuf::Message /* @@protoc_insertion_poin
 
   // nested types ----------------------------------------------------
 
-  // accessors -------------------------------------------------------
-
-  // bytes message = 1;
-  void clear_message();
-  static const int kMessageFieldNumber = 1;
-  const ::std::string& message() const;
-  void set_message(const ::std::string& value);
-  #if LANG_CXX11
-  void set_message(::std::string&& value);
-  #endif
-  void set_message(const char* value);
-  void set_message(const void* value, size_t size);
-  ::std::string* mutable_message();
-  ::std::string* release_message();
-  void set_allocated_message(::std::string* message);
-
-  // @@protoc_insertion_point(class_scope:grpc_signer.RequestMsg)
- private:
-
-  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
-  ::google::protobuf::internal::ArenaStringPtr message_;
-  mutable ::google::protobuf::internal::CachedSize _cached_size_;
-  friend struct ::protobuf_signer_5fservice_2eproto::TableStruct;
-};
-// -------------------------------------------------------------------
-
-class MsgStatus : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:grpc_signer.MsgStatus) */ {
- public:
-  MsgStatus();
-  virtual ~MsgStatus();
-
-  MsgStatus(const MsgStatus& from);
-
-  inline MsgStatus& operator=(const MsgStatus& from) {
-    CopyFrom(from);
-    return *this;
-  }
-  #if LANG_CXX11
-  MsgStatus(MsgStatus&& from) noexcept
-    : MsgStatus() {
-    *this = ::std::move(from);
-  }
-
-  inline MsgStatus& operator=(MsgStatus&& from) noexcept {
-    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
-      if (this != &from) InternalSwap(&from);
-    } else {
-      CopyFrom(from);
-    }
-    return *this;
-  }
-  #endif
-  static const ::google::protobuf::Descriptor* descriptor();
-  static const MsgStatus& default_instance();
-
-  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
-  static inline const MsgStatus* internal_default_instance() {
-    return reinterpret_cast<const MsgStatus*>(
-               &_MsgStatus_default_instance_);
-  }
-  static constexpr int kIndexInFileMessages =
-    3;
-
-  void Swap(MsgStatus* other);
-  friend void swap(MsgStatus& a, MsgStatus& b) {
-    a.Swap(&b);
-  }
-
-  // implements Message ----------------------------------------------
-
-  inline MsgStatus* New() const final {
-    return CreateMaybeMessage<MsgStatus>(NULL);
-  }
-
-  MsgStatus* New(::google::protobuf::Arena* arena) const final {
-    return CreateMaybeMessage<MsgStatus>(arena);
-  }
-  void CopyFrom(const ::google::protobuf::Message& from) final;
-  void MergeFrom(const ::google::protobuf::Message& from) final;
-  void CopyFrom(const MsgStatus& from);
-  void MergeFrom(const MsgStatus& from);
-  void Clear() final;
-  bool IsInitialized() const final;
-
-  size_t ByteSizeLong() const final;
-  bool MergePartialFromCodedStream(
-      ::google::protobuf::io::CodedInputStream* input) final;
-  void SerializeWithCachedSizes(
-      ::google::protobuf::io::CodedOutputStream* output) const final;
-  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
-      bool deterministic, ::google::protobuf::uint8* target) const final;
-  int GetCachedSize() const final { return _cached_size_.Get(); }
-
-  private:
-  void SharedCtor();
-  void SharedDtor();
-  void SetCachedSize(int size) const final;
-  void InternalSwap(MsgStatus* other);
-  private:
-  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
-    return NULL;
-  }
-  inline void* MaybeArenaPtr() const {
-    return NULL;
-  }
-  public:
-
-  ::google::protobuf::Metadata GetMetadata() const final;
-
-  // nested types ----------------------------------------------------
-
-  typedef MsgStatus_Status Status;
+  typedef Reply_Status Status;
+  static const Status UNKOWN =
+    Reply_Status_UNKOWN;
   static const Status SUCCESS =
-    MsgStatus_Status_SUCCESS;
-  static const Status INVALID =
-    MsgStatus_Status_INVALID;
+    Reply_Status_SUCCESS;
+  static const Status HEADER_INVALID =
+    Reply_Status_HEADER_INVALID;
   static const Status INTERNAL =
-    MsgStatus_Status_INTERNAL;
-  static const Status DUPLICATED =
-    MsgStatus_Status_DUPLICATED;
+    Reply_Status_INTERNAL;
+  static const Status ECDH_ILLEGAL_ACCESS =
+    Reply_Status_ECDH_ILLEGAL_ACCESS;
+  static const Status ECDH_MAX_SIGNER_POOL =
+    Reply_Status_ECDH_MAX_SIGNER_POOL;
+  static const Status ECDH_TIMEOUT =
+    Reply_Status_ECDH_TIMEOUT;
+  static const Status ECDH_INVALID_SIG =
+    Reply_Status_ECDH_INVALID_SIG;
+  static const Status ECDH_INVALID_PK =
+    Reply_Status_ECDH_INVALID_PK;
   static inline bool Status_IsValid(int value) {
-    return MsgStatus_Status_IsValid(value);
+    return Reply_Status_IsValid(value);
   }
   static const Status Status_MIN =
-    MsgStatus_Status_Status_MIN;
+    Reply_Status_Status_MIN;
   static const Status Status_MAX =
-    MsgStatus_Status_Status_MAX;
+    Reply_Status_Status_MAX;
   static const int Status_ARRAYSIZE =
-    MsgStatus_Status_Status_ARRAYSIZE;
+    Reply_Status_Status_ARRAYSIZE;
   static inline const ::google::protobuf::EnumDescriptor*
   Status_descriptor() {
-    return MsgStatus_Status_descriptor();
+    return Reply_Status_descriptor();
   }
   static inline const ::std::string& Status_Name(Status value) {
-    return MsgStatus_Status_Name(value);
+    return Reply_Status_Name(value);
   }
   static inline bool Status_Parse(const ::std::string& name,
       Status* value) {
-    return MsgStatus_Status_Parse(name, value);
+    return Reply_Status_Parse(name, value);
   }
 
   // accessors -------------------------------------------------------
 
-  // string message = 2;
+  // bytes message = 2;
   void clear_message();
   static const int kMessageFieldNumber = 2;
   const ::std::string& message() const;
@@ -554,18 +454,18 @@ class MsgStatus : public ::google::protobuf::Message /* @@protoc_insertion_point
   void set_message(::std::string&& value);
   #endif
   void set_message(const char* value);
-  void set_message(const char* value, size_t size);
+  void set_message(const void* value, size_t size);
   ::std::string* mutable_message();
   ::std::string* release_message();
   void set_allocated_message(::std::string* message);
 
-  // .grpc_signer.MsgStatus.Status status = 1;
+  // .grpc_signer.Reply.Status status = 1;
   void clear_status();
   static const int kStatusFieldNumber = 1;
-  ::grpc_signer::MsgStatus_Status status() const;
-  void set_status(::grpc_signer::MsgStatus_Status value);
+  ::grpc_signer::Reply_Status status() const;
+  void set_status(::grpc_signer::Reply_Status value);
 
-  // @@protoc_insertion_point(class_scope:grpc_signer.MsgStatus)
+  // @@protoc_insertion_point(class_scope:grpc_signer.Reply)
  private:
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
@@ -640,194 +540,135 @@ inline void Identity::set_allocated_sender(::std::string* sender) {
 
 // -------------------------------------------------------------------
 
-// ReplyMsg
+// Request
 
 // bytes message = 1;
-inline void ReplyMsg::clear_message() {
+inline void Request::clear_message() {
   message_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
-inline const ::std::string& ReplyMsg::message() const {
-  // @@protoc_insertion_point(field_get:grpc_signer.ReplyMsg.message)
+inline const ::std::string& Request::message() const {
+  // @@protoc_insertion_point(field_get:grpc_signer.Request.message)
   return message_.GetNoArena();
 }
-inline void ReplyMsg::set_message(const ::std::string& value) {
+inline void Request::set_message(const ::std::string& value) {
   
   message_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
-  // @@protoc_insertion_point(field_set:grpc_signer.ReplyMsg.message)
+  // @@protoc_insertion_point(field_set:grpc_signer.Request.message)
 }
 #if LANG_CXX11
-inline void ReplyMsg::set_message(::std::string&& value) {
+inline void Request::set_message(::std::string&& value) {
   
   message_.SetNoArena(
     &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
-  // @@protoc_insertion_point(field_set_rvalue:grpc_signer.ReplyMsg.message)
+  // @@protoc_insertion_point(field_set_rvalue:grpc_signer.Request.message)
 }
 #endif
-inline void ReplyMsg::set_message(const char* value) {
+inline void Request::set_message(const char* value) {
   GOOGLE_DCHECK(value != NULL);
   
   message_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
-  // @@protoc_insertion_point(field_set_char:grpc_signer.ReplyMsg.message)
+  // @@protoc_insertion_point(field_set_char:grpc_signer.Request.message)
 }
-inline void ReplyMsg::set_message(const void* value, size_t size) {
+inline void Request::set_message(const void* value, size_t size) {
   
   message_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       ::std::string(reinterpret_cast<const char*>(value), size));
-  // @@protoc_insertion_point(field_set_pointer:grpc_signer.ReplyMsg.message)
+  // @@protoc_insertion_point(field_set_pointer:grpc_signer.Request.message)
 }
-inline ::std::string* ReplyMsg::mutable_message() {
+inline ::std::string* Request::mutable_message() {
   
-  // @@protoc_insertion_point(field_mutable:grpc_signer.ReplyMsg.message)
+  // @@protoc_insertion_point(field_mutable:grpc_signer.Request.message)
   return message_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
-inline ::std::string* ReplyMsg::release_message() {
-  // @@protoc_insertion_point(field_release:grpc_signer.ReplyMsg.message)
+inline ::std::string* Request::release_message() {
+  // @@protoc_insertion_point(field_release:grpc_signer.Request.message)
   
   return message_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
-inline void ReplyMsg::set_allocated_message(::std::string* message) {
+inline void Request::set_allocated_message(::std::string* message) {
   if (message != NULL) {
     
   } else {
     
   }
   message_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), message);
-  // @@protoc_insertion_point(field_set_allocated:grpc_signer.ReplyMsg.message)
+  // @@protoc_insertion_point(field_set_allocated:grpc_signer.Request.message)
 }
 
 // -------------------------------------------------------------------
 
-// RequestMsg
+// Reply
 
-// bytes message = 1;
-inline void RequestMsg::clear_message() {
-  message_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-inline const ::std::string& RequestMsg::message() const {
-  // @@protoc_insertion_point(field_get:grpc_signer.RequestMsg.message)
-  return message_.GetNoArena();
-}
-inline void RequestMsg::set_message(const ::std::string& value) {
-  
-  message_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
-  // @@protoc_insertion_point(field_set:grpc_signer.RequestMsg.message)
-}
-#if LANG_CXX11
-inline void RequestMsg::set_message(::std::string&& value) {
-  
-  message_.SetNoArena(
-    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
-  // @@protoc_insertion_point(field_set_rvalue:grpc_signer.RequestMsg.message)
-}
-#endif
-inline void RequestMsg::set_message(const char* value) {
-  GOOGLE_DCHECK(value != NULL);
-  
-  message_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
-  // @@protoc_insertion_point(field_set_char:grpc_signer.RequestMsg.message)
-}
-inline void RequestMsg::set_message(const void* value, size_t size) {
-  
-  message_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
-      ::std::string(reinterpret_cast<const char*>(value), size));
-  // @@protoc_insertion_point(field_set_pointer:grpc_signer.RequestMsg.message)
-}
-inline ::std::string* RequestMsg::mutable_message() {
-  
-  // @@protoc_insertion_point(field_mutable:grpc_signer.RequestMsg.message)
-  return message_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-inline ::std::string* RequestMsg::release_message() {
-  // @@protoc_insertion_point(field_release:grpc_signer.RequestMsg.message)
-  
-  return message_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-inline void RequestMsg::set_allocated_message(::std::string* message) {
-  if (message != NULL) {
-    
-  } else {
-    
-  }
-  message_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), message);
-  // @@protoc_insertion_point(field_set_allocated:grpc_signer.RequestMsg.message)
-}
-
-// -------------------------------------------------------------------
-
-// MsgStatus
-
-// .grpc_signer.MsgStatus.Status status = 1;
-inline void MsgStatus::clear_status() {
+// .grpc_signer.Reply.Status status = 1;
+inline void Reply::clear_status() {
   status_ = 0;
 }
-inline ::grpc_signer::MsgStatus_Status MsgStatus::status() const {
-  // @@protoc_insertion_point(field_get:grpc_signer.MsgStatus.status)
-  return static_cast< ::grpc_signer::MsgStatus_Status >(status_);
+inline ::grpc_signer::Reply_Status Reply::status() const {
+  // @@protoc_insertion_point(field_get:grpc_signer.Reply.status)
+  return static_cast< ::grpc_signer::Reply_Status >(status_);
 }
-inline void MsgStatus::set_status(::grpc_signer::MsgStatus_Status value) {
+inline void Reply::set_status(::grpc_signer::Reply_Status value) {
   
   status_ = value;
-  // @@protoc_insertion_point(field_set:grpc_signer.MsgStatus.status)
+  // @@protoc_insertion_point(field_set:grpc_signer.Reply.status)
 }
 
-// string message = 2;
-inline void MsgStatus::clear_message() {
+// bytes message = 2;
+inline void Reply::clear_message() {
   message_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
-inline const ::std::string& MsgStatus::message() const {
-  // @@protoc_insertion_point(field_get:grpc_signer.MsgStatus.message)
+inline const ::std::string& Reply::message() const {
+  // @@protoc_insertion_point(field_get:grpc_signer.Reply.message)
   return message_.GetNoArena();
 }
-inline void MsgStatus::set_message(const ::std::string& value) {
+inline void Reply::set_message(const ::std::string& value) {
   
   message_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
-  // @@protoc_insertion_point(field_set:grpc_signer.MsgStatus.message)
+  // @@protoc_insertion_point(field_set:grpc_signer.Reply.message)
 }
 #if LANG_CXX11
-inline void MsgStatus::set_message(::std::string&& value) {
+inline void Reply::set_message(::std::string&& value) {
   
   message_.SetNoArena(
     &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
-  // @@protoc_insertion_point(field_set_rvalue:grpc_signer.MsgStatus.message)
+  // @@protoc_insertion_point(field_set_rvalue:grpc_signer.Reply.message)
 }
 #endif
-inline void MsgStatus::set_message(const char* value) {
+inline void Reply::set_message(const char* value) {
   GOOGLE_DCHECK(value != NULL);
   
   message_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
-  // @@protoc_insertion_point(field_set_char:grpc_signer.MsgStatus.message)
+  // @@protoc_insertion_point(field_set_char:grpc_signer.Reply.message)
 }
-inline void MsgStatus::set_message(const char* value, size_t size) {
+inline void Reply::set_message(const void* value, size_t size) {
   
   message_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       ::std::string(reinterpret_cast<const char*>(value), size));
-  // @@protoc_insertion_point(field_set_pointer:grpc_signer.MsgStatus.message)
+  // @@protoc_insertion_point(field_set_pointer:grpc_signer.Reply.message)
 }
-inline ::std::string* MsgStatus::mutable_message() {
+inline ::std::string* Reply::mutable_message() {
   
-  // @@protoc_insertion_point(field_mutable:grpc_signer.MsgStatus.message)
+  // @@protoc_insertion_point(field_mutable:grpc_signer.Reply.message)
   return message_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
-inline ::std::string* MsgStatus::release_message() {
-  // @@protoc_insertion_point(field_release:grpc_signer.MsgStatus.message)
+inline ::std::string* Reply::release_message() {
+  // @@protoc_insertion_point(field_release:grpc_signer.Reply.message)
   
   return message_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
-inline void MsgStatus::set_allocated_message(::std::string* message) {
+inline void Reply::set_allocated_message(::std::string* message) {
   if (message != NULL) {
     
   } else {
     
   }
   message_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), message);
-  // @@protoc_insertion_point(field_set_allocated:grpc_signer.MsgStatus.message)
+  // @@protoc_insertion_point(field_set_allocated:grpc_signer.Reply.message)
 }
 
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
-// -------------------------------------------------------------------
-
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------
@@ -840,10 +681,10 @@ inline void MsgStatus::set_allocated_message(::std::string* message) {
 namespace google {
 namespace protobuf {
 
-template <> struct is_proto_enum< ::grpc_signer::MsgStatus_Status> : ::std::true_type {};
+template <> struct is_proto_enum< ::grpc_signer::Reply_Status> : ::std::true_type {};
 template <>
-inline const EnumDescriptor* GetEnumDescriptor< ::grpc_signer::MsgStatus_Status>() {
-  return ::grpc_signer::MsgStatus_Status_descriptor();
+inline const EnumDescriptor* GetEnumDescriptor< ::grpc_signer::Reply_Status>() {
+  return ::grpc_signer::Reply_Status_descriptor();
 }
 
 }  // namespace protobuf

--- a/src/plugins/net_plugin/rpc_services/protos/signer_service.grpc.pb.cc
+++ b/src/plugins/net_plugin/rpc_services/protos/signer_service.grpc.pb.cc
@@ -31,53 +31,53 @@ GruutSignerService::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>&
   , rpcmethod_SignerService_(GruutSignerService_method_names[1], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   {}
 
-::grpc::ClientReaderWriter< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>* GruutSignerService::Stub::OpenChannelRaw(::grpc::ClientContext* context) {
-  return ::grpc::internal::ClientReaderWriterFactory< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>::Create(channel_.get(), rpcmethod_OpenChannel_, context);
+::grpc::ClientReaderWriter< ::grpc_signer::Identity, ::grpc_signer::Request>* GruutSignerService::Stub::OpenChannelRaw(::grpc::ClientContext* context) {
+  return ::grpc::internal::ClientReaderWriterFactory< ::grpc_signer::Identity, ::grpc_signer::Request>::Create(channel_.get(), rpcmethod_OpenChannel_, context);
 }
 
-::grpc::ClientAsyncReaderWriter< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>* GruutSignerService::Stub::AsyncOpenChannelRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq, void* tag) {
-  return ::grpc::internal::ClientAsyncReaderWriterFactory< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>::Create(channel_.get(), cq, rpcmethod_OpenChannel_, context, true, tag);
+::grpc::ClientAsyncReaderWriter< ::grpc_signer::Identity, ::grpc_signer::Request>* GruutSignerService::Stub::AsyncOpenChannelRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq, void* tag) {
+  return ::grpc::internal::ClientAsyncReaderWriterFactory< ::grpc_signer::Identity, ::grpc_signer::Request>::Create(channel_.get(), cq, rpcmethod_OpenChannel_, context, true, tag);
 }
 
-::grpc::ClientAsyncReaderWriter< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>* GruutSignerService::Stub::PrepareAsyncOpenChannelRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq) {
-  return ::grpc::internal::ClientAsyncReaderWriterFactory< ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>::Create(channel_.get(), cq, rpcmethod_OpenChannel_, context, false, nullptr);
+::grpc::ClientAsyncReaderWriter< ::grpc_signer::Identity, ::grpc_signer::Request>* GruutSignerService::Stub::PrepareAsyncOpenChannelRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncReaderWriterFactory< ::grpc_signer::Identity, ::grpc_signer::Request>::Create(channel_.get(), cq, rpcmethod_OpenChannel_, context, false, nullptr);
 }
 
-::grpc::Status GruutSignerService::Stub::SignerService(::grpc::ClientContext* context, const ::grpc_signer::RequestMsg& request, ::grpc_signer::MsgStatus* response) {
+::grpc::Status GruutSignerService::Stub::SignerService(::grpc::ClientContext* context, const ::grpc_signer::Request& request, ::grpc_signer::Reply* response) {
   return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_SignerService_, context, request, response);
 }
 
-::grpc::ClientAsyncResponseReader< ::grpc_signer::MsgStatus>* GruutSignerService::Stub::AsyncSignerServiceRaw(::grpc::ClientContext* context, const ::grpc_signer::RequestMsg& request, ::grpc::CompletionQueue* cq) {
-  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::grpc_signer::MsgStatus>::Create(channel_.get(), cq, rpcmethod_SignerService_, context, request, true);
+::grpc::ClientAsyncResponseReader< ::grpc_signer::Reply>* GruutSignerService::Stub::AsyncSignerServiceRaw(::grpc::ClientContext* context, const ::grpc_signer::Request& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::grpc_signer::Reply>::Create(channel_.get(), cq, rpcmethod_SignerService_, context, request, true);
 }
 
-::grpc::ClientAsyncResponseReader< ::grpc_signer::MsgStatus>* GruutSignerService::Stub::PrepareAsyncSignerServiceRaw(::grpc::ClientContext* context, const ::grpc_signer::RequestMsg& request, ::grpc::CompletionQueue* cq) {
-  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::grpc_signer::MsgStatus>::Create(channel_.get(), cq, rpcmethod_SignerService_, context, request, false);
+::grpc::ClientAsyncResponseReader< ::grpc_signer::Reply>* GruutSignerService::Stub::PrepareAsyncSignerServiceRaw(::grpc::ClientContext* context, const ::grpc_signer::Request& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::grpc_signer::Reply>::Create(channel_.get(), cq, rpcmethod_SignerService_, context, request, false);
 }
 
 GruutSignerService::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       GruutSignerService_method_names[0],
       ::grpc::internal::RpcMethod::BIDI_STREAMING,
-      new ::grpc::internal::BidiStreamingHandler< GruutSignerService::Service, ::grpc_signer::Identity, ::grpc_signer::ReplyMsg>(
+      new ::grpc::internal::BidiStreamingHandler< GruutSignerService::Service, ::grpc_signer::Identity, ::grpc_signer::Request>(
           std::mem_fn(&GruutSignerService::Service::OpenChannel), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       GruutSignerService_method_names[1],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
-      new ::grpc::internal::RpcMethodHandler< GruutSignerService::Service, ::grpc_signer::RequestMsg, ::grpc_signer::MsgStatus>(
+      new ::grpc::internal::RpcMethodHandler< GruutSignerService::Service, ::grpc_signer::Request, ::grpc_signer::Reply>(
           std::mem_fn(&GruutSignerService::Service::SignerService), this)));
 }
 
 GruutSignerService::Service::~Service() {
 }
 
-::grpc::Status GruutSignerService::Service::OpenChannel(::grpc::ServerContext* context, ::grpc::ServerReaderWriter< ::grpc_signer::ReplyMsg, ::grpc_signer::Identity>* stream) {
+::grpc::Status GruutSignerService::Service::OpenChannel(::grpc::ServerContext* context, ::grpc::ServerReaderWriter< ::grpc_signer::Request, ::grpc_signer::Identity>* stream) {
   (void) context;
   (void) stream;
   return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
 }
 
-::grpc::Status GruutSignerService::Service::SignerService(::grpc::ServerContext* context, const ::grpc_signer::RequestMsg* request, ::grpc_signer::MsgStatus* response) {
+::grpc::Status GruutSignerService::Service::SignerService(::grpc::ServerContext* context, const ::grpc_signer::Request* request, ::grpc_signer::Reply* response) {
   (void) context;
   (void) request;
   (void) response;

--- a/src/plugins/net_plugin/rpc_services/protos/signer_service.pb.cc
+++ b/src/plugins/net_plugin/rpc_services/protos/signer_service.pb.cc
@@ -25,21 +25,16 @@ class IdentityDefaultTypeInternal {
   ::google::protobuf::internal::ExplicitlyConstructed<Identity>
       _instance;
 } _Identity_default_instance_;
-class ReplyMsgDefaultTypeInternal {
+class RequestDefaultTypeInternal {
  public:
-  ::google::protobuf::internal::ExplicitlyConstructed<ReplyMsg>
+  ::google::protobuf::internal::ExplicitlyConstructed<Request>
       _instance;
-} _ReplyMsg_default_instance_;
-class RequestMsgDefaultTypeInternal {
+} _Request_default_instance_;
+class ReplyDefaultTypeInternal {
  public:
-  ::google::protobuf::internal::ExplicitlyConstructed<RequestMsg>
+  ::google::protobuf::internal::ExplicitlyConstructed<Reply>
       _instance;
-} _RequestMsg_default_instance_;
-class MsgStatusDefaultTypeInternal {
- public:
-  ::google::protobuf::internal::ExplicitlyConstructed<MsgStatus>
-      _instance;
-} _MsgStatus_default_instance_;
+} _Reply_default_instance_;
 }  // namespace grpc_signer
 namespace protobuf_signer_5fservice_2eproto {
 static void InitDefaultsIdentity() {
@@ -56,56 +51,41 @@ static void InitDefaultsIdentity() {
 ::google::protobuf::internal::SCCInfo<0> scc_info_Identity =
     {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsIdentity}, {}};
 
-static void InitDefaultsReplyMsg() {
+static void InitDefaultsRequest() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
   {
-    void* ptr = &::grpc_signer::_ReplyMsg_default_instance_;
-    new (ptr) ::grpc_signer::ReplyMsg();
+    void* ptr = &::grpc_signer::_Request_default_instance_;
+    new (ptr) ::grpc_signer::Request();
     ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
   }
-  ::grpc_signer::ReplyMsg::InitAsDefaultInstance();
+  ::grpc_signer::Request::InitAsDefaultInstance();
 }
 
-::google::protobuf::internal::SCCInfo<0> scc_info_ReplyMsg =
-    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsReplyMsg}, {}};
+::google::protobuf::internal::SCCInfo<0> scc_info_Request =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsRequest}, {}};
 
-static void InitDefaultsRequestMsg() {
+static void InitDefaultsReply() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
   {
-    void* ptr = &::grpc_signer::_RequestMsg_default_instance_;
-    new (ptr) ::grpc_signer::RequestMsg();
+    void* ptr = &::grpc_signer::_Reply_default_instance_;
+    new (ptr) ::grpc_signer::Reply();
     ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
   }
-  ::grpc_signer::RequestMsg::InitAsDefaultInstance();
+  ::grpc_signer::Reply::InitAsDefaultInstance();
 }
 
-::google::protobuf::internal::SCCInfo<0> scc_info_RequestMsg =
-    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsRequestMsg}, {}};
-
-static void InitDefaultsMsgStatus() {
-  GOOGLE_PROTOBUF_VERIFY_VERSION;
-
-  {
-    void* ptr = &::grpc_signer::_MsgStatus_default_instance_;
-    new (ptr) ::grpc_signer::MsgStatus();
-    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
-  }
-  ::grpc_signer::MsgStatus::InitAsDefaultInstance();
-}
-
-::google::protobuf::internal::SCCInfo<0> scc_info_MsgStatus =
-    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsMsgStatus}, {}};
+::google::protobuf::internal::SCCInfo<0> scc_info_Reply =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsReply}, {}};
 
 void InitDefaults() {
   ::google::protobuf::internal::InitSCC(&scc_info_Identity.base);
-  ::google::protobuf::internal::InitSCC(&scc_info_ReplyMsg.base);
-  ::google::protobuf::internal::InitSCC(&scc_info_RequestMsg.base);
-  ::google::protobuf::internal::InitSCC(&scc_info_MsgStatus.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_Request.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_Reply.base);
 }
 
-::google::protobuf::Metadata file_level_metadata[4];
+::google::protobuf::Metadata file_level_metadata[3];
 const ::google::protobuf::EnumDescriptor* file_level_enum_descriptors[1];
 
 const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
@@ -116,37 +96,29 @@ const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUT
   ~0u,  // no _weak_field_map_
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_signer::Identity, sender_),
   ~0u,  // no _has_bits_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_signer::ReplyMsg, _internal_metadata_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_signer::Request, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_signer::ReplyMsg, message_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_signer::Request, message_),
   ~0u,  // no _has_bits_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_signer::RequestMsg, _internal_metadata_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_signer::Reply, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_signer::RequestMsg, message_),
-  ~0u,  // no _has_bits_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_signer::MsgStatus, _internal_metadata_),
-  ~0u,  // no _extensions_
-  ~0u,  // no _oneof_case_
-  ~0u,  // no _weak_field_map_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_signer::MsgStatus, status_),
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_signer::MsgStatus, message_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_signer::Reply, status_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_signer::Reply, message_),
 };
 static const ::google::protobuf::internal::MigrationSchema schemas[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
   { 0, -1, sizeof(::grpc_signer::Identity)},
-  { 6, -1, sizeof(::grpc_signer::ReplyMsg)},
-  { 12, -1, sizeof(::grpc_signer::RequestMsg)},
-  { 18, -1, sizeof(::grpc_signer::MsgStatus)},
+  { 6, -1, sizeof(::grpc_signer::Request)},
+  { 12, -1, sizeof(::grpc_signer::Reply)},
 };
 
 static ::google::protobuf::Message const * const file_default_instances[] = {
   reinterpret_cast<const ::google::protobuf::Message*>(&::grpc_signer::_Identity_default_instance_),
-  reinterpret_cast<const ::google::protobuf::Message*>(&::grpc_signer::_ReplyMsg_default_instance_),
-  reinterpret_cast<const ::google::protobuf::Message*>(&::grpc_signer::_RequestMsg_default_instance_),
-  reinterpret_cast<const ::google::protobuf::Message*>(&::grpc_signer::_MsgStatus_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::grpc_signer::_Request_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::grpc_signer::_Reply_default_instance_),
 };
 
 void protobuf_AssignDescriptors() {
@@ -164,28 +136,29 @@ void protobuf_AssignDescriptorsOnce() {
 void protobuf_RegisterTypes(const ::std::string&) GOOGLE_PROTOBUF_ATTRIBUTE_COLD;
 void protobuf_RegisterTypes(const ::std::string&) {
   protobuf_AssignDescriptorsOnce();
-  ::google::protobuf::internal::RegisterAllTypes(file_level_metadata, 4);
+  ::google::protobuf::internal::RegisterAllTypes(file_level_metadata, 3);
 }
 
 void AddDescriptorsImpl() {
   InitDefaults();
   static const char descriptor[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
       "\n\024signer_service.proto\022\013grpc_signer\"\032\n\010I"
-      "dentity\022\016\n\006sender\030\001 \001(\014\"\033\n\010ReplyMsg\022\017\n\007m"
-      "essage\030\001 \001(\014\"\035\n\nRequestMsg\022\017\n\007message\030\001 "
-      "\001(\014\"\215\001\n\tMsgStatus\022-\n\006status\030\001 \001(\0162\035.grpc"
-      "_signer.MsgStatus.Status\022\017\n\007message\030\002 \001("
-      "\t\"@\n\006Status\022\013\n\007SUCCESS\020\000\022\013\n\007INVALID\020\001\022\014\n"
-      "\010INTERNAL\020\002\022\016\n\nDUPLICATED\020\0032\233\001\n\022GruutSig"
-      "nerService\022A\n\013OpenChannel\022\025.grpc_signer."
-      "Identity\032\025.grpc_signer.ReplyMsg\"\000(\0010\001\022B\n"
-      "\rSignerService\022\027.grpc_signer.RequestMsg\032"
-      "\026.grpc_signer.MsgStatus\"\000B0\n\036com.gruutne"
-      "tworks.gruutgeneralB\014GruutNetworkP\001b\006pro"
-      "to3"
+      "dentity\022\016\n\006sender\030\001 \001(\014\"\032\n\007Request\022\017\n\007me"
+      "ssage\030\001 \001(\014\"\371\001\n\005Reply\022)\n\006status\030\001 \001(\0162\031."
+      "grpc_signer.Reply.Status\022\017\n\007message\030\002 \001("
+      "\014\"\263\001\n\006Status\022\n\n\006UNKOWN\020\000\022\013\n\007SUCCESS\020\001\022\022\n"
+      "\016HEADER_INVALID\020\002\022\014\n\010INTERNAL\020\003\022\027\n\023ECDH_"
+      "ILLEGAL_ACCESS\020\025\022\030\n\024ECDH_MAX_SIGNER_POOL"
+      "\020\026\022\020\n\014ECDH_TIMEOUT\020\027\022\024\n\020ECDH_INVALID_SIG"
+      "\020\030\022\023\n\017ECDH_INVALID_PK\020\0312\223\001\n\022GruutSignerS"
+      "ervice\022@\n\013OpenChannel\022\025.grpc_signer.Iden"
+      "tity\032\024.grpc_signer.Request\"\000(\0010\001\022;\n\rSign"
+      "erService\022\024.grpc_signer.Request\032\022.grpc_s"
+      "igner.Reply\"\000B0\n\036com.gruutnetworks.gruut"
+      "generalB\014GruutNetworkP\001b\006proto3"
   };
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
-      descriptor, 483);
+      descriptor, 551);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "signer_service.proto", &protobuf_RegisterTypes);
 }
@@ -202,16 +175,21 @@ struct StaticDescriptorInitializer {
 } static_descriptor_initializer;
 }  // namespace protobuf_signer_5fservice_2eproto
 namespace grpc_signer {
-const ::google::protobuf::EnumDescriptor* MsgStatus_Status_descriptor() {
+const ::google::protobuf::EnumDescriptor* Reply_Status_descriptor() {
   protobuf_signer_5fservice_2eproto::protobuf_AssignDescriptorsOnce();
   return protobuf_signer_5fservice_2eproto::file_level_enum_descriptors[0];
 }
-bool MsgStatus_Status_IsValid(int value) {
+bool Reply_Status_IsValid(int value) {
   switch (value) {
     case 0:
     case 1:
     case 2:
     case 3:
+    case 21:
+    case 22:
+    case 23:
+    case 24:
+    case 25:
       return true;
     default:
       return false;
@@ -219,13 +197,18 @@ bool MsgStatus_Status_IsValid(int value) {
 }
 
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
-const MsgStatus_Status MsgStatus::SUCCESS;
-const MsgStatus_Status MsgStatus::INVALID;
-const MsgStatus_Status MsgStatus::INTERNAL;
-const MsgStatus_Status MsgStatus::DUPLICATED;
-const MsgStatus_Status MsgStatus::Status_MIN;
-const MsgStatus_Status MsgStatus::Status_MAX;
-const int MsgStatus::Status_ARRAYSIZE;
+const Reply_Status Reply::UNKOWN;
+const Reply_Status Reply::SUCCESS;
+const Reply_Status Reply::HEADER_INVALID;
+const Reply_Status Reply::INTERNAL;
+const Reply_Status Reply::ECDH_ILLEGAL_ACCESS;
+const Reply_Status Reply::ECDH_MAX_SIGNER_POOL;
+const Reply_Status Reply::ECDH_TIMEOUT;
+const Reply_Status Reply::ECDH_INVALID_SIG;
+const Reply_Status Reply::ECDH_INVALID_PK;
+const Reply_Status Reply::Status_MIN;
+const Reply_Status Reply::Status_MAX;
+const int Reply::Status_ARRAYSIZE;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 // ===================================================================
@@ -460,20 +443,20 @@ void Identity::InternalSwap(Identity* other) {
 
 // ===================================================================
 
-void ReplyMsg::InitAsDefaultInstance() {
+void Request::InitAsDefaultInstance() {
 }
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
-const int ReplyMsg::kMessageFieldNumber;
+const int Request::kMessageFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
-ReplyMsg::ReplyMsg()
+Request::Request()
   : ::google::protobuf::Message(), _internal_metadata_(NULL) {
   ::google::protobuf::internal::InitSCC(
-      &protobuf_signer_5fservice_2eproto::scc_info_ReplyMsg.base);
+      &protobuf_signer_5fservice_2eproto::scc_info_Request.base);
   SharedCtor();
-  // @@protoc_insertion_point(constructor:grpc_signer.ReplyMsg)
+  // @@protoc_insertion_point(constructor:grpc_signer.Request)
 }
-ReplyMsg::ReplyMsg(const ReplyMsg& from)
+Request::Request(const Request& from)
   : ::google::protobuf::Message(),
       _internal_metadata_(NULL) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
@@ -481,38 +464,38 @@ ReplyMsg::ReplyMsg(const ReplyMsg& from)
   if (from.message().size() > 0) {
     message_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.message_);
   }
-  // @@protoc_insertion_point(copy_constructor:grpc_signer.ReplyMsg)
+  // @@protoc_insertion_point(copy_constructor:grpc_signer.Request)
 }
 
-void ReplyMsg::SharedCtor() {
+void Request::SharedCtor() {
   message_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 
-ReplyMsg::~ReplyMsg() {
-  // @@protoc_insertion_point(destructor:grpc_signer.ReplyMsg)
+Request::~Request() {
+  // @@protoc_insertion_point(destructor:grpc_signer.Request)
   SharedDtor();
 }
 
-void ReplyMsg::SharedDtor() {
+void Request::SharedDtor() {
   message_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 
-void ReplyMsg::SetCachedSize(int size) const {
+void Request::SetCachedSize(int size) const {
   _cached_size_.Set(size);
 }
-const ::google::protobuf::Descriptor* ReplyMsg::descriptor() {
+const ::google::protobuf::Descriptor* Request::descriptor() {
   ::protobuf_signer_5fservice_2eproto::protobuf_AssignDescriptorsOnce();
   return ::protobuf_signer_5fservice_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
 }
 
-const ReplyMsg& ReplyMsg::default_instance() {
-  ::google::protobuf::internal::InitSCC(&protobuf_signer_5fservice_2eproto::scc_info_ReplyMsg.base);
+const Request& Request::default_instance() {
+  ::google::protobuf::internal::InitSCC(&protobuf_signer_5fservice_2eproto::scc_info_Request.base);
   return *internal_default_instance();
 }
 
 
-void ReplyMsg::Clear() {
-// @@protoc_insertion_point(message_clear_start:grpc_signer.ReplyMsg)
+void Request::Clear() {
+// @@protoc_insertion_point(message_clear_start:grpc_signer.Request)
   ::google::protobuf::uint32 cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
@@ -521,11 +504,11 @@ void ReplyMsg::Clear() {
   _internal_metadata_.Clear();
 }
 
-bool ReplyMsg::MergePartialFromCodedStream(
+bool Request::MergePartialFromCodedStream(
     ::google::protobuf::io::CodedInputStream* input) {
 #define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
   ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:grpc_signer.ReplyMsg)
+  // @@protoc_insertion_point(parse_start:grpc_signer.Request)
   for (;;) {
     ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
     tag = p.first;
@@ -555,17 +538,17 @@ bool ReplyMsg::MergePartialFromCodedStream(
     }
   }
 success:
-  // @@protoc_insertion_point(parse_success:grpc_signer.ReplyMsg)
+  // @@protoc_insertion_point(parse_success:grpc_signer.Request)
   return true;
 failure:
-  // @@protoc_insertion_point(parse_failure:grpc_signer.ReplyMsg)
+  // @@protoc_insertion_point(parse_failure:grpc_signer.Request)
   return false;
 #undef DO_
 }
 
-void ReplyMsg::SerializeWithCachedSizes(
+void Request::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:grpc_signer.ReplyMsg)
+  // @@protoc_insertion_point(serialize_start:grpc_signer.Request)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -579,13 +562,13 @@ void ReplyMsg::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
   }
-  // @@protoc_insertion_point(serialize_end:grpc_signer.ReplyMsg)
+  // @@protoc_insertion_point(serialize_end:grpc_signer.Request)
 }
 
-::google::protobuf::uint8* ReplyMsg::InternalSerializeWithCachedSizesToArray(
+::google::protobuf::uint8* Request::InternalSerializeWithCachedSizesToArray(
     bool deterministic, ::google::protobuf::uint8* target) const {
   (void)deterministic; // Unused
-  // @@protoc_insertion_point(serialize_to_array_start:grpc_signer.ReplyMsg)
+  // @@protoc_insertion_point(serialize_to_array_start:grpc_signer.Request)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -600,12 +583,12 @@ void ReplyMsg::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:grpc_signer.ReplyMsg)
+  // @@protoc_insertion_point(serialize_to_array_end:grpc_signer.Request)
   return target;
 }
 
-size_t ReplyMsg::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:grpc_signer.ReplyMsg)
+size_t Request::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:grpc_signer.Request)
   size_t total_size = 0;
 
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
@@ -625,23 +608,23 @@ size_t ReplyMsg::ByteSizeLong() const {
   return total_size;
 }
 
-void ReplyMsg::MergeFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:grpc_signer.ReplyMsg)
+void Request::MergeFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:grpc_signer.Request)
   GOOGLE_DCHECK_NE(&from, this);
-  const ReplyMsg* source =
-      ::google::protobuf::internal::DynamicCastToGenerated<const ReplyMsg>(
+  const Request* source =
+      ::google::protobuf::internal::DynamicCastToGenerated<const Request>(
           &from);
   if (source == NULL) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_signer.ReplyMsg)
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_signer.Request)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_signer.ReplyMsg)
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_signer.Request)
     MergeFrom(*source);
   }
 }
 
-void ReplyMsg::MergeFrom(const ReplyMsg& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:grpc_signer.ReplyMsg)
+void Request::MergeFrom(const Request& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:grpc_signer.Request)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   ::google::protobuf::uint32 cached_has_bits = 0;
@@ -653,36 +636,36 @@ void ReplyMsg::MergeFrom(const ReplyMsg& from) {
   }
 }
 
-void ReplyMsg::CopyFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:grpc_signer.ReplyMsg)
+void Request::CopyFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:grpc_signer.Request)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-void ReplyMsg::CopyFrom(const ReplyMsg& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:grpc_signer.ReplyMsg)
+void Request::CopyFrom(const Request& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:grpc_signer.Request)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-bool ReplyMsg::IsInitialized() const {
+bool Request::IsInitialized() const {
   return true;
 }
 
-void ReplyMsg::Swap(ReplyMsg* other) {
+void Request::Swap(Request* other) {
   if (other == this) return;
   InternalSwap(other);
 }
-void ReplyMsg::InternalSwap(ReplyMsg* other) {
+void Request::InternalSwap(Request* other) {
   using std::swap;
   message_.Swap(&other->message_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
     GetArenaNoVirtual());
   _internal_metadata_.Swap(&other->_internal_metadata_);
 }
 
-::google::protobuf::Metadata ReplyMsg::GetMetadata() const {
+::google::protobuf::Metadata Request::GetMetadata() const {
   protobuf_signer_5fservice_2eproto::protobuf_AssignDescriptorsOnce();
   return ::protobuf_signer_5fservice_2eproto::file_level_metadata[kIndexInFileMessages];
 }
@@ -690,251 +673,21 @@ void ReplyMsg::InternalSwap(ReplyMsg* other) {
 
 // ===================================================================
 
-void RequestMsg::InitAsDefaultInstance() {
+void Reply::InitAsDefaultInstance() {
 }
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
-const int RequestMsg::kMessageFieldNumber;
+const int Reply::kStatusFieldNumber;
+const int Reply::kMessageFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
-RequestMsg::RequestMsg()
+Reply::Reply()
   : ::google::protobuf::Message(), _internal_metadata_(NULL) {
   ::google::protobuf::internal::InitSCC(
-      &protobuf_signer_5fservice_2eproto::scc_info_RequestMsg.base);
+      &protobuf_signer_5fservice_2eproto::scc_info_Reply.base);
   SharedCtor();
-  // @@protoc_insertion_point(constructor:grpc_signer.RequestMsg)
+  // @@protoc_insertion_point(constructor:grpc_signer.Reply)
 }
-RequestMsg::RequestMsg(const RequestMsg& from)
-  : ::google::protobuf::Message(),
-      _internal_metadata_(NULL) {
-  _internal_metadata_.MergeFrom(from._internal_metadata_);
-  message_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  if (from.message().size() > 0) {
-    message_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.message_);
-  }
-  // @@protoc_insertion_point(copy_constructor:grpc_signer.RequestMsg)
-}
-
-void RequestMsg::SharedCtor() {
-  message_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-
-RequestMsg::~RequestMsg() {
-  // @@protoc_insertion_point(destructor:grpc_signer.RequestMsg)
-  SharedDtor();
-}
-
-void RequestMsg::SharedDtor() {
-  message_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-}
-
-void RequestMsg::SetCachedSize(int size) const {
-  _cached_size_.Set(size);
-}
-const ::google::protobuf::Descriptor* RequestMsg::descriptor() {
-  ::protobuf_signer_5fservice_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_signer_5fservice_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
-}
-
-const RequestMsg& RequestMsg::default_instance() {
-  ::google::protobuf::internal::InitSCC(&protobuf_signer_5fservice_2eproto::scc_info_RequestMsg.base);
-  return *internal_default_instance();
-}
-
-
-void RequestMsg::Clear() {
-// @@protoc_insertion_point(message_clear_start:grpc_signer.RequestMsg)
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  // Prevent compiler warnings about cached_has_bits being unused
-  (void) cached_has_bits;
-
-  message_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  _internal_metadata_.Clear();
-}
-
-bool RequestMsg::MergePartialFromCodedStream(
-    ::google::protobuf::io::CodedInputStream* input) {
-#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
-  ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:grpc_signer.RequestMsg)
-  for (;;) {
-    ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
-    tag = p.first;
-    if (!p.second) goto handle_unusual;
-    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // bytes message = 1;
-      case 1: {
-        if (static_cast< ::google::protobuf::uint8>(tag) ==
-            static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
-          DO_(::google::protobuf::internal::WireFormatLite::ReadBytes(
-                input, this->mutable_message()));
-        } else {
-          goto handle_unusual;
-        }
-        break;
-      }
-
-      default: {
-      handle_unusual:
-        if (tag == 0) {
-          goto success;
-        }
-        DO_(::google::protobuf::internal::WireFormat::SkipField(
-              input, tag, _internal_metadata_.mutable_unknown_fields()));
-        break;
-      }
-    }
-  }
-success:
-  // @@protoc_insertion_point(parse_success:grpc_signer.RequestMsg)
-  return true;
-failure:
-  // @@protoc_insertion_point(parse_failure:grpc_signer.RequestMsg)
-  return false;
-#undef DO_
-}
-
-void RequestMsg::SerializeWithCachedSizes(
-    ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:grpc_signer.RequestMsg)
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  (void) cached_has_bits;
-
-  // bytes message = 1;
-  if (this->message().size() > 0) {
-    ::google::protobuf::internal::WireFormatLite::WriteBytesMaybeAliased(
-      1, this->message(), output);
-  }
-
-  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
-    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
-        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
-  }
-  // @@protoc_insertion_point(serialize_end:grpc_signer.RequestMsg)
-}
-
-::google::protobuf::uint8* RequestMsg::InternalSerializeWithCachedSizesToArray(
-    bool deterministic, ::google::protobuf::uint8* target) const {
-  (void)deterministic; // Unused
-  // @@protoc_insertion_point(serialize_to_array_start:grpc_signer.RequestMsg)
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  (void) cached_has_bits;
-
-  // bytes message = 1;
-  if (this->message().size() > 0) {
-    target =
-      ::google::protobuf::internal::WireFormatLite::WriteBytesToArray(
-        1, this->message(), target);
-  }
-
-  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
-    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
-        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
-  }
-  // @@protoc_insertion_point(serialize_to_array_end:grpc_signer.RequestMsg)
-  return target;
-}
-
-size_t RequestMsg::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:grpc_signer.RequestMsg)
-  size_t total_size = 0;
-
-  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
-    total_size +=
-      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
-        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
-  }
-  // bytes message = 1;
-  if (this->message().size() > 0) {
-    total_size += 1 +
-      ::google::protobuf::internal::WireFormatLite::BytesSize(
-        this->message());
-  }
-
-  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
-  SetCachedSize(cached_size);
-  return total_size;
-}
-
-void RequestMsg::MergeFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:grpc_signer.RequestMsg)
-  GOOGLE_DCHECK_NE(&from, this);
-  const RequestMsg* source =
-      ::google::protobuf::internal::DynamicCastToGenerated<const RequestMsg>(
-          &from);
-  if (source == NULL) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_signer.RequestMsg)
-    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
-  } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_signer.RequestMsg)
-    MergeFrom(*source);
-  }
-}
-
-void RequestMsg::MergeFrom(const RequestMsg& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:grpc_signer.RequestMsg)
-  GOOGLE_DCHECK_NE(&from, this);
-  _internal_metadata_.MergeFrom(from._internal_metadata_);
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  (void) cached_has_bits;
-
-  if (from.message().size() > 0) {
-
-    message_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.message_);
-  }
-}
-
-void RequestMsg::CopyFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:grpc_signer.RequestMsg)
-  if (&from == this) return;
-  Clear();
-  MergeFrom(from);
-}
-
-void RequestMsg::CopyFrom(const RequestMsg& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:grpc_signer.RequestMsg)
-  if (&from == this) return;
-  Clear();
-  MergeFrom(from);
-}
-
-bool RequestMsg::IsInitialized() const {
-  return true;
-}
-
-void RequestMsg::Swap(RequestMsg* other) {
-  if (other == this) return;
-  InternalSwap(other);
-}
-void RequestMsg::InternalSwap(RequestMsg* other) {
-  using std::swap;
-  message_.Swap(&other->message_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
-    GetArenaNoVirtual());
-  _internal_metadata_.Swap(&other->_internal_metadata_);
-}
-
-::google::protobuf::Metadata RequestMsg::GetMetadata() const {
-  protobuf_signer_5fservice_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_signer_5fservice_2eproto::file_level_metadata[kIndexInFileMessages];
-}
-
-
-// ===================================================================
-
-void MsgStatus::InitAsDefaultInstance() {
-}
-#if !defined(_MSC_VER) || _MSC_VER >= 1900
-const int MsgStatus::kStatusFieldNumber;
-const int MsgStatus::kMessageFieldNumber;
-#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
-
-MsgStatus::MsgStatus()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
-  ::google::protobuf::internal::InitSCC(
-      &protobuf_signer_5fservice_2eproto::scc_info_MsgStatus.base);
-  SharedCtor();
-  // @@protoc_insertion_point(constructor:grpc_signer.MsgStatus)
-}
-MsgStatus::MsgStatus(const MsgStatus& from)
+Reply::Reply(const Reply& from)
   : ::google::protobuf::Message(),
       _internal_metadata_(NULL) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
@@ -943,39 +696,39 @@ MsgStatus::MsgStatus(const MsgStatus& from)
     message_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.message_);
   }
   status_ = from.status_;
-  // @@protoc_insertion_point(copy_constructor:grpc_signer.MsgStatus)
+  // @@protoc_insertion_point(copy_constructor:grpc_signer.Reply)
 }
 
-void MsgStatus::SharedCtor() {
+void Reply::SharedCtor() {
   message_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   status_ = 0;
 }
 
-MsgStatus::~MsgStatus() {
-  // @@protoc_insertion_point(destructor:grpc_signer.MsgStatus)
+Reply::~Reply() {
+  // @@protoc_insertion_point(destructor:grpc_signer.Reply)
   SharedDtor();
 }
 
-void MsgStatus::SharedDtor() {
+void Reply::SharedDtor() {
   message_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 
-void MsgStatus::SetCachedSize(int size) const {
+void Reply::SetCachedSize(int size) const {
   _cached_size_.Set(size);
 }
-const ::google::protobuf::Descriptor* MsgStatus::descriptor() {
+const ::google::protobuf::Descriptor* Reply::descriptor() {
   ::protobuf_signer_5fservice_2eproto::protobuf_AssignDescriptorsOnce();
   return ::protobuf_signer_5fservice_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
 }
 
-const MsgStatus& MsgStatus::default_instance() {
-  ::google::protobuf::internal::InitSCC(&protobuf_signer_5fservice_2eproto::scc_info_MsgStatus.base);
+const Reply& Reply::default_instance() {
+  ::google::protobuf::internal::InitSCC(&protobuf_signer_5fservice_2eproto::scc_info_Reply.base);
   return *internal_default_instance();
 }
 
 
-void MsgStatus::Clear() {
-// @@protoc_insertion_point(message_clear_start:grpc_signer.MsgStatus)
+void Reply::Clear() {
+// @@protoc_insertion_point(message_clear_start:grpc_signer.Reply)
   ::google::protobuf::uint32 cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
@@ -985,17 +738,17 @@ void MsgStatus::Clear() {
   _internal_metadata_.Clear();
 }
 
-bool MsgStatus::MergePartialFromCodedStream(
+bool Reply::MergePartialFromCodedStream(
     ::google::protobuf::io::CodedInputStream* input) {
 #define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
   ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:grpc_signer.MsgStatus)
+  // @@protoc_insertion_point(parse_start:grpc_signer.Reply)
   for (;;) {
     ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // .grpc_signer.MsgStatus.Status status = 1;
+      // .grpc_signer.Reply.Status status = 1;
       case 1: {
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(8u /* 8 & 0xFF */)) {
@@ -1003,23 +756,19 @@ bool MsgStatus::MergePartialFromCodedStream(
           DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
                    int, ::google::protobuf::internal::WireFormatLite::TYPE_ENUM>(
                  input, &value)));
-          set_status(static_cast< ::grpc_signer::MsgStatus_Status >(value));
+          set_status(static_cast< ::grpc_signer::Reply_Status >(value));
         } else {
           goto handle_unusual;
         }
         break;
       }
 
-      // string message = 2;
+      // bytes message = 2;
       case 2: {
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(18u /* 18 & 0xFF */)) {
-          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+          DO_(::google::protobuf::internal::WireFormatLite::ReadBytes(
                 input, this->mutable_message()));
-          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
-            this->message().data(), static_cast<int>(this->message().length()),
-            ::google::protobuf::internal::WireFormatLite::PARSE,
-            "grpc_signer.MsgStatus.message"));
         } else {
           goto handle_unusual;
         }
@@ -1038,33 +787,29 @@ bool MsgStatus::MergePartialFromCodedStream(
     }
   }
 success:
-  // @@protoc_insertion_point(parse_success:grpc_signer.MsgStatus)
+  // @@protoc_insertion_point(parse_success:grpc_signer.Reply)
   return true;
 failure:
-  // @@protoc_insertion_point(parse_failure:grpc_signer.MsgStatus)
+  // @@protoc_insertion_point(parse_failure:grpc_signer.Reply)
   return false;
 #undef DO_
 }
 
-void MsgStatus::SerializeWithCachedSizes(
+void Reply::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:grpc_signer.MsgStatus)
+  // @@protoc_insertion_point(serialize_start:grpc_signer.Reply)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // .grpc_signer.MsgStatus.Status status = 1;
+  // .grpc_signer.Reply.Status status = 1;
   if (this->status() != 0) {
     ::google::protobuf::internal::WireFormatLite::WriteEnum(
       1, this->status(), output);
   }
 
-  // string message = 2;
+  // bytes message = 2;
   if (this->message().size() > 0) {
-    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
-      this->message().data(), static_cast<int>(this->message().length()),
-      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "grpc_signer.MsgStatus.message");
-    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+    ::google::protobuf::internal::WireFormatLite::WriteBytesMaybeAliased(
       2, this->message(), output);
   }
 
@@ -1072,30 +817,26 @@ void MsgStatus::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
   }
-  // @@protoc_insertion_point(serialize_end:grpc_signer.MsgStatus)
+  // @@protoc_insertion_point(serialize_end:grpc_signer.Reply)
 }
 
-::google::protobuf::uint8* MsgStatus::InternalSerializeWithCachedSizesToArray(
+::google::protobuf::uint8* Reply::InternalSerializeWithCachedSizesToArray(
     bool deterministic, ::google::protobuf::uint8* target) const {
   (void)deterministic; // Unused
-  // @@protoc_insertion_point(serialize_to_array_start:grpc_signer.MsgStatus)
+  // @@protoc_insertion_point(serialize_to_array_start:grpc_signer.Reply)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // .grpc_signer.MsgStatus.Status status = 1;
+  // .grpc_signer.Reply.Status status = 1;
   if (this->status() != 0) {
     target = ::google::protobuf::internal::WireFormatLite::WriteEnumToArray(
       1, this->status(), target);
   }
 
-  // string message = 2;
+  // bytes message = 2;
   if (this->message().size() > 0) {
-    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
-      this->message().data(), static_cast<int>(this->message().length()),
-      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "grpc_signer.MsgStatus.message");
     target =
-      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+      ::google::protobuf::internal::WireFormatLite::WriteBytesToArray(
         2, this->message(), target);
   }
 
@@ -1103,12 +844,12 @@ void MsgStatus::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:grpc_signer.MsgStatus)
+  // @@protoc_insertion_point(serialize_to_array_end:grpc_signer.Reply)
   return target;
 }
 
-size_t MsgStatus::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:grpc_signer.MsgStatus)
+size_t Reply::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:grpc_signer.Reply)
   size_t total_size = 0;
 
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
@@ -1116,14 +857,14 @@ size_t MsgStatus::ByteSizeLong() const {
       ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
   }
-  // string message = 2;
+  // bytes message = 2;
   if (this->message().size() > 0) {
     total_size += 1 +
-      ::google::protobuf::internal::WireFormatLite::StringSize(
+      ::google::protobuf::internal::WireFormatLite::BytesSize(
         this->message());
   }
 
-  // .grpc_signer.MsgStatus.Status status = 1;
+  // .grpc_signer.Reply.Status status = 1;
   if (this->status() != 0) {
     total_size += 1 +
       ::google::protobuf::internal::WireFormatLite::EnumSize(this->status());
@@ -1134,23 +875,23 @@ size_t MsgStatus::ByteSizeLong() const {
   return total_size;
 }
 
-void MsgStatus::MergeFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:grpc_signer.MsgStatus)
+void Reply::MergeFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:grpc_signer.Reply)
   GOOGLE_DCHECK_NE(&from, this);
-  const MsgStatus* source =
-      ::google::protobuf::internal::DynamicCastToGenerated<const MsgStatus>(
+  const Reply* source =
+      ::google::protobuf::internal::DynamicCastToGenerated<const Reply>(
           &from);
   if (source == NULL) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_signer.MsgStatus)
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_signer.Reply)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_signer.MsgStatus)
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_signer.Reply)
     MergeFrom(*source);
   }
 }
 
-void MsgStatus::MergeFrom(const MsgStatus& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:grpc_signer.MsgStatus)
+void Reply::MergeFrom(const Reply& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:grpc_signer.Reply)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   ::google::protobuf::uint32 cached_has_bits = 0;
@@ -1165,29 +906,29 @@ void MsgStatus::MergeFrom(const MsgStatus& from) {
   }
 }
 
-void MsgStatus::CopyFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:grpc_signer.MsgStatus)
+void Reply::CopyFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:grpc_signer.Reply)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-void MsgStatus::CopyFrom(const MsgStatus& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:grpc_signer.MsgStatus)
+void Reply::CopyFrom(const Reply& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:grpc_signer.Reply)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-bool MsgStatus::IsInitialized() const {
+bool Reply::IsInitialized() const {
   return true;
 }
 
-void MsgStatus::Swap(MsgStatus* other) {
+void Reply::Swap(Reply* other) {
   if (other == this) return;
   InternalSwap(other);
 }
-void MsgStatus::InternalSwap(MsgStatus* other) {
+void Reply::InternalSwap(Reply* other) {
   using std::swap;
   message_.Swap(&other->message_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
     GetArenaNoVirtual());
@@ -1195,7 +936,7 @@ void MsgStatus::InternalSwap(MsgStatus* other) {
   _internal_metadata_.Swap(&other->_internal_metadata_);
 }
 
-::google::protobuf::Metadata MsgStatus::GetMetadata() const {
+::google::protobuf::Metadata Reply::GetMetadata() const {
   protobuf_signer_5fservice_2eproto::protobuf_AssignDescriptorsOnce();
   return ::protobuf_signer_5fservice_2eproto::file_level_metadata[kIndexInFileMessages];
 }
@@ -1208,14 +949,11 @@ namespace protobuf {
 template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::grpc_signer::Identity* Arena::CreateMaybeMessage< ::grpc_signer::Identity >(Arena* arena) {
   return Arena::CreateInternal< ::grpc_signer::Identity >(arena);
 }
-template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::grpc_signer::ReplyMsg* Arena::CreateMaybeMessage< ::grpc_signer::ReplyMsg >(Arena* arena) {
-  return Arena::CreateInternal< ::grpc_signer::ReplyMsg >(arena);
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::grpc_signer::Request* Arena::CreateMaybeMessage< ::grpc_signer::Request >(Arena* arena) {
+  return Arena::CreateInternal< ::grpc_signer::Request >(arena);
 }
-template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::grpc_signer::RequestMsg* Arena::CreateMaybeMessage< ::grpc_signer::RequestMsg >(Arena* arena) {
-  return Arena::CreateInternal< ::grpc_signer::RequestMsg >(arena);
-}
-template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::grpc_signer::MsgStatus* Arena::CreateMaybeMessage< ::grpc_signer::MsgStatus >(Arena* arena) {
-  return Arena::CreateInternal< ::grpc_signer::MsgStatus >(arena);
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::grpc_signer::Reply* Arena::CreateMaybeMessage< ::grpc_signer::Reply >(Arena* arena) {
+  return Arena::CreateInternal< ::grpc_signer::Reply >(arena);
 }
 }  // namespace protobuf
 }  // namespace google

--- a/src/plugins/net_plugin/rpc_services/protos/signer_service.proto
+++ b/src/plugins/net_plugin/rpc_services/protos/signer_service.proto
@@ -7,28 +7,29 @@ option java_outer_classname = "GruutNetwork";
 package grpc_signer;
 
 service GruutSignerService {
-    rpc OpenChannel(stream Identity) returns (stream ReplyMsg) {}
-    rpc SignerService (RequestMsg) returns (MsgStatus) {}
+    rpc OpenChannel(stream Identity) returns (stream Request) {}
+    rpc SignerService (Request) returns (Reply) {}
 }
 message Identity {
     bytes sender = 1;
 }
 
-message ReplyMsg {
+message Request {
     bytes message = 1;
 }
 
-message RequestMsg {
-    bytes message = 1;
-}
-
-message MsgStatus {
+message Reply {
     enum Status{
-        SUCCESS = 0;
-        INVALID = 1;
-        INTERNAL = 2;
-        DUPLICATED = 3;
+        UNKOWN = 0;
+        SUCCESS = 1;
+        HEADER_INVALID = 2;
+        INTERNAL = 3;
+        ECDH_ILLEGAL_ACCESS = 21;
+        ECDH_MAX_SIGNER_POOL = 22;
+        ECDH_TIMEOUT = 23;
+        ECDH_INVALID_SIG = 24;
+        ECDH_INVALID_PK = 25;
     }
     Status status = 1;
-    string message = 2;
+    bytes message = 2;
 }


### PR DESCRIPTION
### 추가 및 수정
- ErrrorMsgType 추가

- Signer Protobuf 수정
  - Net-plugin에서 Signer 와 ECDH Key exchange를 하므로, Signer로부터 MSG_JOIN, RESPONSE1, SUCCESS를 받았을때, 다른 plugin으로 전달이 필요없습니다.
  - 해당 메시지를 받았을 때, 해당 RPC 를 통해 즉각적으로 답하는 형태가 맞다고 생각하여 수정하였습니다.

- SignerPoolManager
  - SignerPool 추가
  - ECDH exchange 관련 메시지 처리 (JOIN / RESPONSE1 /SUCCESS)

- MessageBuilder 
  - MSG_LEAVE 제거 ( NetPlugin에서 signer pool 관리로 해당 메시지를 발생시킬 필요가 없어짐)
  - CHALLENGE / RESPONSE2  / ACCEPT 추가

- MessageHandler
  - JOIN / RESPONSE1 / SUCCESS 처리

- ~MessageParser~
  - ~RequesterType에 따라 parsing 변경~

- MessagePacker
  - Mac algorithm type에 따라 packMessage 하도록 수정

- Signer로부터 온 메시지 Parsing 시 HMAC 검증하는 코드 추가
- Signer에게 보낼 메시지에 HMAC을 붙이도록 함.

### 기타 수정
- Signer conn manager -> signer conn table 파일 이름 수정