### PR TITLE
# ADD -   setup  & save user key ( sk, cert)

### DIFF
--- a/src/plugins/admin_plugin/CMakeLists.txt
+++ b/src/plugins/admin_plugin/CMakeLists.txt
@@ -20,10 +20,14 @@ add_library(admin_plugin
         ${HEADERS}
         ${SOURCES})
 
+set(LIB_PREFIX "/usr/local/lib")
+set(BOTAN_LIB "${LIB_PREFIX}/libbotan-2.a")
+
 target_link_libraries(admin_plugin
         appbase
         log
         json
+        ${BOTAN_LIB}
         ${Boost_LIBRARIES}
         ${Protobuf_LIBRARIES}
 

--- a/src/plugins/admin_plugin/rpc_services/include/rpc_services.hpp
+++ b/src/plugins/admin_plugin/rpc_services/include/rpc_services.hpp
@@ -85,6 +85,7 @@ private:
   ServerAsyncResponseWriter<ResSetup> responder;
   optional<nlohmann::json> runSetup(shared_ptr<SetupService> setup_service);
   unique_ptr<Server> initSetup(shared_ptr<SetupService> setup_service);
+  bool checkPassword(const string &enc_sk_pem, const string &pass);
 };
 
 } // namespace admin_plugin

--- a/src/plugins/chain_plugin/chain.cpp
+++ b/src/plugins/chain_plugin/chain.cpp
@@ -118,6 +118,10 @@ void Chain::saveBackup(UnresolvedBlock &block_info) {
   kv_controller->saveBackup(block_info);
 }
 
+void Chain::saveSelfInfo(self_info_type &self_info) {
+  kv_controller->saveSelfInfo(self_info);
+}
+
 string Chain::getValueByKey(DataType what, const string &base_keys) {
   return kv_controller->getValueByKey(what, base_keys);
 }

--- a/src/plugins/chain_plugin/config/storage_config.hpp
+++ b/src/plugins/chain_plugin/config/storage_config.hpp
@@ -40,6 +40,7 @@ namespace config {
         const std::string KV_SUB_DIR_WORLD = "world";
         const std::string KV_SUB_DIR_CHAIN = "chain";
         const std::string KV_SUB_DIR_BACKUP = "backup";
+        const std::string KV_SUB_DIR_SELF_INFO = "self-info";
 
 // clang-format on
 

--- a/src/plugins/chain_plugin/config/storage_type.hpp
+++ b/src/plugins/chain_plugin/config/storage_type.hpp
@@ -7,7 +7,7 @@
 namespace gruut {
 
 enum class LedgerType : bool { USERSCOPE = true, CONTRACTSCOPE = false };
-enum class DataType : int { WORLD, CHAIN, BACKUP };
+enum class DataType : int { WORLD, CHAIN, BACKUP, SELF_INFO };
 
 using string = std::string;
 using bytes = std::vector<uint8_t>;
@@ -79,6 +79,12 @@ using ubp_push_result_type = struct _ubp_push_result_type {
   bool linked;
   bool duplicated;
   block_height_type height;
+};
+
+using self_info_type = struct SelfInfo {
+  string enc_sk;
+  string cert;
+  // TODO : may need more info
 };
 
 } // namespace gruut

--- a/src/plugins/chain_plugin/include/chain.hpp
+++ b/src/plugins/chain_plugin/include/chain.hpp
@@ -35,6 +35,7 @@ public:
   void saveWorld(world_type &world_info);
   void saveChain(local_chain_type &chain_info);
   void saveBackup(UnresolvedBlock &block_info);
+  void saveSelfInfo(self_info_type &self_info);
   vector<Block> getBlocksByHeight(int from, int to);
   block_height_type getLatestResolvedHeight();
   string getValueByKey(DataType what, const string &base_keys);

--- a/src/plugins/chain_plugin/include/kv_store.hpp
+++ b/src/plugins/chain_plugin/include/kv_store.hpp
@@ -30,10 +30,12 @@ private:
   leveldb::DB *m_kv_world;
   leveldb::DB *m_kv_chain;
   leveldb::DB *m_kv_backup;
+  leveldb::DB *m_kv_self_info;
 
   leveldb::WriteBatch m_batch_world;
   leveldb::WriteBatch m_batch_chain;
   leveldb::WriteBatch m_batch_backup;
+  leveldb::WriteBatch m_batch_self_info;
 
 public:
   KvController();
@@ -42,6 +44,7 @@ public:
   bool saveWorld(world_type &world_info);
   bool saveChain(local_chain_type &chain_info);
   bool saveBackup(UnresolvedBlock &block_info);
+  bool saveSelfInfo(self_info_type &self_info);
 
   string getValueByKey(DataType what, const string &base_keys);
 


### PR DESCRIPTION
- chain plugin의 key-value storage(leveldb) 에 self-info( enc-sk, cert )를 저장하도록 함.

- Setup (admin-plugin)
  - setup 과정에서 chain의 leveldb에 `self-info` 가 있을시 이를 활용 하도록 함.
  - password가 맞는지 확인하는 checkPassword() 추가

#### TODO:
- password를 다른 플러그인으로 전달하여, enc-sk-pem을 이용하여 서명을 할 수 있도록 하여여함.
