### PR TITLE
 # ADD - ECDH key ex verify / do sig

### DIFF
--- a/src/plugins/net_plugin/include/message_builder.hpp
+++ b/src/plugins/net_plugin/include/message_builder.hpp
@@ -37,11 +37,11 @@ public:
   }
 
   template <MessageType T, typename = enable_if_t<T == MessageType::MSG_RESPONSE_2>>
-  static auto build(const string &b58_recv_id, const string &dhx, const string &dhy, const string &cert, const string &sig) {
+  static auto build(const string &timestamp, const string &b58_recv_id, const string &dhx, const string &dhy, const string &cert, const string &sig) {
     OutNetMsg msg_response2;
     nlohmann::json msg_body;
 
-    msg_body["time"] = TimeUtil::now();
+    msg_body["time"] = timestamp;
     msg_body["dh"]["x"] = dhx;
     msg_body["dh"]["y"] = dhy;
     msg_body["merger"]["id"] = MY_ID_BASE58;


### PR DESCRIPTION
- RESPONSE1의 signer 서명 검증
- RESPONSE2를 보낼 때 서명

- `GPN`에서 ECDH Key exchange 과정에서도 `GEN` 과 동일하게 `ECDSA` 를 이용합니다.