### PR TITLE
 # FIX - Application::getChannel()

### DIFF
--- a/lib/appbase/include/application.hpp
+++ b/lib/appbase/include/application.hpp
@@ -53,14 +53,14 @@ public:
 
   void shutdown();
 
-  template <typename ChannelType>
+  template <typename Channel>
   auto &getChannel() {
-    auto key = type_index(typeid(ChannelType));
+    auto key = type_index(typeid(Channel));
 
-    auto [channel_it, _] = channels.try_emplace(key, std::make_shared<ChannelType>(io_context_ptr));
+    auto [channel_it, _] = channels.try_emplace(key, std::make_shared<typename Channel::channel_type>(io_context_ptr));
 
     auto channel_ptr = channel_it->second.get();
-    return *dynamic_cast<ChannelType *>(channel_ptr);
+    return *dynamic_cast<typename Channel::channel_type *>(channel_ptr);
   }
 
   template <typename Plugin>

--- a/src/plugins/admin_plugin/rpc_services/rpc_services.cpp
+++ b/src/plugins/admin_plugin/rpc_services/rpc_services.cpp
@@ -68,7 +68,7 @@ void AdminService<ReqSetup, ResSetup>::sendKeyInfoToNet(const string &cert, cons
   control_command["cert"] = cert;
   control_command["pass"] = pass;
 
-  app().getChannel<incoming::channels::net_control::channel_type>().publish(control_command);
+  app().getChannel<incoming::channels::net_control>().publish(control_command);
 }
 
 // TODO : handle admin request
@@ -97,8 +97,8 @@ void AdminService<ReqSetup, ResSetup>::proceed() {
       if (checkPassword(self_sk, pass)) {
         merger_status->user_setup = true;
         sendKeyInfoToNet(self_cert, self_sk, pass);
+        res.set_success(true);
       }
-      break;
     } else { // no key info in storage
       shared_ptr<SetupService> setup_service = make_shared<SetupService>();
       unique_ptr<Server> setup_server = initSetup(setup_service);
@@ -127,11 +127,10 @@ void AdminService<ReqSetup, ResSetup>::proceed() {
         setup_server->Shutdown();
       setup_server.reset();
       setup_service.reset();
-
-      receive_status = AdminRpcCallStatus::FINISH;
-      responder.Finish(res, Status::OK, this);
-      break;
     }
+    receive_status = AdminRpcCallStatus::FINISH;
+    responder.Finish(res, Status::OK, this);
+    break;
   }
   default:
     delete this;

--- a/src/plugins/chain_plugin/chain_plugin.cpp
+++ b/src/plugins/chain_plugin/chain_plugin.cpp
@@ -462,11 +462,11 @@ void ChainPlugin::pluginInitialize(const boost::program_options::variables_map &
     throw std::invalid_argument("the input of block input path is empty"s);
   }
 
-  auto &transaction_channel = app().getChannel<incoming::channels::transaction::channel_type>();
+  auto &transaction_channel = app().getChannel<incoming::channels::transaction>();
   impl->incoming_transaction_subscription =
       transaction_channel.subscribe([this](const nlohmann::json &transaction) { impl->pushTransaction(transaction); });
 
-  auto &block_channel = app().getChannel<incoming::channels::block::channel_type>();
+  auto &block_channel = app().getChannel<incoming::channels::block>();
   impl->incoming_block_subscription = block_channel.subscribe([this](const nlohmann::json &block) { impl->pushBlock(block); });
 
   impl->initialize();
