### PR TITLE
## ADD - `TransactionMessage` 을 검증하는 코드 추가

### DIFF
--- a/include/types/transaction.hpp
+++ b/include/types/transaction.hpp
@@ -15,6 +15,7 @@ struct TransactionMessage {
   string cid;
   string receiver;
   string fee;
+  vector<uint8_t> input;
 
   string user_id;
   string user_pk;

--- a/include/types/transaction.hpp
+++ b/include/types/transaction.hpp
@@ -5,19 +5,38 @@
 
 using namespace std;
 
+// TODO: Remove the code duplication between TransactionMessage and Transaction.
+struct TransactionMessage {
+  string txid;
+  string world;
+  string chain;
+  string time;
+
+  string cid;
+  string receiver;
+  string fee;
+
+  string user_id;
+  string user_pk;
+  string user_sig;
+
+  string endorser_id;
+  string endorser_pk;
+  string endorser_sig;
+};
+
 struct Transaction {
-  int tsidx;             // transaction scope index
+  int tsidx;             // transaction scope index, Primary key
   string tx_id;          // transaction’s identifier
   uint64_t tx_time;      // transaction’s time
-  string tx_seed;        // seed included in transaction
   string tx_contract_id; // contract’s identifier for this transaction
   int tx_fee_author;     // transaction fee by author
   int tx_fee_user;       // transaction fee by user
   string tx_user;        // transaction producer’s identifier
   string tx_user_pk;     // transaction producer’s public key
+  string tx_user_sig;    // transaction signature
   string tx_receiver;    // receiver’s identifier
   string tx_input;       // contract’s input
-  string tx_user_sig;    // transaction signature
   string tx_agg_cbor;    // serialized tx tx_agg by CBOR
   string block_id;       // block’s identifier including this transaction
   int tx_pos;            // position on Merkle tree
@@ -31,15 +50,14 @@ RTTR_REGISTRATION {
       .property("tsidx", &Transaction::tsidx)
       .property("tx_id", &Transaction::tx_id)
       .property("tx_time", &Transaction::tx_time)
-      .property("tx_seed", &Transaction::tx_seed)
       .property("tx_contract_id", &Transaction::tx_contract_id)
       .property("tx_fee_author", &Transaction::tx_fee_author)
       .property("tx_fee_user", &Transaction::tx_fee_user)
       .property("tx_user", &Transaction::tx_user)
       .property("tx_user_pk", &Transaction::tx_user_pk)
+      .property("tx_user_sig", &Transaction::tx_user_sig)
       .property("tx_receiver", &Transaction::tx_receiver)
       .property("tx_input", &Transaction::tx_input)
-      .property("tx_user_sig", &Transaction::tx_user_sig)
       .property("tx_agg_cbor", &Transaction::tx_agg_cbor)
       .property("block_id", &Transaction::block_id)
       .property("tx_pos", &Transaction::tx_pos)

--- a/src/plugins/chain_plugin/CMakeLists.txt
+++ b/src/plugins/chain_plugin/CMakeLists.txt
@@ -14,6 +14,13 @@ else()
     message(WARNING "SOCI NOT FOUND")
 endif()
 
+find_package(RTTR CONFIG REQUIRED Core)
+if(RTTR_FOUND)
+    target_link_libraries(chain_plugin RTTR::Core)
+else()
+    message(WARNING "RTTR NOT FOUND")
+endif()
+
 target_link_libraries(chain_plugin appbase log)
 target_include_directories(chain_plugin PUBLIC
         "/usr/local/include/mysql"


### PR DESCRIPTION
- TransactionMessageVerifier 추가
  + tx_id 검증하는 코드 추가
  + 서명 검증은 나중에 구현
- TransactionMsgParser
  + try-catch 추가, exception 발생하면 로그 찍도록 함. optional 검사해서 value가 없으면 그냥 pushTransaction 에서 transaction을 넣지 않도록 함
- Transaction 필드에 누락된 `input` 추가

참조: https://thevaulters.atlassian.net/wiki/spaces/SGN/pages/86638675/Block+Messages
