### PR TITLE
# ADD - ChainPlugin의 chain을 외부 plugin에서 가져올 수 있도록 구현

### DIFF
--- a/lib/appbase/include/application.hpp
+++ b/lib/appbase/include/application.hpp
@@ -73,7 +73,6 @@ public:
       return *plug_itr->second.get();
     } else {
       registerPlugin<Plugin>();
-
       return *app_plugins_map[ns_removed_name];
     }
   }
@@ -81,6 +80,8 @@ public:
   auto &getIoContext() {
     return *io_context_ptr;
   }
+
+  AbstractPlugin* getPlugin(const string &name) const;
 
   static Application &instance();
 
@@ -114,7 +115,6 @@ private:
   unordered_map<string, shared_ptr<AbstractPlugin>> app_plugins_map;
   unordered_map<std::type_index, shared_ptr<AbstractChannel>> channels;
 
-  vector<shared_ptr<AbstractPlugin>> initialized_plugins;
   unique_ptr<ProgramOptions> program_options;
 
   bool parseProgramOptions(int argc, char **argv);

--- a/src/plugins/block_producer_plugin/block_producer_plugin.cpp
+++ b/src/plugins/block_producer_plugin/block_producer_plugin.cpp
@@ -1,5 +1,6 @@
 #include "include/block_producer_plugin.hpp"
 #include "../../../lib/appbase/include/application.hpp"
+#include "../chain_plugin/include/chain_plugin.hpp"
 #include <boost/asio/steady_timer.hpp>
 
 namespace gruut {
@@ -48,7 +49,11 @@ private:
   }
 
   float calculateDistanceBetweenMergers() {
-    
+    // TODO: a number of producers.
+    const int producersCount = 10;
+    auto& chain = dynamic_cast<ChainPlugin*>(app().getPlugin("ChainPlugin"))->chain();
+
+    return 0.0;
   }
 
 

--- a/src/plugins/chain_plugin/chain_plugin.cpp
+++ b/src/plugins/chain_plugin/chain_plugin.cpp
@@ -268,6 +268,10 @@ void ChainPlugin::asyncFetchTransactionsFromPool() {
   app().getChannel<incoming::channels::transaction_pool::channel_type>().publish(transactions);
 }
 
+Chain& ChainPlugin::chain() {
+  return *(impl->chain);
+}
+
 void ChainPlugin::pluginStart() {
   logger::INFO("ChainPlugin Start");
 

--- a/src/plugins/chain_plugin/include/chain_plugin.hpp
+++ b/src/plugins/chain_plugin/include/chain_plugin.hpp
@@ -43,6 +43,7 @@ public:
 
   void asyncFetchTransactionsFromPool();
 
+  Chain& chain();
 private:
   std::unique_ptr<class ChainPluginImpl> impl;
 };


### PR DESCRIPTION
## 구현사항
- ChainPlugin에 있는 chain의 정보가 필요한 경우가 존재. 구체적으로는 BlockProducerPlugin에서 필요함.
- channel은 비동기로 값을 받아오기 때문에 동기적으로 값을 받아올 수 있어야 하기 때문에 plugin을 get 할 수 있는 함수 구현(Application#getPlugin)
- chain 을 l-reference로 리턴하는 함수 구현(ChainPlugin#chain)
- ChainPlugin <-> BlockProducerPlugin 간 의존성이 존재하는데, config.ini 파일에서 순서를 변경하면 프로그램이 오동작함. 초기화할때 순서 의존성을 제거함.