### PR TITLE
# ADD - genesis world 와 local_chain_state 간 제약조건 추가(assert 실패시 프로그램 중…

### DIFF
--- a/genesis_block.json
+++ b/genesis_block.json
@@ -18,7 +18,7 @@
   "eden" : {
     "chain": {
       "id": "TSTCHAIN",
-      "world": "GRUUNET",
+      "world": "GRUUTNET",
       "after": "1556504053"
     },
     "policy": {

--- a/src/plugins/chain_plugin/chain.cpp
+++ b/src/plugins/chain_plugin/chain.cpp
@@ -96,6 +96,11 @@ public:
       genesis_state.cert = state["creator"]["cert"].get<vector<string>>();
       genesis_state.sig = state["/creator/sig"_json_pointer];
 
+      assert(genesis_state.world_id == genesis_state.local_chain_state.world_id);
+      assert(genesis_state.creator_id == genesis_state.local_chain_state.creator_id);
+      assert(genesis_state.cert == genesis_state.local_chain_state.creator_pk);
+      assert(genesis_state.sig == genesis_state.local_chain_state.creator_sig);
+
       return genesis_state;
     } catch (json::parse_error &e) {
       logger::ERROR("Failed to parse genesis.json: {}", e.what());


### PR DESCRIPTION
…단하도록)

설계서에, 다음과 같이 명시되어있어서 assert 추가함
> 에덴체인은 반드시 chain creator가 world creator와 동일해야 하며, world의 eden으로 지정된 체인의 이름을 사용해야만 합니다. 이 경우, 체인의 최초 스테이트에 creator가 모든 기축통화를 소유하고 있는 상태가 됩니다.

[참조](https://thevaulters.atlassian.net/wiki/spaces/SGN/pages/77987903/GP10.+Genesis)

