### PR TITLE
# EDIT - MessageValidator

### DIFF
--- a/src/plugins/net_plugin/config/include/message.hpp
+++ b/src/plugins/net_plugin/config/include/message.hpp
@@ -115,6 +115,7 @@ enum class MsgEntryType {
   DECIMAL,
   ALPHA_64,
   PEM,
+  ENC_PRIVATE_PEM,
   PK,
   PEM_PK,
   HEX_256,


### PR DESCRIPTION
- Message type 추가에 따른 Message validator 수정
  - MSG_SET_MERGER에서 `ENC_PRIVATE_PEM`이 추가 됨에 따라서 PEM 종류에
따라서 `BEGIN` `END`를 구분할 필요가 있어서 함수 추가
  - `where` 같은 경우 object type 임에도 불구하고 확인을 스킵하는
이유는 json 의 where object가 가지고 있는 내용이 정해져있지 않기 때문. (where은 MSG_QUERY 에 있습니다. )
  - MessageValidator::getEntryType 에 확인하는 key 종류 추가.