### PR TITLE
#ADD - handle setup command ( Net - plugin )

### DIFF
--- a/src/plugins/admin_plugin/rpc_services/proto/admin_service.grpc.pb.cc
+++ b/src/plugins/admin_plugin/rpc_services/proto/admin_service.grpc.pb.cc
@@ -2,8 +2,8 @@
 // If you make any local change, they will be lost.
 // source: admin_service.proto
 
-#include "include/admin_service.grpc.pb.h"
 #include "include/admin_service.pb.h"
+#include "include/admin_service.grpc.pb.h"
 
 #include <grpcpp/impl/codegen/async_stream.h>
 #include <grpcpp/impl/codegen/async_unary_call.h>
@@ -47,15 +47,15 @@ GruutAdminService::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& 
   return ::grpc::internal::ClientAsyncResponseReaderFactory< ::grpc_admin::ResSetup>::Create(channel_.get(), cq, rpcmethod_Setup_, context, request, false);
 }
 
-::grpc::Status GruutAdminService::Stub::Start(::grpc::ClientContext* context, const ::grpc_admin::ResStart& request, ::grpc_admin::ResStart* response) {
+::grpc::Status GruutAdminService::Stub::Start(::grpc::ClientContext* context, const ::grpc_admin::ReqStart& request, ::grpc_admin::ResStart* response) {
   return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_Start_, context, request, response);
 }
 
-::grpc::ClientAsyncResponseReader< ::grpc_admin::ResStart>* GruutAdminService::Stub::AsyncStartRaw(::grpc::ClientContext* context, const ::grpc_admin::ResStart& request, ::grpc::CompletionQueue* cq) {
+::grpc::ClientAsyncResponseReader< ::grpc_admin::ResStart>* GruutAdminService::Stub::AsyncStartRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqStart& request, ::grpc::CompletionQueue* cq) {
   return ::grpc::internal::ClientAsyncResponseReaderFactory< ::grpc_admin::ResStart>::Create(channel_.get(), cq, rpcmethod_Start_, context, request, true);
 }
 
-::grpc::ClientAsyncResponseReader< ::grpc_admin::ResStart>* GruutAdminService::Stub::PrepareAsyncStartRaw(::grpc::ClientContext* context, const ::grpc_admin::ResStart& request, ::grpc::CompletionQueue* cq) {
+::grpc::ClientAsyncResponseReader< ::grpc_admin::ResStart>* GruutAdminService::Stub::PrepareAsyncStartRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqStart& request, ::grpc::CompletionQueue* cq) {
   return ::grpc::internal::ClientAsyncResponseReaderFactory< ::grpc_admin::ResStart>::Create(channel_.get(), cq, rpcmethod_Start_, context, request, false);
 }
 
