### PR TITLE
# FIX - 잘못된 거리 계산 수정

### DIFF
--- a/src/plugins/block_producer_plugin/block_producer_plugin.cpp
+++ b/src/plugins/block_producer_plugin/block_producer_plugin.cpp
@@ -151,11 +151,15 @@ private:
           partial_optimal_id_bits[j] =  optimal_signer_id_bits[i * j];
         }
 
-        dist += (getHammingDistance(bits, partial_optimal_id_bits) % 11);
+        dist += exponentialDistance((getHammingDistance(bits, partial_optimal_id_bits) % 11));
       }
     }
 
     return dist;
+  }
+
+  float exponentialDistance(float dist) {
+    return exp(dist) - 1;
   }
 
   bitset<256> getOptimalSignerId(Block &latest_block) {


### PR DESCRIPTION
## 문제
- 2. Time Delay 수식에 의하면 signers 간 distance를 계산하고 exp 연산을 해야 한다.
  + https://thevaulters.atlassian.net/wiki/spaces/SGN/pages/90832930/PoP+in+Public+Network
  + 링크 2장 참조

## 수정
- 수식대로 exp 연산 후 minus 1 하도록 수정