### PR TITLE
# FEATURE - Block 생성하기 전 Signers를 SignerPoolManager에서 가져오기 위한 준비

### DIFF
--- a/src/plugins/block_producer_plugin/block_producer_plugin.cpp
+++ b/src/plugins/block_producer_plugin/block_producer_plugin.cpp
@@ -7,6 +7,8 @@ namespace gruut {
 
 using namespace std;
 
+constexpr int SIGNERS_SIZE = 100;
+
 class BlockProducerPluginImpl {
 public:
   void initialize() {
@@ -70,10 +72,20 @@ private:
 
     bitset<256> id_bits = getOptimalMergerId(blocks, producersCount);
 
-    bitset<256> my_id(app().getId());
+    auto my_id = idToBitSet(app().getId());
     float dist = getHammingDistance(id_bits, my_id);
 
     return dist;
+  }
+
+  bitset<256> idToBitSet(string_view id) {
+    string bits_str;
+
+    for (int i = 0; i < id.size(); ++i) {
+      bits_str += bitset<8>(id[i]).to_string();
+    }
+
+    return bitset<256>(bits_str);
   }
 
   bitset<256> getOptimalMergerId(vector<Block> blocks, const int producers_count) {
@@ -119,7 +131,14 @@ private:
   }
 
   float calculateDistanceBetweenSigners() {
+    const int signers_size = SIGNERS_SIZE;
 
+    auto signer_pool_manager_ptr = dynamic_cast<NetPlugin*>(app().getPlugin("NetPlugin"))->getSignerPoolManager();
+
+    vector<Signer> signers = signer_pool_manager_ptr->getSigners(signers_size);
+    // do something
+
+    return 0.0;
   }
 
   int getHammingDistance(bitset<256> &optimal_merger_id, bitset<256> &my_id) {

--- a/src/plugins/block_producer_plugin/include/block_producer_plugin.hpp
+++ b/src/plugins/block_producer_plugin/include/block_producer_plugin.hpp
@@ -5,6 +5,8 @@
 #include "../../../../lib/log/include/log.hpp"
 #include "../../channel_interface/include/channel_interface.hpp"
 #include "../../chain_plugin/include/chain_plugin.hpp"
+#include "../../net_plugin/include/net_plugin.hpp"
+
 #include "application.hpp"
 #include "plugin.hpp"
 
@@ -13,7 +15,7 @@ using namespace appbase;
 namespace gruut {
 class BlockProducerPlugin : public Plugin<BlockProducerPlugin> {
 public:
-  PLUGIN_REQUIRES((ChainPlugin))
+  PLUGIN_REQUIRES((ChainPlugin)(NetPlugin))
 
   BlockProducerPlugin();
   ~BlockProducerPlugin();

--- a/src/plugins/net_plugin/include/net_plugin.hpp
+++ b/src/plugins/net_plugin/include/net_plugin.hpp
@@ -5,6 +5,7 @@
 #include <memory>
 
 #include "../../channel_interface/include/channel_interface.hpp"
+#include "../include/signer_pool_manager.hpp"
 #include "application.hpp"
 #include "plugin.hpp"
 
@@ -32,6 +33,7 @@ public:
 
   void setProgramOptions(options_description &cfg) override;
 
+  shared_ptr<SignerPoolManager> getSignerPoolManager();
 private:
   std::unique_ptr<class NetPluginImpl> impl;
 };

--- a/src/plugins/net_plugin/include/signer_pool_manager.hpp
+++ b/src/plugins/net_plugin/include/signer_pool_manager.hpp
@@ -83,6 +83,27 @@ public:
     }
   }
 
+  vector<Signer> getSigners(unsigned long size) {
+    {
+      shared_lock<shared_mutex> guard(pool_mutex);
+
+      int signers_count = std::min(size, signer_pool.size());
+
+      vector<Signer> signers;
+      signers.reserve(signers_count);
+      for (auto &[key, value] : signer_pool) {
+          if (signers_count == 0) {
+            break;
+          }
+
+          signers.push_back(value);
+          --signers_count;
+      }
+
+      return signers;
+    }
+  }
+
   bool full() {
     {
       shared_lock<shared_mutex> guard(pool_mutex);
@@ -182,6 +203,10 @@ public:
       throw ErrorMsgType::UNKNOWN;
     }
     }
+  }
+
+  vector<Signer> getSigners(int size) {
+    return signer_pool.getSigners(size);
   }
 
   void removeSigner(const string &b58_signer_id) {

--- a/src/plugins/net_plugin/net_plugin.cpp
+++ b/src/plugins/net_plugin/net_plugin.cpp
@@ -397,6 +397,10 @@ public:
   bool checkUserMsgType(MessageType msg_type) {
     return (msg_type == MessageType::MSG_REQ_SSIG || msg_type == MessageType::MSG_RES_TX_CHECK || msg_type == MessageType::MSG_RESULT);
   }
+
+  shared_ptr<SignerPoolManager> getSignerPoolManager() const {
+    return signer_pool_manager;
+  }
 };
 
 NetPlugin::NetPlugin() : impl(new NetPluginImpl()) {}
@@ -434,6 +438,10 @@ void NetPlugin::pluginStart() {
   logger::INFO("NetPlugin Start");
 
   impl->start();
+}
+
+shared_ptr<SignerPoolManager> NetPlugin::getSignerPoolManager() {
+  return impl->getSignerPoolManager();
 }
 
 NetPlugin::~NetPlugin() {


### PR DESCRIPTION
## 구현사항
- NetPlugin에 Signers 들을 가져올 수 있는 인터페이스를 추가하고, BlockProducerPlugin에서 그 인터페이스를 호출하도록 함
- Merger 간 거리를 계산하는 과정에서 런타임 에러가 발생하여, my_id 로직 수정 (`idToBitSet`)