### PR TITLE
# FEATURE - Setup Merger

### DIFF
--- a/src/plugins/admin_plugin/rpc_services/include/rpc_services.hpp
+++ b/src/plugins/admin_plugin/rpc_services/include/rpc_services.hpp
@@ -83,7 +83,8 @@ private:
   ReqSetup req;
   ResSetup res;
   ServerAsyncResponseWriter<ResSetup> responder;
-  optional<nlohmann::json> runSetup();
+  optional<nlohmann::json> runSetup(shared_ptr<SetupService> setup_service);
+  unique_ptr<Server> initSetup(shared_ptr<SetupService> setup_service);
 };
 
 } // namespace admin_plugin

--- a/src/plugins/admin_plugin/rpc_services/include/rpc_services.hpp
+++ b/src/plugins/admin_plugin/rpc_services/include/rpc_services.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
+#include "../../../net_plugin/rpc_services/protos/include/user_service.grpc.pb.h"
 #include "../proto/include/admin_service.grpc.pb.h"
+#include <atomic>
+#include <future>
 #include <grpc/support/log.h>
 #include <grpcpp/grpcpp.h>
 
@@ -10,13 +13,32 @@ namespace gruut {
 namespace admin_plugin {
 
 using namespace grpc;
+using namespace grpc_user;
 using namespace grpc_admin;
+
+struct MergerStatus {
+  atomic<bool> user_setup{false};
+  atomic<bool> is_running{false};
+};
+
+class SetupService final : public GruutUserService::Service {
+public:
+  SetupService() = default;
+  Status UserService(ServerContext *context, const Request *request, Reply *response) override;
+  promise<optional<nlohmann::json>> &getUserKeyPromise() {
+    return user_key_info;
+  }
+
+private:
+  promise<optional<nlohmann::json>> user_key_info;
+};
 
 enum class AdminRpcCallStatus { CREATE, PROCESS, FINISH };
 
 class CallService {
 public:
-  CallService(GruutAdminService::AsyncService *admin_service, ServerCompletionQueue *cq) {
+  CallService(GruutAdminService::AsyncService *admin_service, ServerCompletionQueue *cq, shared_ptr<MergerStatus> m_status)
+      : merger_status(m_status) {
     service = admin_service;
     completion_queue = cq;
   }
@@ -24,6 +46,7 @@ public:
   virtual void proceed() = 0;
 
 protected:
+  shared_ptr<MergerStatus> merger_status;
   GruutAdminService::AsyncService *service;
   ServerCompletionQueue *completion_queue;
   ServerContext context;
@@ -33,8 +56,8 @@ protected:
 template <typename Request, typename Response>
 class AdminService final : public CallService {
 public:
-  AdminService(GruutAdminService::AsyncService *admin_service, ServerCompletionQueue *cq)
-      : CallService(admin_service, cq), responder(&context) {
+  AdminService(GruutAdminService::AsyncService *admin_service, ServerCompletionQueue *cq, shared_ptr<MergerStatus> m_status)
+      : CallService(admin_service, cq, m_status), responder(&context) {
     proceed();
   }
   void proceed() override;
@@ -43,6 +66,24 @@ private:
   Request req;
   Response res;
   ServerAsyncResponseWriter<Response> responder;
+};
+
+template <>
+class AdminService<ReqSetup, ResSetup> final : public CallService {
+public:
+  AdminService(GruutAdminService::AsyncService *admin_service, ServerCompletionQueue *cq, shared_ptr<MergerStatus> m_status,
+               const string &setup_port)
+      : CallService(admin_service, cq, m_status), responder(&context), port(setup_port) {
+    proceed();
+  }
+  void proceed() override;
+
+private:
+  string port;
+  ReqSetup req;
+  ResSetup res;
+  ServerAsyncResponseWriter<ResSetup> responder;
+  optional<nlohmann::json> runSetup();
 };
 
 } // namespace admin_plugin

--- a/src/plugins/admin_plugin/rpc_services/rpc_services.cpp
+++ b/src/plugins/admin_plugin/rpc_services/rpc_services.cpp
@@ -1,6 +1,8 @@
 #include "include/rpc_services.hpp"
 #include "../../../../lib/json/include/json.hpp"
-
+#include "../../../lib/appbase/include/application.hpp"
+#include "../../../lib/gruut-utils/src/ecdsa.hpp"
+#include "../../../plugins/net_plugin/include/message_parser.hpp"
 #include <exception>
 
 namespace gruut {
@@ -9,9 +11,85 @@ namespace admin_plugin {
 using namespace appbase;
 using namespace std;
 
+Status SetupService::UserService(ServerContext *context, const Request *request, Reply *response) {
+  Status rpc_status;
+  MessageParser msg_parser;
+  auto input_data = msg_parser.parseMessage(request->message(), rpc_status);
+  if (!input_data.has_value()) {
+    user_key_info.set_value({});
+    response->set_status(Reply_Status_INVALID);
+    return rpc_status;
+  }
+  user_key_info.set_value(input_data.value().body);
+  response->set_status(Reply_Status_SUCCESS);
+  return Status::OK;
+}
+
+optional<nlohmann::json> AdminService<ReqSetup, ResSetup>::runSetup() {
+  string setup_serv_addr("0.0.0.0:" + port);
+  SetupService setup_service;
+
+  ServerBuilder setup_serv_builder;
+  setup_serv_builder.AddListeningPort(setup_serv_addr, grpc::InsecureServerCredentials());
+  setup_serv_builder.RegisterService(&setup_service);
+
+  unique_ptr<Server> setup_server(setup_serv_builder.BuildAndStart());
+
+  auto &promise_user_key = setup_service.getUserKeyPromise();
+  auto user_key_info = promise_user_key.get_future();
+
+  user_key_info.wait(); // waiting for user key info
+
+  if (setup_server != nullptr)
+    setup_server->Shutdown();
+  setup_server.reset();
+
+  if (user_key_info.get().has_value()) {
+    return user_key_info.get().value();
+  }
+  return {};
+}
+
 // TODO : handle admin request
-template <>
-void AdminService<ReqSetup, ResSetup>::proceed() {}
+void AdminService<ReqSetup, ResSetup>::proceed() {
+  switch (receive_status) {
+  case AdminRpcCallStatus::CREATE: {
+    receive_status = AdminRpcCallStatus::PROCESS;
+    service->RequestSetup(&context, &req, &responder, completion_queue, completion_queue, this);
+    break;
+  }
+  case AdminRpcCallStatus::PROCESS: {
+    new AdminService<ReqSetup, ResSetup>(service, completion_queue, merger_status, port);
+    auto pass = req.password();
+    bool has_key = false;
+
+    // TODO :  get encrypted sk & cert from `Storage`
+
+    if (!has_key) { // no key info in storage
+      auto user_key_info = runSetup();
+
+      if (!user_key_info.has_value()) {
+        auto enc_sk_pem = json::get<string>(user_key_info.value(), "enc_sk");
+        auto cert = json::get<string>(user_key_info.value(), "cert");
+        if (!enc_sk_pem.has_value() || !cert.has_value())
+          res.set_success(false);
+        else {
+          // TODO : 1. get decrypted sk using password
+          //        2. send  sk & cert to `Storage`
+          merger_status->user_setup = true;
+          res.set_success(true);
+        }
+      }
+    }
+    receive_status = AdminRpcCallStatus::FINISH;
+    responder.Finish(res, Status::OK, this);
+    break;
+  }
+  default:
+    delete this;
+    break;
+  }
+}
 
 template <>
 void AdminService<ReqStart, ResStart>::proceed() {}
@@ -28,19 +106,19 @@ void AdminService<ReqStatus, ResStatus>::proceed() {
   } break;
 
   case AdminRpcCallStatus::PROCESS: {
-    new AdminService(service, completion_queue);
+    new AdminService<ReqStatus, ResStatus>(service, completion_queue, merger_status);
 
-    res.set_alive(true);
+    res.set_alive(merger_status->is_running);
 
-    Status rpc_status = Status::OK;
     receive_status = AdminRpcCallStatus::FINISH;
     responder.Finish(res, Status::OK, this);
   } break;
 
-
-  default: { delete this; } break;
+  default: {
+    delete this;
+  } break;
   }
 }
-  
+
 } // namespace admin_plugin
 } // namespace gruut

--- a/src/plugins/net_plugin/include/message_parser.hpp
+++ b/src/plugins/net_plugin/include/message_parser.hpp
@@ -1,0 +1,103 @@
+#pragma once
+#include "../../../../lib/gruut-utils/src/lz4_compressor.hpp"
+#include "../../../../lib/gruut-utils/src/type_converter.hpp"
+#include "../../../../lib/json/include/json.hpp"
+#include "../config/include/message.hpp"
+#include "msg_schema.hpp"
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace gruut {
+namespace net_plugin {
+
+using namespace std;
+using namespace grpc;
+
+class MessageParser {
+public:
+  optional<InNetMsg> parseMessage(string_view packed_msg, Status &return_rpc_status) {
+    const string raw_header(packed_msg.begin(), packed_msg.begin() + HEADER_LENGTH);
+    auto msg_header = parseHeader(raw_header);
+    if (!validateMsgHdrFormat(msg_header)) {
+      return_rpc_status = Status(StatusCode::INVALID_ARGUMENT, "Bad request (Invalid parameter)");
+      return {};
+    }
+    auto body_size = convertU8ToU32BE(msg_header.total_length) - HEADER_LENGTH;
+    string msg_raw_body(packed_msg.begin() + HEADER_LENGTH, packed_msg.begin() + HEADER_LENGTH + body_size);
+    auto json_body = getJson(msg_header.serialization_algo_type, msg_raw_body);
+
+    if (!JsonValidator::validateSchema(json_body, msg_header.message_type)) {
+      return_rpc_status = Status(StatusCode::INVALID_ARGUMENT, "Bad request (Json schema error)");
+      return {};
+    }
+
+    return_rpc_status = Status::OK;
+
+    InNetMsg in_msg;
+    in_msg.type = msg_header.message_type;
+    in_msg.body = json_body;
+    in_msg.sender_id = TypeConverter::encodeBase<58>(msg_header.sender_id);
+
+    return in_msg;
+  }
+
+private:
+  MessageHeader parseHeader(string_view raw_header) {
+    MessageHeader msg_header;
+
+    int offset = 0;
+    msg_header.identifier = raw_header[offset++];
+    msg_header.version = raw_header[offset++];
+    msg_header.message_type = (MessageType)raw_header[offset++];
+    msg_header.mac_algo_type = (MACAlgorithmType)raw_header[offset++];
+    msg_header.serialization_algo_type = (SerializationAlgorithmType)raw_header[offset++];
+    msg_header.dummy = raw_header[offset++];
+
+    copy(raw_header.begin() + offset, raw_header.begin() + offset + MSG_LENGTH_SIZE, msg_header.total_length.begin());
+    offset += MSG_LENGTH_SIZE;
+    copy(raw_header.begin() + offset, raw_header.begin() + offset + WORLD_ID_TYPE_SIZE, msg_header.world_id.begin());
+    offset += WORLD_ID_TYPE_SIZE;
+    copy(raw_header.begin() + offset, raw_header.begin() + offset + CHAIN_ID_TYPE_SIZE, msg_header.local_chain_id.begin());
+    offset += CHAIN_ID_TYPE_SIZE;
+    copy(raw_header.begin() + offset, raw_header.begin() + offset + SENDER_ID_TYPE_SIZE, msg_header.sender_id.begin());
+    return msg_header;
+  }
+
+  bool validateMsgHdrFormat(MessageHeader &header) {
+    bool check = header.identifier == IDENTIFIER;
+    if (header.mac_algo_type == MACAlgorithmType::HMAC) {
+      check &= (header.message_type == MessageType::MSG_SUCCESS || header.message_type == MessageType::MSG_SSIG ||
+                header.message_type == MessageType::MSG_REQ_TX_CHECK || header.message_type == MessageType::MSG_QUERY ||
+                header.message_type == MessageType::MSG_TX);
+    }
+    return check;
+  }
+
+  int convertU8ToU32BE(array<uint8_t, MSG_LENGTH_SIZE> &len_bytes) {
+    return static_cast<int>(len_bytes[0] << 24 | len_bytes[1] << 16 | len_bytes[2] << 8 | len_bytes[3]);
+  }
+
+  nlohmann::json getJson(SerializationAlgorithmType comperssion_type, string &raw_body) {
+    nlohmann::json unpacked_body;
+    if (!raw_body.empty()) {
+      switch (comperssion_type) {
+      case SerializationAlgorithmType::LZ4: {
+        string origin_data = LZ4Compressor::decompressData(raw_body);
+        unpacked_body = json::parse(origin_data);
+        break;
+      }
+      case SerializationAlgorithmType::NONE: {
+        unpacked_body = json::parse(raw_body);
+        break;
+      }
+      default:
+        break;
+      }
+    }
+    return unpacked_body;
+  }
+};
+} // namespace net_plugin
+}

--- a/src/plugins/net_plugin/rpc_services/rpc_services.cpp
+++ b/src/plugins/net_plugin/rpc_services/rpc_services.cpp
@@ -1,12 +1,12 @@
 #include "include/rpc_services.hpp"
 #include "../../../../lib/gruut-utils/src/hmac.hpp"
-#include "../../../../lib/gruut-utils/src/lz4_compressor.hpp"
 #include "../../../../lib/gruut-utils/src/time_util.hpp"
 #include "../../../../lib/gruut-utils/src/type_converter.hpp"
 #include "../../channel_interface/include/channel_interface.hpp"
 #include "../include/id_mapping_table.hpp"
 #include "../include/message_builder.hpp"
 #include "../include/message_packer.hpp"
+#include "../include/message_parser.hpp"
 #include "../include/signer_pool_manager.hpp"
 #include "application.hpp"
 
@@ -188,91 +188,6 @@ private:
     auto content_len = pem.length() - begin_str.length() - end_str.length();
     auto content = pem.substr(begin_str.length(), content_len);
     return validateEntry(MsgEntryType::BASE64, content);
-  }
-};
-
-class MessageParser {
-public:
-  optional<InNetMsg> parseMessage(string_view packed_msg, Status &return_rpc_status) {
-    const string raw_header(packed_msg.begin(), packed_msg.begin() + HEADER_LENGTH);
-    auto msg_header = parseHeader(raw_header);
-    if (!validateMsgHdrFormat(msg_header)) {
-      return_rpc_status = Status(StatusCode::INVALID_ARGUMENT, "Bad request (Invalid parameter)");
-      return {};
-    }
-    auto body_size = convertU8ToU32BE(msg_header.total_length) - HEADER_LENGTH;
-    string msg_raw_body(packed_msg.begin() + HEADER_LENGTH, packed_msg.begin() + HEADER_LENGTH + body_size);
-    auto json_body = getJson(msg_header.serialization_algo_type, msg_raw_body);
-
-    if (!JsonValidator::validateSchema(json_body, msg_header.message_type)) {
-      return_rpc_status = Status(StatusCode::INVALID_ARGUMENT, "Bad request (Json schema error)");
-      return {};
-    }
-
-    return_rpc_status = Status::OK;
-
-    InNetMsg in_msg;
-    in_msg.type = msg_header.message_type;
-    in_msg.body = json_body;
-    in_msg.sender_id = TypeConverter::encodeBase<58>(msg_header.sender_id);
-
-    return in_msg;
-  }
-
-private:
-  MessageHeader parseHeader(string_view raw_header) {
-    MessageHeader msg_header;
-
-    int offset = 0;
-    msg_header.identifier = raw_header[offset++];
-    msg_header.version = raw_header[offset++];
-    msg_header.message_type = (MessageType)raw_header[offset++];
-    msg_header.mac_algo_type = (MACAlgorithmType)raw_header[offset++];
-    msg_header.serialization_algo_type = (SerializationAlgorithmType)raw_header[offset++];
-    msg_header.dummy = raw_header[offset++];
-
-    copy(raw_header.begin() + offset, raw_header.begin() + offset + MSG_LENGTH_SIZE, msg_header.total_length.begin());
-    offset += MSG_LENGTH_SIZE;
-    copy(raw_header.begin() + offset, raw_header.begin() + offset + WORLD_ID_TYPE_SIZE, msg_header.world_id.begin());
-    offset += WORLD_ID_TYPE_SIZE;
-    copy(raw_header.begin() + offset, raw_header.begin() + offset + CHAIN_ID_TYPE_SIZE, msg_header.local_chain_id.begin());
-    offset += CHAIN_ID_TYPE_SIZE;
-    copy(raw_header.begin() + offset, raw_header.begin() + offset + SENDER_ID_TYPE_SIZE, msg_header.sender_id.begin());
-    return msg_header;
-  }
-
-  bool validateMsgHdrFormat(MessageHeader &header) {
-    bool check = header.identifier == IDENTIFIER;
-    if (header.mac_algo_type == MACAlgorithmType::HMAC) {
-      check &= (header.message_type == MessageType::MSG_SUCCESS || header.message_type == MessageType::MSG_SSIG ||
-                header.message_type == MessageType::MSG_REQ_TX_CHECK || header.message_type == MessageType::MSG_QUERY ||
-                header.message_type == MessageType::MSG_TX);
-    }
-    return check;
-  }
-
-  int convertU8ToU32BE(array<uint8_t, MSG_LENGTH_SIZE> &len_bytes) {
-    return static_cast<int>(len_bytes[0] << 24 | len_bytes[1] << 16 | len_bytes[2] << 8 | len_bytes[3]);
-  }
-
-  nlohmann::json getJson(SerializationAlgorithmType comperssion_type, string &raw_body) {
-    nlohmann::json unpacked_body;
-    if (!raw_body.empty()) {
-      switch (comperssion_type) {
-      case SerializationAlgorithmType::LZ4: {
-        string origin_data = LZ4Compressor::decompressData(raw_body);
-        unpacked_body = json::parse(origin_data);
-        break;
-      }
-      case SerializationAlgorithmType::NONE: {
-        unpacked_body = json::parse(raw_body);
-        break;
-      }
-      default:
-        break;
-      }
-    }
-    return unpacked_body;
   }
 };
 


### PR DESCRIPTION
 ### 추가사항

### admin plugin
- Admin plugin 에서 `setup` 명령을 처리
  - storage에 user의 sk와 cert 정보가 없을 경우:
  - Setup 명령을 받으면 설정한 `setup-port`를 이용해 임시 setup server를
생성합니다. (Sync server이며 User로 부터 정보를 받을 때 까지 block
된 상태를 유지합니다. )  User로 부터 `MSG_MERGER_SETUP` 을 받아 parsing 후 처리

### TODO
- Start / Stop 명령 처리
- storage에서 user key 가 저장되어 있는지 확인 및 받아오기. 
- Setup 여부에 따라 merger 동작 방식 수정 
  - ex) observer mode ,  tracker 접속 유무 등.