### PR TITLE
# ADD - 블록 생성 시간 계산을 위한 사전 작업

### DIFF
--- a/src/plugins/block_producer_plugin/block_producer_plugin.cpp
+++ b/src/plugins/block_producer_plugin/block_producer_plugin.cpp
@@ -1,18 +1,74 @@
 #include "include/block_producer_plugin.hpp"
+#include "../../../lib/appbase/include/application.hpp"
+#include <boost/asio/steady_timer.hpp>
 
 namespace gruut {
 
+using namespace std;
+
 class BlockProducerPluginImpl {
 public:
-  
+  void initialize() {
+    timer = make_unique<boost::asio::steady_timer>(app().getIoContext());
+  }
+
+  void start() {
+    scheduleBlockProductionLoop();
+  }
+
+private:
+  void scheduleBlockProductionLoop() {
+    auto wake_up_time = calculateNextBlockTime();
+    timer->expires_from_now(wake_up_time);
+    timer->async_wait([this](boost::system::error_code ec) {
+      if (!ec) {
+        // produce a block.
+        scheduleBlockProductionLoop();
+      } else {
+        logger::ERROR("Error from block producer timer: {}", ec.message());
+      }
+    });
+  }
+
+  std::chrono::seconds calculateNextBlockTime() {
+    std::chrono::seconds minimum_delay_time(5);
+
+    // TODO: 일정 개수 이전의 블록들을 기준으로 계산합니다. 현재는 임시로 상수값
+    float d = 0.5;
+    float b = 0.1;
+    float signers_count = 10;
+
+    // calculate the distance between a node and an optimal merger.
+    auto mergers_distance = calculateDistanceBetweenMergers();
+    // calculate the distance between signers and an optimal signer.
+    auto signers_distance = calculateDistanceBetweenSigners();
+
+    // TODO: temporary value
+    return minimum_delay_time;
+  }
+
+  float calculateDistanceBetweenMergers() {
+
+  }
+
+
+  float calculateDistanceBetweenSigners() {
+
+  }
+
+  unique_ptr<boost::asio::steady_timer> timer;
 };
 
 void BlockProducerPlugin::pluginInitialize(const boost::program_options::variables_map &options) {
   logger::INFO("BlockProducerPlugin Initialize");
+
+  impl->initialize();
 }
 
 void BlockProducerPlugin::pluginStart() {
   logger::INFO("BlockProducerPlugin Start");
+
+  impl->start();
 }
 
 BlockProducerPlugin::BlockProducerPlugin() : impl(make_unique<BlockProducerPluginImpl>()) {}


### PR DESCRIPTION
- BlockPlugin 이 시작(start)과 동시에 블록 생성 시간을 계산하고, 생성 시점에 블록을 생성할 수 있도록 skeleton code 작성
- 일부 변수값들 임시로 상수값으로 고정 (TODO 에 명시)
- 블록 생성시간을 계산하기 위해서는 최적 병합자를 계산할 수 있어야 하는데, 이 내용들은 다음 PR에서 진행
- 참조: https://thevaulters.atlassian.net/wiki/spaces/SGN/pages/90832930/PoP+in+Public+Network