### PR TITLE
 # FIX - 최적 Merger ID 계산할때 0이 리턴되는 문제

### DIFF
--- a/src/plugins/chain_plugin/rdb_controller.cpp
+++ b/src/plugins/chain_plugin/rdb_controller.cpp
@@ -99,10 +99,10 @@ bool RdbController::insertTransactionData(gruut::Block &block) {
 vector<Block> RdbController::getBlocks(const string &condition) {
   try {
     soci::session db_session(RdbController::pool());
-    soci::rowset<soci::row> rs = (db_session.prepare << "select * from blocks where " + condition);
 
+    soci::rowset<> rs(db_session.prepare << "select * from blocks where " + condition);
     vector<Block> blocks;
-    blocks.reserve(distance(rs.begin(), rs.end()));
+
     for (auto it = rs.begin(); it != rs.end(); ++it) {
       soci::row const &row = *it;
       Block block = rowToBlock(row);


### PR DESCRIPTION
## 원인
- 계산된 값을 리턴안하고(dist) 0.0을 리턴하고 있었음
- string <-> bitset 타입 convert할때 string의 총 bytes를 bitset에 담을 수 있는게 아니라 8bit, 1byte 에 하나의 character를 담을 수 밖에 없어서 종전의 코드에서는 런타임 에러가 발생함
- soci::rowset::begin() 을 한번 호출하면 Memory로 쿼리 결과값을 fetch하는데, 한번 더 호출하면 memory에 저장된 결과값이 flush 되는 듯한 현상이 발견됨. (rdb_controller.cpp) 실제 구현(begin())을 따라가보니까 두번 호출하면 첫번째 호출에서 fetch한 값이 없어지도록 구현이 되어있음.

## 수정사항
- bitset<256> 을 선언하고 string 값을 담도록 하는 코드를 수정함
  + bitset<8>를 담는 vector를 선언하고, 블록생성자 ID의 문자를 하나씩 담도록 함