### PR TITLE
# REFACTOR - kv_store.hpp / cpp

### DIFF
--- a/src/plugins/admin_plugin/CMakeLists.txt
+++ b/src/plugins/admin_plugin/CMakeLists.txt
@@ -23,6 +23,14 @@ add_library(admin_plugin
 set(LIB_PREFIX "/usr/local/lib")
 set(BOTAN_LIB "${LIB_PREFIX}/libbotan-2.a")
 
+find_package(Soci)
+if (SOCI_FOUND)
+    target_link_libraries(admin_plugin ${SOCI_LIBRARY} ${SOCI_mysql_PLUGIN})
+    target_include_directories(admin_plugin PUBLIC ${SOCI_INCLUDE_DIR})
+else (SOCI_FOUND)
+    message(WARNING "SOCI NOT FOUND")
+endif (SOCI_FOUND)
+
 target_link_libraries(admin_plugin
         appbase
         log

--- a/src/plugins/chain_plugin/chain.cpp
+++ b/src/plugins/chain_plugin/chain.cpp
@@ -122,7 +122,7 @@ void Chain::saveSelfInfo(self_info_type &self_info) {
   kv_controller->saveSelfInfo(self_info);
 }
 
-string Chain::getValueByKey(DataType what, const string &base_keys) {
+string Chain::getValueByKey(string what, const string &base_keys) {
   return kv_controller->getValueByKey(what, base_keys);
 }
 

--- a/src/plugins/chain_plugin/config/storage_config.hpp
+++ b/src/plugins/chain_plugin/config/storage_config.hpp
@@ -37,13 +37,19 @@ namespace config {
         const std::string GENESIS_BLOCK_PREV_ID_B58 = "11111111111111111111111111111111";
 
         const std::string DEFAULT_KV_PATH = "./leveldb";
-        const std::string KV_SUB_DIR_WORLD = "world";
-        const std::string KV_SUB_DIR_CHAIN = "chain";
-        const std::string KV_SUB_DIR_BACKUP = "backup";
-        const std::string KV_SUB_DIR_SELF_INFO = "self-info";
 
+        static vector<string> keyValueDBNames() {
+          vector<string> names;
+
+          names.emplace_back(DataType::WORLD);
+          names.emplace_back(DataType::CHAIN);
+          names.emplace_back(DataType::BACKUP);
+          names.emplace_back(DataType::SELF_INFO);
+
+          return names;
+        }
+}
 // clang-format on
 
-} // namespace config
 } // namespace gruut
 #endif

--- a/src/plugins/chain_plugin/config/storage_type.hpp
+++ b/src/plugins/chain_plugin/config/storage_type.hpp
@@ -4,10 +4,17 @@
 #include <string>
 #include <vector>
 
+using namespace std;
+
 namespace gruut {
 
 enum class LedgerType : bool { USERSCOPE = true, CONTRACTSCOPE = false };
-enum class DataType : int { WORLD, CHAIN, BACKUP, SELF_INFO };
+struct DataType {
+  inline static const string WORLD = "world";
+  inline static const string CHAIN = "chain";
+  inline static const string BACKUP = "backup";
+  inline static const string SELF_INFO = "self_info";
+};
 
 using string = std::string;
 using bytes = std::vector<uint8_t>;

--- a/src/plugins/chain_plugin/include/chain.hpp
+++ b/src/plugins/chain_plugin/include/chain.hpp
@@ -38,7 +38,7 @@ public:
   void saveSelfInfo(self_info_type &self_info);
   vector<Block> getBlocksByHeight(int from, int to);
   block_height_type getLatestResolvedHeight();
-  string getValueByKey(DataType what, const string &base_keys);
+  string getValueByKey(string what, const string &base_keys);
 
 private:
   unique_ptr<class ChainImpl> impl;

--- a/src/plugins/chain_plugin/include/kv_store.hpp
+++ b/src/plugins/chain_plugin/include/kv_store.hpp
@@ -14,6 +14,7 @@
 #include <leveldb/write_batch.h>
 
 #include <iostream>
+#include <unordered_map>
 
 using namespace std;
 
@@ -27,15 +28,8 @@ private:
   leveldb::WriteOptions m_write_options;
   leveldb::ReadOptions m_read_options;
 
-  leveldb::DB *m_kv_world;
-  leveldb::DB *m_kv_chain;
-  leveldb::DB *m_kv_backup;
-  leveldb::DB *m_kv_self_info;
-
-  leveldb::WriteBatch m_batch_world;
-  leveldb::WriteBatch m_batch_chain;
-  leveldb::WriteBatch m_batch_backup;
-  leveldb::WriteBatch m_batch_self_info;
+  unordered_map<string, leveldb::DB *> db_map;
+  unordered_map<string, leveldb::WriteBatch> write_batch_map;
 
 public:
   KvController();
@@ -46,7 +40,7 @@ public:
   bool saveBackup(UnresolvedBlock &block_info);
   bool saveSelfInfo(self_info_type &self_info);
 
-  string getValueByKey(DataType what, const string &base_keys);
+  string getValueByKey(string what, const string &base_keys);
 
   std::string readBackup(const std::string &key);
   void flushBackup();
@@ -57,7 +51,7 @@ public:
 
 private:
   bool errorOnCritical(const leveldb::Status &status);
-  bool addBatch(DataType what, const string &base_key, const string &value);
+  bool addBatch(string what, const string &key, const string &value);
   void commitBatchAll();
   void rollbackBatchAll();
   void clearBatchAll();

--- a/src/plugins/chain_plugin/include/rdb_controller.hpp
+++ b/src/plugins/chain_plugin/include/rdb_controller.hpp
@@ -5,7 +5,6 @@
 #include "../config/storage_config.hpp"
 #include "../config/storage_type.hpp"
 #include "../structure/block.hpp"
-#include "mysql/soci-mysql.h"
 #include "soci.h"
 
 #include <vector>

--- a/src/plugins/chain_plugin/rdb_controller.cpp
+++ b/src/plugins/chain_plugin/rdb_controller.cpp
@@ -1,4 +1,5 @@
 #include "include/rdb_controller.hpp"
+#include "mysql/soci-mysql.h"
 
 using namespace std;
 


### PR DESCRIPTION
## 수정사항
- 종전의 코드에서는 `kv_store`에 Type을 하나 추가하게 되면 여러 곳에서 코드를 수정해야 했었음
- 앞으로 Type을 추가하게 되면 코드 복잡도가 높아지게 되고 maintainable 하지 않은 코드가 된다.
- 종전의 코드의 근본적인 문제는 DataType에 의존하면서 `kv_store.hpp/cpp` 에서는 DataType에 대한 case 문으로 모든 걸 처리하고 있었음
- DataType에 대한 의존성 코드를 제거하고 DataType 자체를 kv_store 클래스에 의존성 주입을 하도록 함
- DataType와 연관된 멤버변수를 모두 제거하고 Map으로 관리하게 함
- 앞으로 Type이 추가되면 storage_config, storage_type에만 코드를 수정하면 됨