@@ -484,7 +484,7 @@ void ChainPlugin::setProgramOptions(options_description &cfg) {
 
 void ChainPlugin::asyncFetchTransactionsFromPool() {
   auto transactions = impl->getTransactions();
-  app().getChannel<incoming::channels::transaction_pool::channel_type>().publish(transactions);
+  app().getChannel<incoming::channels::transaction_pool>().publish(transactions);
 }
 
 Chain &ChainPlugin::chain() {

--- a/src/plugins/channel_interface/include/channel_interface.hpp
+++ b/src/plugins/channel_interface/include/channel_interface.hpp
@@ -15,7 +15,6 @@ using net_control = ChannelTypeTemplate<struct net_control_tag, nlohmann::json>;
 using network = ChannelTypeTemplate<struct network_tag, InNetMsg>;
 using transaction = ChannelTypeTemplate<struct transaction_tag, nlohmann::json>;
 using block = ChannelTypeTemplate<struct block_tag, nlohmann::json>;
-
 using transaction_pool = ChannelTypeTemplate<struct tx_pool_tag, vector<gruut::Transaction>>;
 }; // namespace channels
 } // namespace appbase::incoming
@@ -23,5 +22,5 @@ using transaction_pool = ChannelTypeTemplate<struct tx_pool_tag, vector<gruut::T
 namespace appbase::outgoing {
 namespace channels {
 using network = ChannelTypeTemplate<struct network_tag, OutNetMsg>;
-};
+}; // namespace channels
 } // namespace appbase::outgoing

--- a/src/plugins/net_plugin/net_plugin.cpp
+++ b/src/plugins/net_plugin/net_plugin.cpp
@@ -371,11 +371,11 @@ public:
 
     switch (control_type) {
     case NetControlType::SETUP: {
-      if(!user_setup_flag) {
+      if (!user_setup_flag) {
         user_setup_flag = true;
         signer_pool_manager->setSelfKeyInfo(control_info);
         getPeersFromTracker();
-        //TODO : do something more
+        // TODO : do something more
       }
       break;
     }
@@ -421,10 +421,10 @@ void NetPlugin::pluginInitialize(const variables_map &options) {
     impl->tracker_address = tracker_address;
   }
 
-  auto &out_channel = app().getChannel<outgoing::channels::network::channel_type>();
+  auto &out_channel = app().getChannel<outgoing::channels::network>();
   impl->out_channel_subscription = out_channel.subscribe([this](auto data) { impl->sendMessage(data); });
 
-  auto &net_control_channel = app().getChannel<incoming::channels::net_control::channel_type>();
+  auto &net_control_channel = app().getChannel<incoming::channels::net_control>();
   impl->net_control_channel_subscription = net_control_channel.subscribe([this](auto data) { impl->controlNet(data); });
 
   impl->initialize();

--- a/src/plugins/net_plugin/rpc_services/rpc_services.cpp
+++ b/src/plugins/net_plugin/rpc_services/rpc_services.cpp
@@ -211,10 +211,10 @@ private:
 
     switch (msg.type) {
     case MessageType::MSG_TX:
-      app().getChannel<incoming::channels::transaction::channel_type>().publish(msg.body);
+      app().getChannel<incoming::channels::transaction>().publish(msg.body);
       return {};
     case MessageType::MSG_BLOCK:
-      app().getChannel<incoming::channels::block::channel_type>().publish(msg.body);
+      app().getChannel<incoming::channels::block>().publish(msg.body);
       return {};
     case MessageType::MSG_JOIN:
     case MessageType::MSG_RESPONSE_1:


### PR DESCRIPTION
 #### 문제점
- 기존에 getChannel시 channel_type을 이용하여 생성된 채널을 불러왔음.
- 이때, Channel_type(=`Channel<Data>`) 은 unique 하지 않음. 따라서 Data가
같다면 중복됨. 따라서 문제가 발생하였음.
- 기존에 Data가 nlohmann::json인 channel들이 여러개 있었음 ( net_control, block, transaction )

 #### 해결
- Channel 자체를 typeid로 이용하도록 수정

 #### 기타수정
- AdminPlugin::AdminService<ReqSetup, ResSetup>::proceed()에서 leveldb에
값이 있을 때 console로 reply 하는 부분이 빠져서 수정