### PR TITLE
 # EDIT - ECDH key exchange service

### DIFF
--- a/src/plugins/net_plugin/rpc_services/rpc_services.cpp
+++ b/src/plugins/net_plugin/rpc_services/rpc_services.cpp
@@ -145,7 +145,7 @@ private:
       return MsgEntryType::BASE58_256;
     else if (key == "block" || key == "proof" || key == "output")
       return MsgEntryType::BASE64;
-    else if (key == "txroot" || key == "usroot" || key == "csroot" || key == "sgroot" || key == "hash" || key == "link")
+    else if (key == "txroot" || key == "usroot" || key == "csroot" || key == "sgroot" || key == "hash" || key == "link" || key == "un")
       return MsgEntryType::BASE64_256;
     else if (key == "sig")
       return MsgEntryType::BASE64_SIG;


### PR DESCRIPTION
- 기존에 Key exchange가 끝난후 Singer pool에 저장하는 Signer의 정보 중
pk 정보가 누락 따라서 추가함.

- MSG_RESPONSE_1 의 항목 중 `sn` -> `un` 으로 수정
- MessageValidator에서 Entry type을 얻기 위해 검사하는 key 종류로 `un`
추가

 #### 기타 
- clang-format 적용