### PR TITLE
 # FIX - SignerPoolManager

### DIFF
--- a/src/plugins/net_plugin/include/signer_pool_manager.hpp
+++ b/src/plugins/net_plugin/include/signer_pool_manager.hpp
@@ -114,7 +114,7 @@ public:
       }
 
       auto signer_id_in_body = json::get<string>(msg.body, "user");
-      if (signer_id_in_body.value() == msg.sender_id) {
+      if (signer_id_in_body.value() != msg.sender_id) {
         logger::ERROR("[ECDH] Message header and body id are different");
         throw ErrorMsgType::ECDH_ILLEGAL_ACCESS;
       }
@@ -154,7 +154,7 @@ public:
       }
       temp_signer_pool[msg.sender_id].shared_sk = shared_sk_bytes;
 
-      auto sn = json::get<string>(msg.body["user"], "sn").value();
+      auto sn = json::get<string>(msg.body, "sn").value();
       auto mn = temp_signer_pool[msg.sender_id].merger_nonce;
       auto curr_time = TimeUtil::now();
       // TODO : get sk, sk_pass, cert
@@ -195,6 +195,13 @@ public:
 
   optional<vector<uint8_t>> getHmacKey(const string &b58_signer_id) {
     return signer_pool.getHmacKey(b58_signer_id);
+  }
+
+  optional<vector<uint8_t>> getTempHmacKey(const string &b58_signer_id) {
+    if(temp_signer_pool.count(b58_signer_id) > 0){
+      return temp_signer_pool[b58_signer_id].shared_sk;
+    }
+    return {};
   }
 
 private:

--- a/src/plugins/net_plugin/net_plugin.cpp
+++ b/src/plugins/net_plugin/net_plugin.cpp
@@ -94,6 +94,7 @@ public:
   }
 
   void registerServices() {
+    signer_pool_manager = make_shared<SignerPoolManager>();
     signer_conn_table = make_shared<SignerConnTable>();
     broadcast_check_table = make_shared<BroadcastMsgTable>();
     id_mapping_table = make_shared<IdMappingTable>();


### PR DESCRIPTION
- NetPlugin initialize시  SignerPoolManager를 초기화하지 않아
접근하였을때 문제가 발생하였던 것 수정
- SignerPoolManager::handleMsg()에서 RESPONSE_1에서 `sn` 은 msg body
에서 `user` scope 안의 값이 아니므로 수정
- MSG_SUCCESS의 경우 아직 signer_pool에 데이터가 있지 않고
temp_signer_pool에 데이터가 존재한다. 따라서 getHmacKey() 호출시 key를
가져오지 못함.
- Signer pool manager에서 join 매시지 처리하는 과정에서 메시지 헤더에
있는 id와 body에 있는 id 비교하는 부분 잘 못 되어있던것 수정
- getTempHmacKey() 함수 추가 ( temp signer pool 에서 hmackey를 가져옴)