### PR TITLE
 # EDIT - setup ( Netplugin / AdminPlugin )

### DIFF
--- a/src/plugins/admin_plugin/admin_plugin.cpp
+++ b/src/plugins/admin_plugin/admin_plugin.cpp
@@ -34,12 +34,12 @@ public:
   void initialize() {
     initializeAdminServer();
     registerService();
-
-    merger_status = make_shared<MergerStatus>();
     admin_req_check_timer = make_unique<boost::asio::steady_timer>(app().getIoContext());
   }
 
   void registerService() {
+    merger_status = make_shared<MergerStatus>();
+
     new AdminService<ReqSetup, ResSetup>(&admin_service, completion_queue.get(), merger_status, setup_port);
     new AdminService<ReqStart, ResStart>(&admin_service, completion_queue.get(), merger_status);
     new AdminService<ReqStop, ResStop>(&admin_service, completion_queue.get(), merger_status);

--- a/src/plugins/admin_plugin/rpc_services/include/rpc_services.hpp
+++ b/src/plugins/admin_plugin/rpc_services/include/rpc_services.hpp
@@ -17,8 +17,10 @@ using namespace grpc_user;
 using namespace grpc_admin;
 
 struct MergerStatus {
-  atomic<bool> user_setup{false};
-  atomic<bool> is_running{false};
+  atomic<bool> user_setup;
+  atomic<bool> is_running;
+
+  MergerStatus() : user_setup(false), is_running(true) {}
 };
 
 class SetupService final : public GruutUserService::Service {
@@ -86,6 +88,7 @@ private:
   optional<nlohmann::json> runSetup(shared_ptr<SetupService> setup_service);
   unique_ptr<Server> initSetup(shared_ptr<SetupService> setup_service);
   bool checkPassword(const string &enc_sk_pem, const string &pass);
+  void sendKeyInfoToNet(const string &cert, const string &enc_sk_pem, const string &pass);
 };
 
 } // namespace admin_plugin

--- a/src/plugins/channel_interface/include/channel_interface.hpp
+++ b/src/plugins/channel_interface/include/channel_interface.hpp
@@ -2,8 +2,8 @@
 
 #include "../../../../lib/appbase/include/channel.hpp"
 #include "../../../include/json.hpp"
-#include "../../net_plugin/config/include/message.hpp"
 #include "../../chain_plugin/structure/transaction.hpp"
+#include "../../net_plugin/config/include/message.hpp"
 #include <vector>
 
 using namespace gruut::net_plugin;
@@ -11,7 +11,7 @@ using namespace std;
 
 namespace appbase::incoming {
 namespace channels {
-using net_control = ChannelTypeTemplate<struct net_control_tag, NetControlType>;
+using net_control = ChannelTypeTemplate<struct net_control_tag, nlohmann::json>;
 using network = ChannelTypeTemplate<struct network_tag, InNetMsg>;
 using transaction = ChannelTypeTemplate<struct transaction_tag, nlohmann::json>;
 using block = ChannelTypeTemplate<struct block_tag, nlohmann::json>;

--- a/src/plugins/net_plugin/config/include/network_type.hpp
+++ b/src/plugins/net_plugin/config/include/network_type.hpp
@@ -8,9 +8,9 @@ namespace gruut {
 namespace net_plugin {
 
 enum class NetControlType : int{
-  SETUP,
-  START,
-  STOP
+  SETUP = 1,
+  START = 2,
+  STOP = 3
 };
 
 struct IpEndpoint {

--- a/src/plugins/net_plugin/include/signer_pool_manager.hpp
+++ b/src/plugins/net_plugin/include/signer_pool_manager.hpp
@@ -157,9 +157,8 @@ public:
       auto sn = json::get<string>(msg.body, "sn").value();
       auto mn = temp_signer_pool[msg.sender_id].merger_nonce;
       auto curr_time = TimeUtil::now();
-      // TODO : get sk, sk_pass, cert
-      string my_sk, my_pass, my_cert;
-      auto sig = signMessage(curr_time, mn, sn, dhx, dhy, my_sk, my_pass);
+
+      auto sig = signMessage(curr_time, mn, sn, dhx, dhy, my_enc_sk, my_pass);
       auto msg_response2 = MessageBuilder::build<MessageType::MSG_RESPONSE_2>(curr_time, recv_id_b58, dhx, dhy, my_cert, sig);
 
       return msg_response2;
@@ -198,13 +197,27 @@ public:
   }
 
   optional<vector<uint8_t>> getTempHmacKey(const string &b58_signer_id) {
-    if(temp_signer_pool.count(b58_signer_id) > 0){
+    if (temp_signer_pool.count(b58_signer_id) > 0) {
       return temp_signer_pool[b58_signer_id].shared_sk;
     }
     return {};
   }
 
+  void setSelfKeyInfo(nlohmann::json &key_info) {
+    auto enc_sk = json::get<string>(key_info, "enc_sk");
+    auto cert = json::get<string>(key_info, "cert");
+    auto pass = json::get<string>(key_info, "pass");
+
+    my_enc_sk = enc_sk.value();
+    my_cert = cert.value();
+    my_pass = pass.value();
+  }
+
 private:
+  string my_enc_sk;
+  string my_cert;
+  string my_pass;
+
   bool isJoinable() {
     return signer_pool.full();
   }

--- a/src/plugins/net_plugin/net_plugin.cpp
+++ b/src/plugins/net_plugin/net_plugin.cpp
@@ -365,11 +365,15 @@ public:
     }
   }
 
-  void controlNet(NetControlType &control_type) {
+  void controlNet(nlohmann::json &control_info) {
+    int control_type_int = json::get<int>(control_info, "type").value();
+    NetControlType control_type = static_cast<NetControlType>(control_type_int);
+
     switch (control_type) {
     case NetControlType::SETUP: {
       if(!user_setup_flag) {
         user_setup_flag = true;
+        signer_pool_manager->setSelfKeyInfo(control_info);
         getPeersFromTracker();
         //TODO : do something more
       }


### PR DESCRIPTION
- 초기화가 안된 MergerStatus로 다른 객체들을 초기화 하려고 하여 문제 발생하여, MergerStatus 초기화하는 부분 수정
- setup시 받아온 sk, cert를 net plugin 쪽으로 보내도록 하는 함수 추가
- net_control 채널 수정
  - 기존 enum NetControlType가 아닌 json 으로 수정 (좀 더 복합적으로
데이터를 전송하기위함)

- netplugin 의 signer pool manager에서 sk, cert, pass를 사용할 수 있도록 수정
- netplugin 의 controlNet 함수 수정
  - controlNet(NetControlType) -> controlNet(nlohman::json)
  - json을 받았았을때 처리하도록 수정
