### PR TITLE
# FEATURE - [SETUP] get id from certificate

### DIFF
--- a/src/plugins/admin_plugin/rpc_services/include/rpc_services.hpp
+++ b/src/plugins/admin_plugin/rpc_services/include/rpc_services.hpp
@@ -6,6 +6,7 @@
 #include <future>
 #include <grpc/support/log.h>
 #include <grpcpp/grpcpp.h>
+#include <optional>
 
 #include "../../../channel_interface/include/channel_interface.hpp"
 
@@ -89,6 +90,7 @@ private:
   unique_ptr<Server> initSetup(shared_ptr<SetupService> setup_service);
   bool checkPassword(const string &enc_sk_pem, const string &pass);
   void sendKeyInfoToNet(const string &cert, const string &enc_sk_pem, const string &pass);
+  optional<string> getIdFromCert(const string &cert_pem);
 };
 
 } // namespace admin_plugin

--- a/src/plugins/chain_plugin/chain_plugin.cpp
+++ b/src/plugins/chain_plugin/chain_plugin.cpp
@@ -150,6 +150,10 @@ public:
     unresolved_block_pool = make_unique<UnresolvedBlockPool>();
 
     chain->startup(genesis_state);
+
+    auto self_id = chain->getValueByKey(DataType::SELF_INFO, "self_id");
+    if (!self_id.empty())
+      app().setId(self_id);
   }
 
   void pushTransaction(const nlohmann::json &transaction_json) {

--- a/src/plugins/chain_plugin/config/storage_type.hpp
+++ b/src/plugins/chain_plugin/config/storage_type.hpp
@@ -106,6 +106,7 @@ using block_info_type = struct _block_info_type {
 using self_info_type = struct SelfInfo {
   string enc_sk;
   string cert;
+  string id;
   // TODO : may need more info
 };
 

--- a/src/plugins/chain_plugin/kv_store.cpp
+++ b/src/plugins/chain_plugin/kv_store.cpp
@@ -14,7 +14,7 @@ KvController::KvController() {
 
   auto dir_names = config::keyValueDBNames();
   for (auto &dir_name : dir_names) {
-    leveldb::DB* db;
+    leveldb::DB *db;
     errorOnCritical(leveldb::DB::Open(m_options, m_db_path + "/" + dir_name, &db));
     db_map[dir_name] = db;
 
@@ -23,7 +23,7 @@ KvController::KvController() {
 }
 
 KvController::~KvController() {
-  for(auto &[_, db_ptr] : db_map) {
+  for (auto &[_, db_ptr] : db_map) {
     delete db_ptr;
     db_ptr = nullptr;
   }
@@ -124,6 +124,7 @@ bool KvController::saveBackup(UnresolvedBlock &block_info) {
 bool KvController::saveSelfInfo(self_info_type &self_info) {
   addBatch(DataType::SELF_INFO, "self_enc_sk", self_info.enc_sk);
   addBatch(DataType::SELF_INFO, "self_cert", self_info.cert);
+  addBatch(DataType::SELF_INFO, "self_id", self_info.id);
 
   commitBatchAll();
 
@@ -136,7 +137,7 @@ bool KvController::addBatch(string what, const string &key, const string &value)
 }
 
 void KvController::commitBatchAll() {
-  for(auto &[name, db_ptr] : db_map) {
+  for (auto &[name, db_ptr] : db_map) {
     db_ptr->Write(m_write_options, &write_batch_map[name]);
   }
 
@@ -148,7 +149,7 @@ void KvController::rollbackBatchAll() {
 }
 
 void KvController::clearBatchAll() {
-  for(auto &[_, write_batch] : write_batch_map) {
+  for (auto &[_, write_batch] : write_batch_map) {
     write_batch.Clear();
   }
 }

--- a/src/plugins/net_plugin/config/include/network_config.hpp
+++ b/src/plugins/net_plugin/config/include/network_config.hpp
@@ -10,9 +10,6 @@ namespace net_plugin {
 constexpr unsigned int PARALLELISM_ALPHA = 3;
 constexpr auto GENERAL_SERVICE_TIMEOUT = std::chrono::milliseconds(100);
 
-// TODO : MERGER의 ID를 GA로 받아 올 수 있을때 사용치 않을것. (ID : TEST-MERGER-ID-1TEST-MERGER-ID-1 )
-const std::string MY_ID_BASE58 = "6fxZPb2whbwVGUGSSwFW1FnmtqMaXptz8wq7A3dgLyG4";
-const std::string MY_ID = "TEST-MERGER-ID-1TEST-MERGER-ID-1"; // 32bytes
 // TODO : LOCAL CHAIN ID / WORLD ID 에 대해서 정해진 바가 없어 임시 사용 수정될 것.
 const std::string LOCAL_CHAIN_ID = "LCHAINID"; // 8bytes
 const std::string WORLD_ID = "WORLD-ID";       // 8bytes

--- a/src/plugins/net_plugin/include/message_builder.hpp
+++ b/src/plugins/net_plugin/include/message_builder.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../../../../lib/appbase/include/application.hpp"
 #include "../../../../lib/gruut-utils/src/hmac_key_maker.hpp"
 #include "../../../../lib/gruut-utils/src/time_util.hpp"
 #include "../../../../lib/json/include/json.hpp"
@@ -13,6 +14,7 @@
 
 using namespace grpc;
 using namespace std;
+using namespace appbase;
 
 namespace gruut {
 namespace net_plugin {
@@ -26,7 +28,7 @@ public:
 
     msg_body["time"] = TimeUtil::now();
     msg_body["user"] = b58_recv_id;
-    msg_body["merger"] = MY_ID_BASE58;
+    msg_body["merger"] = TypeConverter::encodeBase<58>(app().getId());
     msg_body["mn"] = merger_nonce;
 
     msg_challenge.type = MessageType::MSG_CHALLENGE;
@@ -37,14 +39,15 @@ public:
   }
 
   template <MessageType T, typename = enable_if_t<T == MessageType::MSG_RESPONSE_2>>
-  static auto build(const string &timestamp, const string &b58_recv_id, const string &dhx, const string &dhy, const string &cert, const string &sig) {
+  static auto build(const string &timestamp, const string &b58_recv_id, const string &dhx, const string &dhy, const string &cert,
+                    const string &sig) {
     OutNetMsg msg_response2;
     nlohmann::json msg_body;
 
     msg_body["time"] = timestamp;
     msg_body["dh"]["x"] = dhx;
     msg_body["dh"]["y"] = dhy;
-    msg_body["merger"]["id"] = MY_ID_BASE58;
+    msg_body["merger"]["id"] = TypeConverter::encodeBase<58>(app().getId());
     msg_body["merger"]["cert"] = cert;
     msg_body["merger"]["sig"] = sig;
 

--- a/src/plugins/net_plugin/include/message_packer.hpp
+++ b/src/plugins/net_plugin/include/message_packer.hpp
@@ -51,7 +51,9 @@ private:
     serialized_header.insert(serialized_header.end(), begin(total_length), end(total_length));
     serialized_header.insert(serialized_header.end(), begin(WORLD_ID), end(WORLD_ID));
     serialized_header.insert(serialized_header.end(), begin(LOCAL_CHAIN_ID), end(LOCAL_CHAIN_ID));
-    serialized_header.insert(serialized_header.end(), begin(MY_ID), end(MY_ID));
+
+    auto &my_id = app().getId();
+    serialized_header.insert(serialized_header.end(), my_id.begin(), my_id.end());
     return serialized_header;
   }
 };

--- a/src/plugins/net_plugin/net_plugin.cpp
+++ b/src/plugins/net_plugin/net_plugin.cpp
@@ -74,9 +74,6 @@ public:
 
     connection_check_timer = make_unique<boost::asio::steady_timer>(app().getIoContext());
     net_message_check_timer = make_unique<boost::asio::steady_timer>(app().getIoContext());
-
-    // TODO: GA로부터 ID 받아올 때까지 임시로 ID 지정
-    app().setId(MY_ID_BASE58);
   }
 
   void initializeRoutingTable() {


### PR DESCRIPTION
- Setup 과정에서 얻어온 certificate 로부터 id를 얻어 오도록함. 
  - Certificate의 Common Name이 id가 됨.
  - Common Name은 Base58 형태 이므로 이를 decoding 하여
Application::setId() 하도록 함.
  - [Handle id 참고](https://thevaulters.atlassian.net/wiki/spaces/SGN/pages/91947025/Handling+User+ID+with+Botan-2)

- ChainPlugin의 초기화과정에서 `Self-info`에 id의 정보가 있다면 이때
Application::setId()를 하도록 함.
- 아니라면 `Setup`에서 User로 부터  cert / sk를 받는 과정을 거칠때 하도록 함.

 ##### 기타 수정
- Message Packer에서 Application::getId() 로 MergerId를 얻어
MessageHeader에 넣도록 함.
- Message Builder에서 Application::getId() 로 값을 세팅하도록 함.
- Net Config에서 MY_ID 부분 제거
- Net plugin에서 setID 하던부분 제거
- clang-format