### PR TITLE
 # ADD - 최적의 Merger의 ID를 계산 구현

### DIFF
--- a/src/plugins/chain_plugin/chain.cpp
+++ b/src/plugins/chain_plugin/chain.cpp
@@ -95,6 +95,7 @@ vector<Block> Chain::getBlocksByHeight(int from, int to) {
   ss << "block_height BETWEEN " << from << " AND " << to;
 
   vector<Block> blocks = rdb_controller->getBlocks(ss.str());
+  return blocks;
 }
 
 block_height_type Chain::getLatestResolvedHeight() {


### PR DESCRIPTION
## 구현사항
- `calculateDistanceBetweenMergers` 구현
  + 가장 최근에 블록을 만든 Merger ID를 DB에서 가져와서 계산
  + 구체적인 알고리즘은 [링크, 3. Optimal Merger](https://thevaulters.atlassian.net/wiki/spaces/SGN/pages/90832930/PoP+in+Public+Network)에서 참조바람

 Optimal Merger를 구하는 알고리즘이 명세서와 다르게 구현되어있는데 제가 코멘트 남겨놓은 것 확인해주시고 제가 생각한게 맞는지 확인 부탁드립니다.