@@ -92,7 +92,7 @@ GruutAdminService::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       GruutAdminService_method_names[1],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
-      new ::grpc::internal::RpcMethodHandler< GruutAdminService::Service, ::grpc_admin::ResStart, ::grpc_admin::ResStart>(
+      new ::grpc::internal::RpcMethodHandler< GruutAdminService::Service, ::grpc_admin::ReqStart, ::grpc_admin::ResStart>(
           std::mem_fn(&GruutAdminService::Service::Start), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       GruutAdminService_method_names[2],
@@ -116,7 +116,7 @@ GruutAdminService::Service::~Service() {
   return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
 }
 
-::grpc::Status GruutAdminService::Service::Start(::grpc::ServerContext* context, const ::grpc_admin::ResStart* request, ::grpc_admin::ResStart* response) {
+::grpc::Status GruutAdminService::Service::Start(::grpc::ServerContext* context, const ::grpc_admin::ReqStart* request, ::grpc_admin::ResStart* response) {
   (void) context;
   (void) request;
   (void) response;

--- a/src/plugins/admin_plugin/rpc_services/proto/admin_service.pb.cc
+++ b/src/plugins/admin_plugin/rpc_services/proto/admin_service.pb.cc
@@ -284,7 +284,7 @@ void AddDescriptorsImpl() {
       "uccess\030\001 \001(\010\"\013\n\tReqStatus\"\032\n\tResStatus\022\r"
       "\n\005alive\030\001 \001(\0102\364\001\n\021GruutAdminService\0225\n\005S"
       "etup\022\024.grpc_admin.ReqSetup\032\024.grpc_admin."
-      "ResSetup\"\000\0225\n\005Start\022\024.grpc_admin.ResStar"
+      "ResSetup\"\000\0225\n\005Start\022\024.grpc_admin.ReqStar"
       "t\032\024.grpc_admin.ResStart\"\000\0222\n\004Stop\022\023.grpc"
       "_admin.ReqStop\032\023.grpc_admin.ResStop\"\000\022=\n"
       "\013CheckStatus\022\025.grpc_admin.ReqStatus\032\025.gr"

--- a/src/plugins/admin_plugin/rpc_services/proto/admin_service.proto
+++ b/src/plugins/admin_plugin/rpc_services/proto/admin_service.proto
@@ -4,7 +4,7 @@ package grpc_admin;
 
 service GruutAdminService {
     rpc Setup (ReqSetup) returns (ResSetup) {}
-    rpc Start (ResStart) returns (ResStart) {}
+    rpc Start (ReqStart) returns (ResStart) {}
     rpc Stop (ReqStop) returns (ResStop) {}
     rpc CheckStatus (ReqStatus) returns (ResStatus) {}
 }

--- a/src/plugins/admin_plugin/rpc_services/proto/include/admin_service.grpc.pb.h
+++ b/src/plugins/admin_plugin/rpc_services/proto/include/admin_service.grpc.pb.h
@@ -41,11 +41,11 @@ class GruutAdminService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResSetup>> PrepareAsyncSetup(::grpc::ClientContext* context, const ::grpc_admin::ReqSetup& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResSetup>>(PrepareAsyncSetupRaw(context, request, cq));
     }
-    virtual ::grpc::Status Start(::grpc::ClientContext* context, const ::grpc_admin::ResStart& request, ::grpc_admin::ResStart* response) = 0;
-    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResStart>> AsyncStart(::grpc::ClientContext* context, const ::grpc_admin::ResStart& request, ::grpc::CompletionQueue* cq) {
+    virtual ::grpc::Status Start(::grpc::ClientContext* context, const ::grpc_admin::ReqStart& request, ::grpc_admin::ResStart* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResStart>> AsyncStart(::grpc::ClientContext* context, const ::grpc_admin::ReqStart& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResStart>>(AsyncStartRaw(context, request, cq));
     }
-    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResStart>> PrepareAsyncStart(::grpc::ClientContext* context, const ::grpc_admin::ResStart& request, ::grpc::CompletionQueue* cq) {
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResStart>> PrepareAsyncStart(::grpc::ClientContext* context, const ::grpc_admin::ReqStart& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResStart>>(PrepareAsyncStartRaw(context, request, cq));
     }
     virtual ::grpc::Status Stop(::grpc::ClientContext* context, const ::grpc_admin::ReqStop& request, ::grpc_admin::ResStop* response) = 0;
@@ -65,8 +65,8 @@ class GruutAdminService final {
   private:
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResSetup>* AsyncSetupRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqSetup& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResSetup>* PrepareAsyncSetupRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqSetup& request, ::grpc::CompletionQueue* cq) = 0;
-    virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResStart>* AsyncStartRaw(::grpc::ClientContext* context, const ::grpc_admin::ResStart& request, ::grpc::CompletionQueue* cq) = 0;
-    virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResStart>* PrepareAsyncStartRaw(::grpc::ClientContext* context, const ::grpc_admin::ResStart& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResStart>* AsyncStartRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqStart& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResStart>* PrepareAsyncStartRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqStart& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResStop>* AsyncStopRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqStop& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResStop>* PrepareAsyncStopRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqStop& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResStatus>* AsyncCheckStatusRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqStatus& request, ::grpc::CompletionQueue* cq) = 0;
@@ -82,11 +82,11 @@ class GruutAdminService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResSetup>> PrepareAsyncSetup(::grpc::ClientContext* context, const ::grpc_admin::ReqSetup& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResSetup>>(PrepareAsyncSetupRaw(context, request, cq));
     }
-    ::grpc::Status Start(::grpc::ClientContext* context, const ::grpc_admin::ResStart& request, ::grpc_admin::ResStart* response) override;
-    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResStart>> AsyncStart(::grpc::ClientContext* context, const ::grpc_admin::ResStart& request, ::grpc::CompletionQueue* cq) {
+    ::grpc::Status Start(::grpc::ClientContext* context, const ::grpc_admin::ReqStart& request, ::grpc_admin::ResStart* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResStart>> AsyncStart(::grpc::ClientContext* context, const ::grpc_admin::ReqStart& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResStart>>(AsyncStartRaw(context, request, cq));
     }
-    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResStart>> PrepareAsyncStart(::grpc::ClientContext* context, const ::grpc_admin::ResStart& request, ::grpc::CompletionQueue* cq) {
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResStart>> PrepareAsyncStart(::grpc::ClientContext* context, const ::grpc_admin::ReqStart& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResStart>>(PrepareAsyncStartRaw(context, request, cq));
     }
     ::grpc::Status Stop(::grpc::ClientContext* context, const ::grpc_admin::ReqStop& request, ::grpc_admin::ResStop* response) override;
@@ -108,8 +108,8 @@ class GruutAdminService final {
     std::shared_ptr< ::grpc::ChannelInterface> channel_;
     ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResSetup>* AsyncSetupRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqSetup& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResSetup>* PrepareAsyncSetupRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqSetup& request, ::grpc::CompletionQueue* cq) override;
-    ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResStart>* AsyncStartRaw(::grpc::ClientContext* context, const ::grpc_admin::ResStart& request, ::grpc::CompletionQueue* cq) override;
-    ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResStart>* PrepareAsyncStartRaw(::grpc::ClientContext* context, const ::grpc_admin::ResStart& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResStart>* AsyncStartRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqStart& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResStart>* PrepareAsyncStartRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqStart& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResStop>* AsyncStopRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqStop& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResStop>* PrepareAsyncStopRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqStop& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResStatus>* AsyncCheckStatusRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqStatus& request, ::grpc::CompletionQueue* cq) override;
@@ -126,7 +126,7 @@ class GruutAdminService final {
     Service();
     virtual ~Service();
     virtual ::grpc::Status Setup(::grpc::ServerContext* context, const ::grpc_admin::ReqSetup* request, ::grpc_admin::ResSetup* response);
-    virtual ::grpc::Status Start(::grpc::ServerContext* context, const ::grpc_admin::ResStart* request, ::grpc_admin::ResStart* response);
+    virtual ::grpc::Status Start(::grpc::ServerContext* context, const ::grpc_admin::ReqStart* request, ::grpc_admin::ResStart* response);
     virtual ::grpc::Status Stop(::grpc::ServerContext* context, const ::grpc_admin::ReqStop* request, ::grpc_admin::ResStop* response);
     virtual ::grpc::Status CheckStatus(::grpc::ServerContext* context, const ::grpc_admin::ReqStatus* request, ::grpc_admin::ResStatus* response);
   };
@@ -162,11 +162,11 @@ class GruutAdminService final {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status Start(::grpc::ServerContext* context, const ::grpc_admin::ResStart* request, ::grpc_admin::ResStart* response) override {
+    ::grpc::Status Start(::grpc::ServerContext* context, const ::grpc_admin::ReqStart* request, ::grpc_admin::ResStart* response) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    void RequestStart(::grpc::ServerContext* context, ::grpc_admin::ResStart* request, ::grpc::ServerAsyncResponseWriter< ::grpc_admin::ResStart>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+    void RequestStart(::grpc::ServerContext* context, ::grpc_admin::ReqStart* request, ::grpc::ServerAsyncResponseWriter< ::grpc_admin::ResStart>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
       ::grpc::Service::RequestAsyncUnary(1, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
@@ -240,7 +240,7 @@ class GruutAdminService final {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status Start(::grpc::ServerContext* context, const ::grpc_admin::ResStart* request, ::grpc_admin::ResStart* response) override {
+    ::grpc::Status Start(::grpc::ServerContext* context, const ::grpc_admin::ReqStart* request, ::grpc_admin::ResStart* response) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
@@ -311,7 +311,7 @@ class GruutAdminService final {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status Start(::grpc::ServerContext* context, const ::grpc_admin::ResStart* request, ::grpc_admin::ResStart* response) override {
+    ::grpc::Status Start(::grpc::ServerContext* context, const ::grpc_admin::ReqStart* request, ::grpc_admin::ResStart* response) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
@@ -386,18 +386,18 @@ class GruutAdminService final {
    public:
     WithStreamedUnaryMethod_Start() {
       ::grpc::Service::MarkMethodStreamed(1,
-        new ::grpc::internal::StreamedUnaryHandler< ::grpc_admin::ResStart, ::grpc_admin::ResStart>(std::bind(&WithStreamedUnaryMethod_Start<BaseClass>::StreamedStart, this, std::placeholders::_1, std::placeholders::_2)));
+        new ::grpc::internal::StreamedUnaryHandler< ::grpc_admin::ReqStart, ::grpc_admin::ResStart>(std::bind(&WithStreamedUnaryMethod_Start<BaseClass>::StreamedStart, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_Start() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable regular version of this method
-    ::grpc::Status Start(::grpc::ServerContext* context, const ::grpc_admin::ResStart* request, ::grpc_admin::ResStart* response) override {
+    ::grpc::Status Start(::grpc::ServerContext* context, const ::grpc_admin::ReqStart* request, ::grpc_admin::ResStart* response) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     // replace default version of method with streamed unary
-    virtual ::grpc::Status StreamedStart(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::grpc_admin::ResStart,::grpc_admin::ResStart>* server_unary_streamer) = 0;
+    virtual ::grpc::Status StreamedStart(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::grpc_admin::ReqStart,::grpc_admin::ResStart>* server_unary_streamer) = 0;
   };
   template <class BaseClass>
   class WithStreamedUnaryMethod_Stop : public BaseClass {

--- a/src/plugins/admin_plugin/rpc_services/rpc_services.cpp
+++ b/src/plugins/admin_plugin/rpc_services/rpc_services.cpp
@@ -56,6 +56,12 @@ void AdminService<ReqSetup, ResSetup>::proceed() {
     break;
   }
   case AdminRpcCallStatus::PROCESS: {
+    if(merger_status->user_setup){
+      res.set_success(true);
+      receive_status = AdminRpcCallStatus::FINISH;
+      responder.Finish(res, Status::OK, this);
+      break;
+    }
     new AdminService<ReqSetup, ResSetup>(service, completion_queue, merger_status, port);
     auto pass = req.password();
     bool has_key = false;
@@ -75,6 +81,8 @@ void AdminService<ReqSetup, ResSetup>::proceed() {
         else {
           // TODO : 1. get decrypted sk using password
           //        2. send  sk & cert to `Storage`
+          auto control_command = NetControlType::SETUP;
+          app().getChannel<incoming::channels::net_control::channel_type>().publish(control_command);
           merger_status->user_setup = true;
           res.set_success(true);
         }

--- a/src/plugins/channel_interface/include/channel_interface.hpp
+++ b/src/plugins/channel_interface/include/channel_interface.hpp
@@ -11,6 +11,7 @@ using namespace std;
 
 namespace appbase::incoming {
 namespace channels {
+using net_control = ChannelTypeTemplate<struct net_control_tag, NetControlType>;
 using network = ChannelTypeTemplate<struct network_tag, InNetMsg>;
 using transaction = ChannelTypeTemplate<struct transaction_tag, nlohmann::json>;
 using block = ChannelTypeTemplate<struct block_tag, nlohmann::json>;

--- a/src/plugins/net_plugin/config/include/network_type.hpp
+++ b/src/plugins/net_plugin/config/include/network_type.hpp
@@ -6,6 +6,13 @@
 
 namespace gruut {
 namespace net_plugin {
+
+enum class NetControlType : int{
+  SETUP,
+  START,
+  STOP
+};
+
 struct IpEndpoint {
   std::string address;
   std::string port;


### PR DESCRIPTION
- Admin plugin 에서 `Setup` 처리가 끝나면, Net plugin 쪽으로 channel을 통해 명령을 보내도록함.
https://thevaulters.atlassian.net/wiki/spaces/SGN/pages/95125611/GP13.+Merger+Setup
- Admin plugin 에서 이미 setup이 완료된 상황이면, key setting 과정을
진행하지 않고 끝냄.

- 기타수정 : admin_service.proto typo 수정 `rpc Start (ResStart)  -> rpc Start (ReqStart)`