### PR TITLE
# ADD - User rpc service

### DIFF
--- a/src/plugins/net_plugin/net_plugin.cpp
+++ b/src/plugins/net_plugin/net_plugin.cpp
@@ -360,7 +360,7 @@ public:
   }
 
   bool checkMergerMsgType(MessageType msg_type) {
-    return (msg_type == MessageType::MSG_TX || msg_type == MessageType::MSG_REQ_BLOCK || msg_type == MessageType::MSG_BLOCK);
+    return (msg_type == MessageType::MSG_TX || msg_type == MessageType::MSG_BONE || msg_type == MessageType::MSG_BLOCK);
   }
 
   bool checkUserMsgType(MessageType msg_type) {

--- a/src/plugins/net_plugin/net_plugin.cpp
+++ b/src/plugins/net_plugin/net_plugin.cpp
@@ -327,7 +327,7 @@ public:
         for (auto &b58_receiver_id : out_msg.receivers) {
           auto hashed_net_id = id_mapping_table->get(b58_receiver_id);
 
-          if(hashed_net_id.has_value()) {
+          if (hashed_net_id.has_value()) {
             auto node = routing_table->findNode(hashed_net_id.value());
 
             if (node.has_value()) {

--- a/src/plugins/net_plugin/rpc_services/include/rpc_services.hpp
+++ b/src/plugins/net_plugin/rpc_services/include/rpc_services.hpp
@@ -87,9 +87,27 @@ private:
   Request m_request;
   Reply m_reply;
   ServerAsyncResponseWriter<Reply> m_responder;
-
   shared_ptr<SignerPoolManager> m_signer_pool_manager;
-  grpc::Status verifyHMAC(string_view packed_msg, vector<uint8_t> &hmac_key);
+  void proceed() override;
+};
+
+class UserService final : public CallData {
+public:
+  UserService(GruutUserService::AsyncService *service, ServerCompletionQueue *cq, shared_ptr<SignerPoolManager> signer_pool_manager)
+      : m_responder(&m_context), m_signer_pool_manager(move(signer_pool_manager)) {
+    m_service = service;
+    m_completion_queue = cq;
+    m_receive_status = RpcCallStatus::CREATE;
+
+    proceed();
+  }
+
+private:
+  GruutUserService::AsyncService *m_service;
+  Request m_request;
+  Reply m_reply;
+  ServerAsyncResponseWriter<Reply> m_responder;
+  shared_ptr<SignerPoolManager> m_signer_pool_manager;
   void proceed() override;
 };
 

--- a/src/plugins/net_plugin/rpc_services/rpc_services.cpp
+++ b/src/plugins/net_plugin/rpc_services/rpc_services.cpp
@@ -39,7 +39,7 @@ public:
       if (val.is_array())
         continue;
       else if (val.is_object()) {
-        if(key == "where")
+        if (key == "where")
           continue;
         check = validate(val);
         if (!check)
@@ -164,15 +164,15 @@ private:
     else
       return MsgEntryType::NONE;
   }
-  bool checkPemContents(MsgEntryType pem_type, const string &pem){
+  bool checkPemContents(MsgEntryType pem_type, const string &pem) {
     string begin_str, end_str;
-    switch(pem_type){
-    case MsgEntryType::PEM:{
+    switch (pem_type) {
+    case MsgEntryType::PEM: {
       begin_str = "-----BEGIN CERTIFICATE-----";
       end_str = "-----END CERTIFICATE-----";
       break;
     }
-    case MsgEntryType::ENC_PRIVATE_PEM:{
+    case MsgEntryType::ENC_PRIVATE_PEM: {
       begin_str = "-----BEGIN ENCRYPTED PRIVATE KEY-----";
       end_str = "-----END ENCRYPTED PRIVATE KEY-----";
       break;
@@ -183,7 +183,7 @@ private:
     }
     auto found1 = pem.find(begin_str);
     auto found2 = pem.find(end_str);
-    if(found1 == string::npos || found2 == string::npos) {
+    if (found1 == string::npos || found2 == string::npos) {
       logger::ERROR("[MVAL] Error on PEM");
       return false;
     }

--- a/src/plugins/net_plugin/rpc_services/rpc_services.cpp
+++ b/src/plugins/net_plugin/rpc_services/rpc_services.cpp
@@ -292,7 +292,7 @@ private:
   optional<OutNetMsg> handle_message(InNetMsg &msg) {
     auto msg_type = msg.type;
 
-    if (msg_type == MessageType::MSG_BLOCK || msg_type == MessageType::MSG_TX || msg_type == MessageType::MSG_REQ_BLOCK) {
+    if (msg_type == MessageType::MSG_REQ_BONE || msg_type == MessageType::MSG_REQ_BLOCK) {
       mapping_user_id_to_net_id(msg);
     }
 
@@ -308,7 +308,9 @@ private:
       // TODO : ssig message must be sent to `block producer`
     case MessageType::MSG_REQ_TX_CHECK:
     case MessageType::MSG_QUERY:
-      // TODO : REQ_TX_CHECK & QUERY message must be sent to `chain plugin`
+    case MessageType::MSG_REQ_BONE:
+    case MessageType::MSG_REQ_BLOCK:
+      // TODO : REQ_TX_CHECK , QUERY, REQ_BONE, REQ_BLOCK message must be sent to `chain plugin`
       return {};
     default:
       return {};


### PR DESCRIPTION
- UserService rpc 추가
- UserService 에서도 `verifiyHMAC()`을 사용하기 위해 KeyExService에서 밖으로
꺼냄

- NetPluginImpl
  - checkSignerMsgType -> checkUserMsgType
  - `checkUserMsgType()` // `checkMergerMsgType()`에 확인할 메시지 타입 추가
  - `sendMessage()`에서 User에게 보내는 메시지는 ECDH 키교환 이후 이므로
모든 message에 HMAC을 붙이도록 수정

- MessageHandler에서 처리해야할 메시지타입 추가 
  - MSG_TX와 MSG_BLOCK에 대해서는 답장이 필요하지 않기 때문에 id mapping 하지 않는다.