### PR TITLE
# EDIT - Admin service [ SetupKey / Login ] 

### DIFF
--- a/src/plugins/admin_plugin/admin_plugin.cpp
+++ b/src/plugins/admin_plugin/admin_plugin.cpp
@@ -40,9 +40,9 @@ public:
   void registerService() {
     merger_status = make_shared<MergerStatus>();
 
-    new AdminService<ReqSetup, ResSetup>(&admin_service, completion_queue.get(), merger_status, setup_port);
+    new AdminService<ReqSetupKey, ResSetupKey>(&admin_service, completion_queue.get(), merger_status, setup_port);
+    new AdminService<ReqLogin, ResLogin>(&admin_service, completion_queue.get(), merger_status);
     new AdminService<ReqStart, ResStart>(&admin_service, completion_queue.get(), merger_status);
-    new AdminService<ReqStop, ResStop>(&admin_service, completion_queue.get(), merger_status);
     new AdminService<ReqStatus, ResStatus>(&admin_service, completion_queue.get(), merger_status);
   }
 

--- a/src/plugins/admin_plugin/rpc_services/proto/admin_service.grpc.pb.cc
+++ b/src/plugins/admin_plugin/rpc_services/proto/admin_service.grpc.pb.cc
@@ -2,8 +2,8 @@
 // If you make any local change, they will be lost.
 // source: admin_service.proto
 
-#include "include/admin_service.pb.h"
 #include "include/admin_service.grpc.pb.h"
+#include "include/admin_service.pb.h"
 
 #include <grpcpp/impl/codegen/async_stream.h>
 #include <grpcpp/impl/codegen/async_unary_call.h>
@@ -16,9 +16,11 @@
 namespace grpc_admin {
 
 static const char* GruutAdminService_method_names[] = {
-  "/grpc_admin.GruutAdminService/Setup",
+  "/grpc_admin.GruutAdminService/SetupKey",
+  "/grpc_admin.GruutAdminService/Login",
   "/grpc_admin.GruutAdminService/Start",
-  "/grpc_admin.GruutAdminService/Stop",
+  "/grpc_admin.GruutAdminService/LoadWorld",
+  "/grpc_admin.GruutAdminService/LoadChain",
   "/grpc_admin.GruutAdminService/CheckStatus",
 };
 
@@ -29,22 +31,36 @@ std::unique_ptr< GruutAdminService::Stub> GruutAdminService::NewStub(const std::
 }
 
 GruutAdminService::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channel)
-  : channel_(channel), rpcmethod_Setup_(GruutAdminService_method_names[0], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_Start_(GruutAdminService_method_names[1], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_Stop_(GruutAdminService_method_names[2], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_CheckStatus_(GruutAdminService_method_names[3], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  : channel_(channel), rpcmethod_SetupKey_(GruutAdminService_method_names[0], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_Login_(GruutAdminService_method_names[1], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_Start_(GruutAdminService_method_names[2], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_LoadWorld_(GruutAdminService_method_names[3], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_LoadChain_(GruutAdminService_method_names[4], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_CheckStatus_(GruutAdminService_method_names[5], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   {}
 
-::grpc::Status GruutAdminService::Stub::Setup(::grpc::ClientContext* context, const ::grpc_admin::ReqSetup& request, ::grpc_admin::ResSetup* response) {
-  return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_Setup_, context, request, response);
+::grpc::Status GruutAdminService::Stub::SetupKey(::grpc::ClientContext* context, const ::grpc_admin::ReqSetupKey& request, ::grpc_admin::ResSetupKey* response) {
+  return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_SetupKey_, context, request, response);
 }
 
-::grpc::ClientAsyncResponseReader< ::grpc_admin::ResSetup>* GruutAdminService::Stub::AsyncSetupRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqSetup& request, ::grpc::CompletionQueue* cq) {
-  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::grpc_admin::ResSetup>::Create(channel_.get(), cq, rpcmethod_Setup_, context, request, true);
+::grpc::ClientAsyncResponseReader< ::grpc_admin::ResSetupKey>* GruutAdminService::Stub::AsyncSetupKeyRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqSetupKey& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::grpc_admin::ResSetupKey>::Create(channel_.get(), cq, rpcmethod_SetupKey_, context, request, true);
 }
 
-::grpc::ClientAsyncResponseReader< ::grpc_admin::ResSetup>* GruutAdminService::Stub::PrepareAsyncSetupRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqSetup& request, ::grpc::CompletionQueue* cq) {
-  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::grpc_admin::ResSetup>::Create(channel_.get(), cq, rpcmethod_Setup_, context, request, false);
+::grpc::ClientAsyncResponseReader< ::grpc_admin::ResSetupKey>* GruutAdminService::Stub::PrepareAsyncSetupKeyRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqSetupKey& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::grpc_admin::ResSetupKey>::Create(channel_.get(), cq, rpcmethod_SetupKey_, context, request, false);
+}
+
+::grpc::Status GruutAdminService::Stub::Login(::grpc::ClientContext* context, const ::grpc_admin::ReqLogin& request, ::grpc_admin::ResLogin* response) {
+  return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_Login_, context, request, response);
+}
+
+::grpc::ClientAsyncResponseReader< ::grpc_admin::ResLogin>* GruutAdminService::Stub::AsyncLoginRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqLogin& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::grpc_admin::ResLogin>::Create(channel_.get(), cq, rpcmethod_Login_, context, request, true);
+}
+
+::grpc::ClientAsyncResponseReader< ::grpc_admin::ResLogin>* GruutAdminService::Stub::PrepareAsyncLoginRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqLogin& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::grpc_admin::ResLogin>::Create(channel_.get(), cq, rpcmethod_Login_, context, request, false);
 }
 
 ::grpc::Status GruutAdminService::Stub::Start(::grpc::ClientContext* context, const ::grpc_admin::ReqStart& request, ::grpc_admin::ResStart* response) {
@@ -59,16 +75,28 @@ GruutAdminService::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& 
   return ::grpc::internal::ClientAsyncResponseReaderFactory< ::grpc_admin::ResStart>::Create(channel_.get(), cq, rpcmethod_Start_, context, request, false);
 }
 
-::grpc::Status GruutAdminService::Stub::Stop(::grpc::ClientContext* context, const ::grpc_admin::ReqStop& request, ::grpc_admin::ResStop* response) {
-  return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_Stop_, context, request, response);
+::grpc::Status GruutAdminService::Stub::LoadWorld(::grpc::ClientContext* context, const ::grpc_admin::ReqLoadWorld& request, ::grpc_admin::ResLoadWorld* response) {
+  return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_LoadWorld_, context, request, response);
 }
 
-::grpc::ClientAsyncResponseReader< ::grpc_admin::ResStop>* GruutAdminService::Stub::AsyncStopRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqStop& request, ::grpc::CompletionQueue* cq) {
-  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::grpc_admin::ResStop>::Create(channel_.get(), cq, rpcmethod_Stop_, context, request, true);
+::grpc::ClientAsyncResponseReader< ::grpc_admin::ResLoadWorld>* GruutAdminService::Stub::AsyncLoadWorldRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqLoadWorld& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::grpc_admin::ResLoadWorld>::Create(channel_.get(), cq, rpcmethod_LoadWorld_, context, request, true);
 }
 
-::grpc::ClientAsyncResponseReader< ::grpc_admin::ResStop>* GruutAdminService::Stub::PrepareAsyncStopRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqStop& request, ::grpc::CompletionQueue* cq) {
-  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::grpc_admin::ResStop>::Create(channel_.get(), cq, rpcmethod_Stop_, context, request, false);
+::grpc::ClientAsyncResponseReader< ::grpc_admin::ResLoadWorld>* GruutAdminService::Stub::PrepareAsyncLoadWorldRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqLoadWorld& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::grpc_admin::ResLoadWorld>::Create(channel_.get(), cq, rpcmethod_LoadWorld_, context, request, false);
+}
+
+::grpc::Status GruutAdminService::Stub::LoadChain(::grpc::ClientContext* context, const ::grpc_admin::ReqLoadChain& request, ::grpc_admin::ResLoadChain* response) {
+  return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_LoadChain_, context, request, response);
+}
+
+::grpc::ClientAsyncResponseReader< ::grpc_admin::ResLoadChain>* GruutAdminService::Stub::AsyncLoadChainRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqLoadChain& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::grpc_admin::ResLoadChain>::Create(channel_.get(), cq, rpcmethod_LoadChain_, context, request, true);
+}
+
+::grpc::ClientAsyncResponseReader< ::grpc_admin::ResLoadChain>* GruutAdminService::Stub::PrepareAsyncLoadChainRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqLoadChain& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::grpc_admin::ResLoadChain>::Create(channel_.get(), cq, rpcmethod_LoadChain_, context, request, false);
 }
 
 ::grpc::Status GruutAdminService::Stub::CheckStatus(::grpc::ClientContext* context, const ::grpc_admin::ReqStatus& request, ::grpc_admin::ResStatus* response) {
@@ -87,20 +115,30 @@ GruutAdminService::Service::Service() {
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       GruutAdminService_method_names[0],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
-      new ::grpc::internal::RpcMethodHandler< GruutAdminService::Service, ::grpc_admin::ReqSetup, ::grpc_admin::ResSetup>(
-          std::mem_fn(&GruutAdminService::Service::Setup), this)));
+      new ::grpc::internal::RpcMethodHandler< GruutAdminService::Service, ::grpc_admin::ReqSetupKey, ::grpc_admin::ResSetupKey>(
+          std::mem_fn(&GruutAdminService::Service::SetupKey), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       GruutAdminService_method_names[1],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< GruutAdminService::Service, ::grpc_admin::ReqLogin, ::grpc_admin::ResLogin>(
+          std::mem_fn(&GruutAdminService::Service::Login), this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      GruutAdminService_method_names[2],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< GruutAdminService::Service, ::grpc_admin::ReqStart, ::grpc_admin::ResStart>(
           std::mem_fn(&GruutAdminService::Service::Start), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
-      GruutAdminService_method_names[2],
-      ::grpc::internal::RpcMethod::NORMAL_RPC,
-      new ::grpc::internal::RpcMethodHandler< GruutAdminService::Service, ::grpc_admin::ReqStop, ::grpc_admin::ResStop>(
-          std::mem_fn(&GruutAdminService::Service::Stop), this)));
-  AddMethod(new ::grpc::internal::RpcServiceMethod(
       GruutAdminService_method_names[3],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< GruutAdminService::Service, ::grpc_admin::ReqLoadWorld, ::grpc_admin::ResLoadWorld>(
+          std::mem_fn(&GruutAdminService::Service::LoadWorld), this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      GruutAdminService_method_names[4],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< GruutAdminService::Service, ::grpc_admin::ReqLoadChain, ::grpc_admin::ResLoadChain>(
+          std::mem_fn(&GruutAdminService::Service::LoadChain), this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      GruutAdminService_method_names[5],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
       new ::grpc::internal::RpcMethodHandler< GruutAdminService::Service, ::grpc_admin::ReqStatus, ::grpc_admin::ResStatus>(
           std::mem_fn(&GruutAdminService::Service::CheckStatus), this)));
@@ -109,7 +147,14 @@ GruutAdminService::Service::Service() {
 GruutAdminService::Service::~Service() {
 }
 
-::grpc::Status GruutAdminService::Service::Setup(::grpc::ServerContext* context, const ::grpc_admin::ReqSetup* request, ::grpc_admin::ResSetup* response) {
+::grpc::Status GruutAdminService::Service::SetupKey(::grpc::ServerContext* context, const ::grpc_admin::ReqSetupKey* request, ::grpc_admin::ResSetupKey* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status GruutAdminService::Service::Login(::grpc::ServerContext* context, const ::grpc_admin::ReqLogin* request, ::grpc_admin::ResLogin* response) {
   (void) context;
   (void) request;
   (void) response;
@@ -123,7 +168,14 @@ GruutAdminService::Service::~Service() {
   return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
 }
 
-::grpc::Status GruutAdminService::Service::Stop(::grpc::ServerContext* context, const ::grpc_admin::ReqStop* request, ::grpc_admin::ResStop* response) {
+::grpc::Status GruutAdminService::Service::LoadWorld(::grpc::ServerContext* context, const ::grpc_admin::ReqLoadWorld* request, ::grpc_admin::ResLoadWorld* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status GruutAdminService::Service::LoadChain(::grpc::ServerContext* context, const ::grpc_admin::ReqLoadChain* request, ::grpc_admin::ResLoadChain* response) {
   (void) context;
   (void) request;
   (void) response;

--- a/src/plugins/admin_plugin/rpc_services/proto/admin_service.pb.cc
+++ b/src/plugins/admin_plugin/rpc_services/proto/admin_service.pb.cc
@@ -20,16 +20,26 @@
 // @@protoc_insertion_point(includes)
 
 namespace grpc_admin {
-class ReqSetupDefaultTypeInternal {
+class ReqSetupKeyDefaultTypeInternal {
  public:
-  ::google::protobuf::internal::ExplicitlyConstructed<ReqSetup>
+  ::google::protobuf::internal::ExplicitlyConstructed<ReqSetupKey>
       _instance;
-} _ReqSetup_default_instance_;
-class ResSetupDefaultTypeInternal {
+} _ReqSetupKey_default_instance_;
+class ResSetupKeyDefaultTypeInternal {
  public:
-  ::google::protobuf::internal::ExplicitlyConstructed<ResSetup>
+  ::google::protobuf::internal::ExplicitlyConstructed<ResSetupKey>
       _instance;
-} _ResSetup_default_instance_;
+} _ResSetupKey_default_instance_;
+class ReqLoginDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<ReqLogin>
+      _instance;
+} _ReqLogin_default_instance_;
+class ResLoginDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<ResLogin>
+      _instance;
+} _ResLogin_default_instance_;
 class ReqStartDefaultTypeInternal {
  public:
   ::google::protobuf::internal::ExplicitlyConstructed<ReqStart>
@@ -40,16 +50,6 @@ class ResStartDefaultTypeInternal {
   ::google::protobuf::internal::ExplicitlyConstructed<ResStart>
       _instance;
 } _ResStart_default_instance_;
-class ReqStopDefaultTypeInternal {
- public:
-  ::google::protobuf::internal::ExplicitlyConstructed<ReqStop>
-      _instance;
-} _ReqStop_default_instance_;
-class ResStopDefaultTypeInternal {
- public:
-  ::google::protobuf::internal::ExplicitlyConstructed<ResStop>
-      _instance;
-} _ResStop_default_instance_;
 class ReqStatusDefaultTypeInternal {
  public:
   ::google::protobuf::internal::ExplicitlyConstructed<ReqStatus>
@@ -60,35 +60,83 @@ class ResStatusDefaultTypeInternal {
   ::google::protobuf::internal::ExplicitlyConstructed<ResStatus>
       _instance;
 } _ResStatus_default_instance_;
+class ReqLoadWorldDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<ReqLoadWorld>
+      _instance;
+} _ReqLoadWorld_default_instance_;
+class ResLoadWorldDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<ResLoadWorld>
+      _instance;
+} _ResLoadWorld_default_instance_;
+class ReqLoadChainDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<ReqLoadChain>
+      _instance;
+} _ReqLoadChain_default_instance_;
+class ResLoadChainDefaultTypeInternal {
+ public:
+  ::google::protobuf::internal::ExplicitlyConstructed<ResLoadChain>
+      _instance;
+} _ResLoadChain_default_instance_;
 }  // namespace grpc_admin
 namespace protobuf_admin_5fservice_2eproto {
-static void InitDefaultsReqSetup() {
+static void InitDefaultsReqSetupKey() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
   {
-    void* ptr = &::grpc_admin::_ReqSetup_default_instance_;
-    new (ptr) ::grpc_admin::ReqSetup();
+    void* ptr = &::grpc_admin::_ReqSetupKey_default_instance_;
+    new (ptr) ::grpc_admin::ReqSetupKey();
     ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
   }
-  ::grpc_admin::ReqSetup::InitAsDefaultInstance();
+  ::grpc_admin::ReqSetupKey::InitAsDefaultInstance();
 }
 
-::google::protobuf::internal::SCCInfo<0> scc_info_ReqSetup =
-    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsReqSetup}, {}};
+::google::protobuf::internal::SCCInfo<0> scc_info_ReqSetupKey =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsReqSetupKey}, {}};
 
-static void InitDefaultsResSetup() {
+static void InitDefaultsResSetupKey() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
   {
-    void* ptr = &::grpc_admin::_ResSetup_default_instance_;
-    new (ptr) ::grpc_admin::ResSetup();
+    void* ptr = &::grpc_admin::_ResSetupKey_default_instance_;
+    new (ptr) ::grpc_admin::ResSetupKey();
     ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
   }
-  ::grpc_admin::ResSetup::InitAsDefaultInstance();
+  ::grpc_admin::ResSetupKey::InitAsDefaultInstance();
 }
 
-::google::protobuf::internal::SCCInfo<0> scc_info_ResSetup =
-    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsResSetup}, {}};
+::google::protobuf::internal::SCCInfo<0> scc_info_ResSetupKey =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsResSetupKey}, {}};
+
+static void InitDefaultsReqLogin() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::grpc_admin::_ReqLogin_default_instance_;
+    new (ptr) ::grpc_admin::ReqLogin();
+    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::grpc_admin::ReqLogin::InitAsDefaultInstance();
+}
+
+::google::protobuf::internal::SCCInfo<0> scc_info_ReqLogin =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsReqLogin}, {}};
+
+static void InitDefaultsResLogin() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::grpc_admin::_ResLogin_default_instance_;
+    new (ptr) ::grpc_admin::ResLogin();
+    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::grpc_admin::ResLogin::InitAsDefaultInstance();
+}
+
+::google::protobuf::internal::SCCInfo<0> scc_info_ResLogin =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsResLogin}, {}};
 
 static void InitDefaultsReqStart() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
@@ -118,34 +166,6 @@ static void InitDefaultsResStart() {
 ::google::protobuf::internal::SCCInfo<0> scc_info_ResStart =
     {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsResStart}, {}};
 
-static void InitDefaultsReqStop() {
-  GOOGLE_PROTOBUF_VERIFY_VERSION;
-
-  {
-    void* ptr = &::grpc_admin::_ReqStop_default_instance_;
-    new (ptr) ::grpc_admin::ReqStop();
-    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
-  }
-  ::grpc_admin::ReqStop::InitAsDefaultInstance();
-}
-
-::google::protobuf::internal::SCCInfo<0> scc_info_ReqStop =
-    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsReqStop}, {}};
-
-static void InitDefaultsResStop() {
-  GOOGLE_PROTOBUF_VERIFY_VERSION;
-
-  {
-    void* ptr = &::grpc_admin::_ResStop_default_instance_;
-    new (ptr) ::grpc_admin::ResStop();
-    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
-  }
-  ::grpc_admin::ResStop::InitAsDefaultInstance();
-}
-
-::google::protobuf::internal::SCCInfo<0> scc_info_ResStop =
-    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsResStop}, {}};
-
 static void InitDefaultsReqStatus() {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
@@ -174,54 +194,120 @@ static void InitDefaultsResStatus() {
 ::google::protobuf::internal::SCCInfo<0> scc_info_ResStatus =
     {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsResStatus}, {}};
 
-void InitDefaults() {
-  ::google::protobuf::internal::InitSCC(&scc_info_ReqSetup.base);
-  ::google::protobuf::internal::InitSCC(&scc_info_ResSetup.base);
-  ::google::protobuf::internal::InitSCC(&scc_info_ReqStart.base);
-  ::google::protobuf::internal::InitSCC(&scc_info_ResStart.base);
-  ::google::protobuf::internal::InitSCC(&scc_info_ReqStop.base);
-  ::google::protobuf::internal::InitSCC(&scc_info_ResStop.base);
-  ::google::protobuf::internal::InitSCC(&scc_info_ReqStatus.base);
-  ::google::protobuf::internal::InitSCC(&scc_info_ResStatus.base);
+static void InitDefaultsReqLoadWorld() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::grpc_admin::_ReqLoadWorld_default_instance_;
+    new (ptr) ::grpc_admin::ReqLoadWorld();
+    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::grpc_admin::ReqLoadWorld::InitAsDefaultInstance();
 }
 
-::google::protobuf::Metadata file_level_metadata[8];
+::google::protobuf::internal::SCCInfo<0> scc_info_ReqLoadWorld =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsReqLoadWorld}, {}};
+
+static void InitDefaultsResLoadWorld() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::grpc_admin::_ResLoadWorld_default_instance_;
+    new (ptr) ::grpc_admin::ResLoadWorld();
+    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::grpc_admin::ResLoadWorld::InitAsDefaultInstance();
+}
+
+::google::protobuf::internal::SCCInfo<0> scc_info_ResLoadWorld =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsResLoadWorld}, {}};
+
+static void InitDefaultsReqLoadChain() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::grpc_admin::_ReqLoadChain_default_instance_;
+    new (ptr) ::grpc_admin::ReqLoadChain();
+    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::grpc_admin::ReqLoadChain::InitAsDefaultInstance();
+}
+
+::google::protobuf::internal::SCCInfo<0> scc_info_ReqLoadChain =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsReqLoadChain}, {}};
+
+static void InitDefaultsResLoadChain() {
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  {
+    void* ptr = &::grpc_admin::_ResLoadChain_default_instance_;
+    new (ptr) ::grpc_admin::ResLoadChain();
+    ::google::protobuf::internal::OnShutdownDestroyMessage(ptr);
+  }
+  ::grpc_admin::ResLoadChain::InitAsDefaultInstance();
+}
+
+::google::protobuf::internal::SCCInfo<0> scc_info_ResLoadChain =
+    {{ATOMIC_VAR_INIT(::google::protobuf::internal::SCCInfoBase::kUninitialized), 0, InitDefaultsResLoadChain}, {}};
+
+void InitDefaults() {
+  ::google::protobuf::internal::InitSCC(&scc_info_ReqSetupKey.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_ResSetupKey.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_ReqLogin.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_ResLogin.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_ReqStart.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_ResStart.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_ReqStatus.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_ResStatus.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_ReqLoadWorld.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_ResLoadWorld.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_ReqLoadChain.base);
+  ::google::protobuf::internal::InitSCC(&scc_info_ResLoadChain.base);
+}
+
+::google::protobuf::Metadata file_level_metadata[12];
+const ::google::protobuf::EnumDescriptor* file_level_enum_descriptors[1];
 
 const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
   ~0u,  // no _has_bits_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_admin::ReqSetup, _internal_metadata_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_admin::ReqSetupKey, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_admin::ReqSetup, password_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_admin::ReqSetupKey, setup_port_),
   ~0u,  // no _has_bits_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_admin::ResSetup, _internal_metadata_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_admin::ResSetupKey, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_admin::ResSetup, success_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_admin::ResSetupKey, success_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_admin::ResSetupKey, info_),
+  ~0u,  // no _has_bits_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_admin::ReqLogin, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_admin::ReqLogin, password_),
+  ~0u,  // no _has_bits_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_admin::ResLogin, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_admin::ResLogin, success_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_admin::ResLogin, info_),
   ~0u,  // no _has_bits_
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_admin::ReqStart, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_admin::ReqStart, mode_),
   ~0u,  // no _has_bits_
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_admin::ResStart, _internal_metadata_),
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_admin::ResStart, success_),
-  ~0u,  // no _has_bits_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_admin::ReqStop, _internal_metadata_),
-  ~0u,  // no _extensions_
-  ~0u,  // no _oneof_case_
-  ~0u,  // no _weak_field_map_
-  ~0u,  // no _has_bits_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_admin::ResStop, _internal_metadata_),
-  ~0u,  // no _extensions_
-  ~0u,  // no _oneof_case_
-  ~0u,  // no _weak_field_map_
-  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_admin::ResStop, success_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_admin::ResStart, info_),
   ~0u,  // no _has_bits_
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_admin::ReqStatus, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -233,34 +319,66 @@ const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUT
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_admin::ResStatus, alive_),
+  ~0u,  // no _has_bits_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_admin::ReqLoadWorld, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  ~0u,  // no _has_bits_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_admin::ResLoadWorld, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_admin::ResLoadWorld, success_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_admin::ResLoadWorld, info_),
+  ~0u,  // no _has_bits_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_admin::ReqLoadChain, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  ~0u,  // no _has_bits_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_admin::ResLoadChain, _internal_metadata_),
+  ~0u,  // no _extensions_
+  ~0u,  // no _oneof_case_
+  ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_admin::ResLoadChain, success_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_admin::ResLoadChain, info_),
 };
 static const ::google::protobuf::internal::MigrationSchema schemas[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
-  { 0, -1, sizeof(::grpc_admin::ReqSetup)},
-  { 6, -1, sizeof(::grpc_admin::ResSetup)},
-  { 12, -1, sizeof(::grpc_admin::ReqStart)},
-  { 17, -1, sizeof(::grpc_admin::ResStart)},
-  { 23, -1, sizeof(::grpc_admin::ReqStop)},
-  { 28, -1, sizeof(::grpc_admin::ResStop)},
-  { 34, -1, sizeof(::grpc_admin::ReqStatus)},
-  { 39, -1, sizeof(::grpc_admin::ResStatus)},
+  { 0, -1, sizeof(::grpc_admin::ReqSetupKey)},
+  { 6, -1, sizeof(::grpc_admin::ResSetupKey)},
+  { 13, -1, sizeof(::grpc_admin::ReqLogin)},
+  { 19, -1, sizeof(::grpc_admin::ResLogin)},
+  { 26, -1, sizeof(::grpc_admin::ReqStart)},
+  { 32, -1, sizeof(::grpc_admin::ResStart)},
+  { 39, -1, sizeof(::grpc_admin::ReqStatus)},
+  { 44, -1, sizeof(::grpc_admin::ResStatus)},
+  { 50, -1, sizeof(::grpc_admin::ReqLoadWorld)},
+  { 55, -1, sizeof(::grpc_admin::ResLoadWorld)},
+  { 62, -1, sizeof(::grpc_admin::ReqLoadChain)},
+  { 67, -1, sizeof(::grpc_admin::ResLoadChain)},
 };
 
 static ::google::protobuf::Message const * const file_default_instances[] = {
-  reinterpret_cast<const ::google::protobuf::Message*>(&::grpc_admin::_ReqSetup_default_instance_),
-  reinterpret_cast<const ::google::protobuf::Message*>(&::grpc_admin::_ResSetup_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::grpc_admin::_ReqSetupKey_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::grpc_admin::_ResSetupKey_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::grpc_admin::_ReqLogin_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::grpc_admin::_ResLogin_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::grpc_admin::_ReqStart_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::grpc_admin::_ResStart_default_instance_),
-  reinterpret_cast<const ::google::protobuf::Message*>(&::grpc_admin::_ReqStop_default_instance_),
-  reinterpret_cast<const ::google::protobuf::Message*>(&::grpc_admin::_ResStop_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::grpc_admin::_ReqStatus_default_instance_),
   reinterpret_cast<const ::google::protobuf::Message*>(&::grpc_admin::_ResStatus_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::grpc_admin::_ReqLoadWorld_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::grpc_admin::_ResLoadWorld_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::grpc_admin::_ReqLoadChain_default_instance_),
+  reinterpret_cast<const ::google::protobuf::Message*>(&::grpc_admin::_ResLoadChain_default_instance_),
 };
 
 void protobuf_AssignDescriptors() {
   AddDescriptors();
   AssignDescriptors(
       "admin_service.proto", schemas, file_default_instances, TableStruct::offsets,
-      file_level_metadata, NULL, NULL);
+      file_level_metadata, file_level_enum_descriptors, NULL);
 }
 
 void protobuf_AssignDescriptorsOnce() {
@@ -271,27 +389,38 @@ void protobuf_AssignDescriptorsOnce() {
 void protobuf_RegisterTypes(const ::std::string&) GOOGLE_PROTOBUF_ATTRIBUTE_COLD;
 void protobuf_RegisterTypes(const ::std::string&) {
   protobuf_AssignDescriptorsOnce();
-  ::google::protobuf::internal::RegisterAllTypes(file_level_metadata, 8);
+  ::google::protobuf::internal::RegisterAllTypes(file_level_metadata, 12);
 }
 
 void AddDescriptorsImpl() {
   InitDefaults();
   static const char descriptor[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
-      "\n\023admin_service.proto\022\ngrpc_admin\"\034\n\010Req"
-      "Setup\022\020\n\010password\030\001 \001(\t\"\033\n\010ResSetup\022\017\n\007s"
-      "uccess\030\001 \001(\010\"\n\n\010ReqStart\"\033\n\010ResStart\022\017\n\007"
-      "success\030\001 \001(\010\"\t\n\007ReqStop\"\032\n\007ResStop\022\017\n\007s"
-      "uccess\030\001 \001(\010\"\013\n\tReqStatus\"\032\n\tResStatus\022\r"
-      "\n\005alive\030\001 \001(\0102\364\001\n\021GruutAdminService\0225\n\005S"
-      "etup\022\024.grpc_admin.ReqSetup\032\024.grpc_admin."
-      "ResSetup\"\000\0225\n\005Start\022\024.grpc_admin.ReqStar"
-      "t\032\024.grpc_admin.ResStart\"\000\0222\n\004Stop\022\023.grpc"
-      "_admin.ReqStop\032\023.grpc_admin.ResStop\"\000\022=\n"
-      "\013CheckStatus\022\025.grpc_admin.ReqStatus\032\025.gr"
-      "pc_admin.ResStatus\"\000b\006proto3"
+      "\n\023admin_service.proto\022\ngrpc_admin\"!\n\013Req"
+      "SetupKey\022\022\n\nsetup_port\030\001 \001(\t\",\n\013ResSetup"
+      "Key\022\017\n\007success\030\001 \001(\010\022\014\n\004info\030\002 \001(\t\"\034\n\010Re"
+      "qLogin\022\020\n\010password\030\001 \001(\t\")\n\010ResLogin\022\017\n\007"
+      "success\030\001 \001(\010\022\014\n\004info\030\002 \001(\t\"U\n\010ReqStart\022"
+      "\'\n\004mode\030\001 \001(\0162\031.grpc_admin.ReqStart.Mode"
+      "\" \n\004Mode\022\013\n\007DEFAULT\020\000\022\013\n\007MONITOR\020\001\")\n\010Re"
+      "sStart\022\017\n\007success\030\001 \001(\010\022\014\n\004info\030\002 \001(\t\"\013\n"
+      "\tReqStatus\"\032\n\tResStatus\022\r\n\005alive\030\001 \001(\010\"\016"
+      "\n\014ReqLoadWorld\"-\n\014ResLoadWorld\022\017\n\007succes"
+      "s\030\001 \001(\010\022\014\n\004info\030\002 \001(\t\"\016\n\014ReqLoadChain\"-\n"
+      "\014ResLoadChain\022\017\n\007success\030\001 \001(\010\022\014\n\004info\030\002"
+      " \001(\t2\206\003\n\021GruutAdminService\022>\n\010SetupKey\022\027"
+      ".grpc_admin.ReqSetupKey\032\027.grpc_admin.Res"
+      "SetupKey\"\000\0225\n\005Login\022\024.grpc_admin.ReqLogi"
+      "n\032\024.grpc_admin.ResLogin\"\000\0225\n\005Start\022\024.grp"
+      "c_admin.ReqStart\032\024.grpc_admin.ResStart\"\000"
+      "\022A\n\tLoadWorld\022\030.grpc_admin.ReqLoadWorld\032"
+      "\030.grpc_admin.ResLoadWorld\"\000\022A\n\tLoadChain"
+      "\022\030.grpc_admin.ReqLoadChain\032\030.grpc_admin."
+      "ResLoadChain\"\000\022=\n\013CheckStatus\022\025.grpc_adm"
+      "in.ReqStatus\032\025.grpc_admin.ResStatus\"\000b\006p"
+      "roto3"
   };
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
-      descriptor, 468);
+      descriptor, 885);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "admin_service.proto", &protobuf_RegisterTypes);
 }
@@ -308,90 +437,111 @@ struct StaticDescriptorInitializer {
 } static_descriptor_initializer;
 }  // namespace protobuf_admin_5fservice_2eproto
 namespace grpc_admin {
+const ::google::protobuf::EnumDescriptor* ReqStart_Mode_descriptor() {
+  protobuf_admin_5fservice_2eproto::protobuf_AssignDescriptorsOnce();
+  return protobuf_admin_5fservice_2eproto::file_level_enum_descriptors[0];
+}
+bool ReqStart_Mode_IsValid(int value) {
+  switch (value) {
+    case 0:
+    case 1:
+      return true;
+    default:
+      return false;
+  }
+}
+
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+const ReqStart_Mode ReqStart::DEFAULT;
+const ReqStart_Mode ReqStart::MONITOR;
+const ReqStart_Mode ReqStart::Mode_MIN;
+const ReqStart_Mode ReqStart::Mode_MAX;
+const int ReqStart::Mode_ARRAYSIZE;
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 // ===================================================================
 
-void ReqSetup::InitAsDefaultInstance() {
+void ReqSetupKey::InitAsDefaultInstance() {
 }
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
-const int ReqSetup::kPasswordFieldNumber;
+const int ReqSetupKey::kSetupPortFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
-ReqSetup::ReqSetup()
+ReqSetupKey::ReqSetupKey()
   : ::google::protobuf::Message(), _internal_metadata_(NULL) {
   ::google::protobuf::internal::InitSCC(
-      &protobuf_admin_5fservice_2eproto::scc_info_ReqSetup.base);
+      &protobuf_admin_5fservice_2eproto::scc_info_ReqSetupKey.base);
   SharedCtor();
-  // @@protoc_insertion_point(constructor:grpc_admin.ReqSetup)
+  // @@protoc_insertion_point(constructor:grpc_admin.ReqSetupKey)
 }
-ReqSetup::ReqSetup(const ReqSetup& from)
+ReqSetupKey::ReqSetupKey(const ReqSetupKey& from)
   : ::google::protobuf::Message(),
       _internal_metadata_(NULL) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
-  password_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
-  if (from.password().size() > 0) {
-    password_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.password_);
+  setup_port_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.setup_port().size() > 0) {
+    setup_port_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.setup_port_);
   }
-  // @@protoc_insertion_point(copy_constructor:grpc_admin.ReqSetup)
+  // @@protoc_insertion_point(copy_constructor:grpc_admin.ReqSetupKey)
 }
 
-void ReqSetup::SharedCtor() {
-  password_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+void ReqSetupKey::SharedCtor() {
+  setup_port_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 
-ReqSetup::~ReqSetup() {
-  // @@protoc_insertion_point(destructor:grpc_admin.ReqSetup)
+ReqSetupKey::~ReqSetupKey() {
+  // @@protoc_insertion_point(destructor:grpc_admin.ReqSetupKey)
   SharedDtor();
 }
 
-void ReqSetup::SharedDtor() {
-  password_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+void ReqSetupKey::SharedDtor() {
+  setup_port_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 
-void ReqSetup::SetCachedSize(int size) const {
+void ReqSetupKey::SetCachedSize(int size) const {
   _cached_size_.Set(size);
 }
-const ::google::protobuf::Descriptor* ReqSetup::descriptor() {
+const ::google::protobuf::Descriptor* ReqSetupKey::descriptor() {
   ::protobuf_admin_5fservice_2eproto::protobuf_AssignDescriptorsOnce();
   return ::protobuf_admin_5fservice_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
 }
 
-const ReqSetup& ReqSetup::default_instance() {
-  ::google::protobuf::internal::InitSCC(&protobuf_admin_5fservice_2eproto::scc_info_ReqSetup.base);
+const ReqSetupKey& ReqSetupKey::default_instance() {
+  ::google::protobuf::internal::InitSCC(&protobuf_admin_5fservice_2eproto::scc_info_ReqSetupKey.base);
   return *internal_default_instance();
 }
 
 
-void ReqSetup::Clear() {
-// @@protoc_insertion_point(message_clear_start:grpc_admin.ReqSetup)
+void ReqSetupKey::Clear() {
+// @@protoc_insertion_point(message_clear_start:grpc_admin.ReqSetupKey)
   ::google::protobuf::uint32 cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
-  password_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  setup_port_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   _internal_metadata_.Clear();
 }
 
-bool ReqSetup::MergePartialFromCodedStream(
+bool ReqSetupKey::MergePartialFromCodedStream(
     ::google::protobuf::io::CodedInputStream* input) {
 #define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
   ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:grpc_admin.ReqSetup)
+  // @@protoc_insertion_point(parse_start:grpc_admin.ReqSetupKey)
   for (;;) {
     ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
     tag = p.first;
     if (!p.second) goto handle_unusual;
     switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // string password = 1;
+      // string setup_port = 1;
       case 1: {
         if (static_cast< ::google::protobuf::uint8>(tag) ==
             static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadString(
-                input, this->mutable_password()));
+                input, this->mutable_setup_port()));
           DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
-            this->password().data(), static_cast<int>(this->password().length()),
+            this->setup_port().data(), static_cast<int>(this->setup_port().length()),
             ::google::protobuf::internal::WireFormatLite::PARSE,
-            "grpc_admin.ReqSetup.password"));
+            "grpc_admin.ReqSetupKey.setup_port"));
         } else {
           goto handle_unusual;
         }
@@ -410,65 +560,65 @@ bool ReqSetup::MergePartialFromCodedStream(
     }
   }
 success:
-  // @@protoc_insertion_point(parse_success:grpc_admin.ReqSetup)
+  // @@protoc_insertion_point(parse_success:grpc_admin.ReqSetupKey)
   return true;
 failure:
-  // @@protoc_insertion_point(parse_failure:grpc_admin.ReqSetup)
+  // @@protoc_insertion_point(parse_failure:grpc_admin.ReqSetupKey)
   return false;
 #undef DO_
 }
 
-void ReqSetup::SerializeWithCachedSizes(
+void ReqSetupKey::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:grpc_admin.ReqSetup)
+  // @@protoc_insertion_point(serialize_start:grpc_admin.ReqSetupKey)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // string password = 1;
-  if (this->password().size() > 0) {
+  // string setup_port = 1;
+  if (this->setup_port().size() > 0) {
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
-      this->password().data(), static_cast<int>(this->password().length()),
+      this->setup_port().data(), static_cast<int>(this->setup_port().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "grpc_admin.ReqSetup.password");
+      "grpc_admin.ReqSetupKey.setup_port");
     ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
-      1, this->password(), output);
+      1, this->setup_port(), output);
   }
 
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
   }
-  // @@protoc_insertion_point(serialize_end:grpc_admin.ReqSetup)
+  // @@protoc_insertion_point(serialize_end:grpc_admin.ReqSetupKey)
 }
 
-::google::protobuf::uint8* ReqSetup::InternalSerializeWithCachedSizesToArray(
+::google::protobuf::uint8* ReqSetupKey::InternalSerializeWithCachedSizesToArray(
     bool deterministic, ::google::protobuf::uint8* target) const {
   (void)deterministic; // Unused
-  // @@protoc_insertion_point(serialize_to_array_start:grpc_admin.ReqSetup)
+  // @@protoc_insertion_point(serialize_to_array_start:grpc_admin.ReqSetupKey)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  // string password = 1;
-  if (this->password().size() > 0) {
+  // string setup_port = 1;
+  if (this->setup_port().size() > 0) {
     ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
-      this->password().data(), static_cast<int>(this->password().length()),
+      this->setup_port().data(), static_cast<int>(this->setup_port().length()),
       ::google::protobuf::internal::WireFormatLite::SERIALIZE,
-      "grpc_admin.ReqSetup.password");
+      "grpc_admin.ReqSetupKey.setup_port");
     target =
       ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
-        1, this->password(), target);
+        1, this->setup_port(), target);
   }
 
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:grpc_admin.ReqSetup)
+  // @@protoc_insertion_point(serialize_to_array_end:grpc_admin.ReqSetupKey)
   return target;
 }
 
-size_t ReqSetup::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:grpc_admin.ReqSetup)
+size_t ReqSetupKey::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:grpc_admin.ReqSetupKey)
   size_t total_size = 0;
 
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
@@ -476,11 +626,11 @@ size_t ReqSetup::ByteSizeLong() const {
       ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
   }
-  // string password = 1;
-  if (this->password().size() > 0) {
+  // string setup_port = 1;
+  if (this->setup_port().size() > 0) {
     total_size += 1 +
       ::google::protobuf::internal::WireFormatLite::StringSize(
-        this->password());
+        this->setup_port());
   }
 
   int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
@@ -488,64 +638,64 @@ size_t ReqSetup::ByteSizeLong() const {
   return total_size;
 }
 
-void ReqSetup::MergeFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:grpc_admin.ReqSetup)
+void ReqSetupKey::MergeFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:grpc_admin.ReqSetupKey)
   GOOGLE_DCHECK_NE(&from, this);
-  const ReqSetup* source =
-      ::google::protobuf::internal::DynamicCastToGenerated<const ReqSetup>(
+  const ReqSetupKey* source =
+      ::google::protobuf::internal::DynamicCastToGenerated<const ReqSetupKey>(
           &from);
   if (source == NULL) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_admin.ReqSetup)
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_admin.ReqSetupKey)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_admin.ReqSetup)
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_admin.ReqSetupKey)
     MergeFrom(*source);
   }
 }
 
-void ReqSetup::MergeFrom(const ReqSetup& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:grpc_admin.ReqSetup)
+void ReqSetupKey::MergeFrom(const ReqSetupKey& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:grpc_admin.ReqSetupKey)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
-  if (from.password().size() > 0) {
+  if (from.setup_port().size() > 0) {
 
-    password_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.password_);
+    setup_port_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.setup_port_);
   }
 }
 
-void ReqSetup::CopyFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:grpc_admin.ReqSetup)
+void ReqSetupKey::CopyFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:grpc_admin.ReqSetupKey)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-void ReqSetup::CopyFrom(const ReqSetup& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:grpc_admin.ReqSetup)
+void ReqSetupKey::CopyFrom(const ReqSetupKey& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:grpc_admin.ReqSetupKey)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-bool ReqSetup::IsInitialized() const {
+bool ReqSetupKey::IsInitialized() const {
   return true;
 }
 
-void ReqSetup::Swap(ReqSetup* other) {
+void ReqSetupKey::Swap(ReqSetupKey* other) {
   if (other == this) return;
   InternalSwap(other);
 }
-void ReqSetup::InternalSwap(ReqSetup* other) {
+void ReqSetupKey::InternalSwap(ReqSetupKey* other) {
   using std::swap;
-  password_.Swap(&other->password_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+  setup_port_.Swap(&other->setup_port_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
     GetArenaNoVirtual());
   _internal_metadata_.Swap(&other->_internal_metadata_);
 }
 
-::google::protobuf::Metadata ReqSetup::GetMetadata() const {
+::google::protobuf::Metadata ReqSetupKey::GetMetadata() const {
   protobuf_admin_5fservice_2eproto::protobuf_AssignDescriptorsOnce();
   return ::protobuf_admin_5fservice_2eproto::file_level_metadata[kIndexInFileMessages];
 }
@@ -553,68 +703,76 @@ void ReqSetup::InternalSwap(ReqSetup* other) {
 
 // ===================================================================
 
-void ResSetup::InitAsDefaultInstance() {
+void ResSetupKey::InitAsDefaultInstance() {
 }
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
-const int ResSetup::kSuccessFieldNumber;
+const int ResSetupKey::kSuccessFieldNumber;
+const int ResSetupKey::kInfoFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
-ResSetup::ResSetup()
+ResSetupKey::ResSetupKey()
   : ::google::protobuf::Message(), _internal_metadata_(NULL) {
   ::google::protobuf::internal::InitSCC(
-      &protobuf_admin_5fservice_2eproto::scc_info_ResSetup.base);
+      &protobuf_admin_5fservice_2eproto::scc_info_ResSetupKey.base);
   SharedCtor();
-  // @@protoc_insertion_point(constructor:grpc_admin.ResSetup)
+  // @@protoc_insertion_point(constructor:grpc_admin.ResSetupKey)
 }
-ResSetup::ResSetup(const ResSetup& from)
+ResSetupKey::ResSetupKey(const ResSetupKey& from)
   : ::google::protobuf::Message(),
       _internal_metadata_(NULL) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  info_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.info().size() > 0) {
+    info_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.info_);
+  }
   success_ = from.success_;
-  // @@protoc_insertion_point(copy_constructor:grpc_admin.ResSetup)
+  // @@protoc_insertion_point(copy_constructor:grpc_admin.ResSetupKey)
 }
 
-void ResSetup::SharedCtor() {
+void ResSetupKey::SharedCtor() {
+  info_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   success_ = false;
 }
 
-ResSetup::~ResSetup() {
-  // @@protoc_insertion_point(destructor:grpc_admin.ResSetup)
+ResSetupKey::~ResSetupKey() {
+  // @@protoc_insertion_point(destructor:grpc_admin.ResSetupKey)
   SharedDtor();
 }
 
-void ResSetup::SharedDtor() {
+void ResSetupKey::SharedDtor() {
+  info_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 
-void ResSetup::SetCachedSize(int size) const {
+void ResSetupKey::SetCachedSize(int size) const {
   _cached_size_.Set(size);
 }
-const ::google::protobuf::Descriptor* ResSetup::descriptor() {
+const ::google::protobuf::Descriptor* ResSetupKey::descriptor() {
   ::protobuf_admin_5fservice_2eproto::protobuf_AssignDescriptorsOnce();
   return ::protobuf_admin_5fservice_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
 }
 
-const ResSetup& ResSetup::default_instance() {
-  ::google::protobuf::internal::InitSCC(&protobuf_admin_5fservice_2eproto::scc_info_ResSetup.base);
+const ResSetupKey& ResSetupKey::default_instance() {
+  ::google::protobuf::internal::InitSCC(&protobuf_admin_5fservice_2eproto::scc_info_ResSetupKey.base);
   return *internal_default_instance();
 }
 
 
-void ResSetup::Clear() {
-// @@protoc_insertion_point(message_clear_start:grpc_admin.ResSetup)
+void ResSetupKey::Clear() {
+// @@protoc_insertion_point(message_clear_start:grpc_admin.ResSetupKey)
   ::google::protobuf::uint32 cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
+  info_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   success_ = false;
   _internal_metadata_.Clear();
 }
 
-bool ResSetup::MergePartialFromCodedStream(
+bool ResSetupKey::MergePartialFromCodedStream(
     ::google::protobuf::io::CodedInputStream* input) {
 #define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
   ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:grpc_admin.ResSetup)
+  // @@protoc_insertion_point(parse_start:grpc_admin.ResSetupKey)
   for (;;) {
     ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
     tag = p.first;
@@ -634,6 +792,22 @@ bool ResSetup::MergePartialFromCodedStream(
         break;
       }
 
+      // string info = 2;
+      case 2: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(18u /* 18 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_info()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->info().data(), static_cast<int>(this->info().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "grpc_admin.ResSetupKey.info"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
       default: {
       handle_unusual:
         if (tag == 0) {
@@ -646,17 +820,17 @@ bool ResSetup::MergePartialFromCodedStream(
     }
   }
 success:
-  // @@protoc_insertion_point(parse_success:grpc_admin.ResSetup)
+  // @@protoc_insertion_point(parse_success:grpc_admin.ResSetupKey)
   return true;
 failure:
-  // @@protoc_insertion_point(parse_failure:grpc_admin.ResSetup)
+  // @@protoc_insertion_point(parse_failure:grpc_admin.ResSetupKey)
   return false;
 #undef DO_
 }
 
-void ResSetup::SerializeWithCachedSizes(
+void ResSetupKey::SerializeWithCachedSizes(
     ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:grpc_admin.ResSetup)
+  // @@protoc_insertion_point(serialize_start:grpc_admin.ResSetupKey)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -665,17 +839,27 @@ void ResSetup::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::WriteBool(1, this->success(), output);
   }
 
+  // string info = 2;
+  if (this->info().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->info().data(), static_cast<int>(this->info().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "grpc_admin.ResSetupKey.info");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      2, this->info(), output);
+  }
+
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
   }
-  // @@protoc_insertion_point(serialize_end:grpc_admin.ResSetup)
+  // @@protoc_insertion_point(serialize_end:grpc_admin.ResSetupKey)
 }
 
-::google::protobuf::uint8* ResSetup::InternalSerializeWithCachedSizesToArray(
+::google::protobuf::uint8* ResSetupKey::InternalSerializeWithCachedSizesToArray(
     bool deterministic, ::google::protobuf::uint8* target) const {
   (void)deterministic; // Unused
-  // @@protoc_insertion_point(serialize_to_array_start:grpc_admin.ResSetup)
+  // @@protoc_insertion_point(serialize_to_array_start:grpc_admin.ResSetupKey)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
@@ -684,16 +868,27 @@ void ResSetup::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormatLite::WriteBoolToArray(1, this->success(), target);
   }
 
+  // string info = 2;
+  if (this->info().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->info().data(), static_cast<int>(this->info().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "grpc_admin.ResSetupKey.info");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        2, this->info(), target);
+  }
+
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
   }
-  // @@protoc_insertion_point(serialize_to_array_end:grpc_admin.ResSetup)
+  // @@protoc_insertion_point(serialize_to_array_end:grpc_admin.ResSetupKey)
   return target;
 }
 
-size_t ResSetup::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:grpc_admin.ResSetup)
+size_t ResSetupKey::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:grpc_admin.ResSetupKey)
   size_t total_size = 0;
 
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
@@ -701,6 +896,13 @@ size_t ResSetup::ByteSizeLong() const {
       ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
   }
+  // string info = 2;
+  if (this->info().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->info());
+  }
+
   // bool success = 1;
   if (this->success() != 0) {
     total_size += 1 + 1;
@@ -711,62 +913,589 @@ size_t ResSetup::ByteSizeLong() const {
   return total_size;
 }
 
-void ResSetup::MergeFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:grpc_admin.ResSetup)
+void ResSetupKey::MergeFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:grpc_admin.ResSetupKey)
   GOOGLE_DCHECK_NE(&from, this);
-  const ResSetup* source =
-      ::google::protobuf::internal::DynamicCastToGenerated<const ResSetup>(
+  const ResSetupKey* source =
+      ::google::protobuf::internal::DynamicCastToGenerated<const ResSetupKey>(
           &from);
   if (source == NULL) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_admin.ResSetup)
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_admin.ResSetupKey)
     ::google::protobuf::internal::ReflectionOps::Merge(from, this);
   } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_admin.ResSetup)
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_admin.ResSetupKey)
     MergeFrom(*source);
   }
 }
 
-void ResSetup::MergeFrom(const ResSetup& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:grpc_admin.ResSetup)
+void ResSetupKey::MergeFrom(const ResSetupKey& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:grpc_admin.ResSetupKey)
   GOOGLE_DCHECK_NE(&from, this);
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
+  if (from.info().size() > 0) {
+
+    info_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.info_);
+  }
   if (from.success() != 0) {
     set_success(from.success());
   }
 }
 
-void ResSetup::CopyFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:grpc_admin.ResSetup)
+void ResSetupKey::CopyFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:grpc_admin.ResSetupKey)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-void ResSetup::CopyFrom(const ResSetup& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:grpc_admin.ResSetup)
+void ResSetupKey::CopyFrom(const ResSetupKey& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:grpc_admin.ResSetupKey)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
-bool ResSetup::IsInitialized() const {
+bool ResSetupKey::IsInitialized() const {
   return true;
 }
 
-void ResSetup::Swap(ResSetup* other) {
+void ResSetupKey::Swap(ResSetupKey* other) {
   if (other == this) return;
   InternalSwap(other);
 }
-void ResSetup::InternalSwap(ResSetup* other) {
+void ResSetupKey::InternalSwap(ResSetupKey* other) {
   using std::swap;
+  info_.Swap(&other->info_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
   swap(success_, other->success_);
   _internal_metadata_.Swap(&other->_internal_metadata_);
 }
 
-::google::protobuf::Metadata ResSetup::GetMetadata() const {
+::google::protobuf::Metadata ResSetupKey::GetMetadata() const {
+  protobuf_admin_5fservice_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_admin_5fservice_2eproto::file_level_metadata[kIndexInFileMessages];
+}
+
+
+// ===================================================================
+
+void ReqLogin::InitAsDefaultInstance() {
+}
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int ReqLogin::kPasswordFieldNumber;
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+ReqLogin::ReqLogin()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  ::google::protobuf::internal::InitSCC(
+      &protobuf_admin_5fservice_2eproto::scc_info_ReqLogin.base);
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:grpc_admin.ReqLogin)
+}
+ReqLogin::ReqLogin(const ReqLogin& from)
+  : ::google::protobuf::Message(),
+      _internal_metadata_(NULL) {
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  password_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.password().size() > 0) {
+    password_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.password_);
+  }
+  // @@protoc_insertion_point(copy_constructor:grpc_admin.ReqLogin)
+}
+
+void ReqLogin::SharedCtor() {
+  password_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+
+ReqLogin::~ReqLogin() {
+  // @@protoc_insertion_point(destructor:grpc_admin.ReqLogin)
+  SharedDtor();
+}
+
+void ReqLogin::SharedDtor() {
+  password_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+
+void ReqLogin::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const ::google::protobuf::Descriptor* ReqLogin::descriptor() {
+  ::protobuf_admin_5fservice_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_admin_5fservice_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
+}
+
+const ReqLogin& ReqLogin::default_instance() {
+  ::google::protobuf::internal::InitSCC(&protobuf_admin_5fservice_2eproto::scc_info_ReqLogin.base);
+  return *internal_default_instance();
+}
+
+
+void ReqLogin::Clear() {
+// @@protoc_insertion_point(message_clear_start:grpc_admin.ReqLogin)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  password_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  _internal_metadata_.Clear();
+}
+
+bool ReqLogin::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:grpc_admin.ReqLogin)
+  for (;;) {
+    ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // string password = 1;
+      case 1: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_password()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->password().data(), static_cast<int>(this->password().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "grpc_admin.ReqLogin.password"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, _internal_metadata_.mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:grpc_admin.ReqLogin)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:grpc_admin.ReqLogin)
+  return false;
+#undef DO_
+}
+
+void ReqLogin::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:grpc_admin.ReqLogin)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string password = 1;
+  if (this->password().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->password().data(), static_cast<int>(this->password().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "grpc_admin.ReqLogin.password");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      1, this->password(), output);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
+  }
+  // @@protoc_insertion_point(serialize_end:grpc_admin.ReqLogin)
+}
+
+::google::protobuf::uint8* ReqLogin::InternalSerializeWithCachedSizesToArray(
+    bool deterministic, ::google::protobuf::uint8* target) const {
+  (void)deterministic; // Unused
+  // @@protoc_insertion_point(serialize_to_array_start:grpc_admin.ReqLogin)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // string password = 1;
+  if (this->password().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->password().data(), static_cast<int>(this->password().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "grpc_admin.ReqLogin.password");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        1, this->password(), target);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:grpc_admin.ReqLogin)
+  return target;
+}
+
+size_t ReqLogin::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:grpc_admin.ReqLogin)
+  size_t total_size = 0;
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
+  }
+  // string password = 1;
+  if (this->password().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->password());
+  }
+
+  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void ReqLogin::MergeFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:grpc_admin.ReqLogin)
+  GOOGLE_DCHECK_NE(&from, this);
+  const ReqLogin* source =
+      ::google::protobuf::internal::DynamicCastToGenerated<const ReqLogin>(
+          &from);
+  if (source == NULL) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_admin.ReqLogin)
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_admin.ReqLogin)
+    MergeFrom(*source);
+  }
+}
+
+void ReqLogin::MergeFrom(const ReqLogin& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:grpc_admin.ReqLogin)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.password().size() > 0) {
+
+    password_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.password_);
+  }
+}
+
+void ReqLogin::CopyFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:grpc_admin.ReqLogin)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void ReqLogin::CopyFrom(const ReqLogin& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:grpc_admin.ReqLogin)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool ReqLogin::IsInitialized() const {
+  return true;
+}
+
+void ReqLogin::Swap(ReqLogin* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void ReqLogin::InternalSwap(ReqLogin* other) {
+  using std::swap;
+  password_.Swap(&other->password_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+}
+
+::google::protobuf::Metadata ReqLogin::GetMetadata() const {
+  protobuf_admin_5fservice_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_admin_5fservice_2eproto::file_level_metadata[kIndexInFileMessages];
+}
+
+
+// ===================================================================
+
+void ResLogin::InitAsDefaultInstance() {
+}
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int ResLogin::kSuccessFieldNumber;
+const int ResLogin::kInfoFieldNumber;
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+ResLogin::ResLogin()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  ::google::protobuf::internal::InitSCC(
+      &protobuf_admin_5fservice_2eproto::scc_info_ResLogin.base);
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:grpc_admin.ResLogin)
+}
+ResLogin::ResLogin(const ResLogin& from)
+  : ::google::protobuf::Message(),
+      _internal_metadata_(NULL) {
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  info_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.info().size() > 0) {
+    info_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.info_);
+  }
+  success_ = from.success_;
+  // @@protoc_insertion_point(copy_constructor:grpc_admin.ResLogin)
+}
+
+void ResLogin::SharedCtor() {
+  info_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  success_ = false;
+}
+
+ResLogin::~ResLogin() {
+  // @@protoc_insertion_point(destructor:grpc_admin.ResLogin)
+  SharedDtor();
+}
+
+void ResLogin::SharedDtor() {
+  info_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+
+void ResLogin::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const ::google::protobuf::Descriptor* ResLogin::descriptor() {
+  ::protobuf_admin_5fservice_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_admin_5fservice_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
+}
+
+const ResLogin& ResLogin::default_instance() {
+  ::google::protobuf::internal::InitSCC(&protobuf_admin_5fservice_2eproto::scc_info_ResLogin.base);
+  return *internal_default_instance();
+}
+
+
+void ResLogin::Clear() {
+// @@protoc_insertion_point(message_clear_start:grpc_admin.ResLogin)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  info_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  success_ = false;
+  _internal_metadata_.Clear();
+}
+
+bool ResLogin::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:grpc_admin.ResLogin)
+  for (;;) {
+    ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // bool success = 1;
+      case 1: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(8u /* 8 & 0xFF */)) {
+
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   bool, ::google::protobuf::internal::WireFormatLite::TYPE_BOOL>(
+                 input, &success_)));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // string info = 2;
+      case 2: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(18u /* 18 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_info()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->info().data(), static_cast<int>(this->info().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "grpc_admin.ResLogin.info"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, _internal_metadata_.mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:grpc_admin.ResLogin)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:grpc_admin.ResLogin)
+  return false;
+#undef DO_
+}
+
+void ResLogin::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:grpc_admin.ResLogin)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // bool success = 1;
+  if (this->success() != 0) {
+    ::google::protobuf::internal::WireFormatLite::WriteBool(1, this->success(), output);
+  }
+
+  // string info = 2;
+  if (this->info().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->info().data(), static_cast<int>(this->info().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "grpc_admin.ResLogin.info");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      2, this->info(), output);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
+  }
+  // @@protoc_insertion_point(serialize_end:grpc_admin.ResLogin)
+}
+
+::google::protobuf::uint8* ResLogin::InternalSerializeWithCachedSizesToArray(
+    bool deterministic, ::google::protobuf::uint8* target) const {
+  (void)deterministic; // Unused
+  // @@protoc_insertion_point(serialize_to_array_start:grpc_admin.ResLogin)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // bool success = 1;
+  if (this->success() != 0) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteBoolToArray(1, this->success(), target);
+  }
+
+  // string info = 2;
+  if (this->info().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->info().data(), static_cast<int>(this->info().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "grpc_admin.ResLogin.info");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        2, this->info(), target);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:grpc_admin.ResLogin)
+  return target;
+}
+
+size_t ResLogin::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:grpc_admin.ResLogin)
+  size_t total_size = 0;
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
+  }
+  // string info = 2;
+  if (this->info().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->info());
+  }
+
+  // bool success = 1;
+  if (this->success() != 0) {
+    total_size += 1 + 1;
+  }
+
+  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void ResLogin::MergeFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:grpc_admin.ResLogin)
+  GOOGLE_DCHECK_NE(&from, this);
+  const ResLogin* source =
+      ::google::protobuf::internal::DynamicCastToGenerated<const ResLogin>(
+          &from);
+  if (source == NULL) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_admin.ResLogin)
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_admin.ResLogin)
+    MergeFrom(*source);
+  }
+}
+
+void ResLogin::MergeFrom(const ResLogin& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:grpc_admin.ResLogin)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.info().size() > 0) {
+
+    info_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.info_);
+  }
+  if (from.success() != 0) {
+    set_success(from.success());
+  }
+}
+
+void ResLogin::CopyFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:grpc_admin.ResLogin)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void ResLogin::CopyFrom(const ResLogin& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:grpc_admin.ResLogin)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool ResLogin::IsInitialized() const {
+  return true;
+}
+
+void ResLogin::Swap(ResLogin* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void ResLogin::InternalSwap(ResLogin* other) {
+  using std::swap;
+  info_.Swap(&other->info_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
+  swap(success_, other->success_);
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+}
+
+::google::protobuf::Metadata ResLogin::GetMetadata() const {
   protobuf_admin_5fservice_2eproto::protobuf_AssignDescriptorsOnce();
   return ::protobuf_admin_5fservice_2eproto::file_level_metadata[kIndexInFileMessages];
 }
@@ -777,6 +1506,7 @@ void ResSetup::InternalSwap(ResSetup* other) {
 void ReqStart::InitAsDefaultInstance() {
 }
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int ReqStart::kModeFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 ReqStart::ReqStart()
@@ -790,10 +1520,12 @@ ReqStart::ReqStart(const ReqStart& from)
   : ::google::protobuf::Message(),
       _internal_metadata_(NULL) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  mode_ = from.mode_;
   // @@protoc_insertion_point(copy_constructor:grpc_admin.ReqStart)
 }
 
 void ReqStart::SharedCtor() {
+  mode_ = 0;
 }
 
 ReqStart::~ReqStart() {
@@ -824,6 +1556,7 @@ void ReqStart::Clear() {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
+  mode_ = 0;
   _internal_metadata_.Clear();
 }
 
@@ -836,12 +1569,32 @@ bool ReqStart::MergePartialFromCodedStream(
     ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
     tag = p.first;
     if (!p.second) goto handle_unusual;
-  handle_unusual:
-    if (tag == 0) {
-      goto success;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // .grpc_admin.ReqStart.Mode mode = 1;
+      case 1: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(8u /* 8 & 0xFF */)) {
+          int value;
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   int, ::google::protobuf::internal::WireFormatLite::TYPE_ENUM>(
+                 input, &value)));
+          set_mode(static_cast< ::grpc_admin::ReqStart_Mode >(value));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, _internal_metadata_.mutable_unknown_fields()));
+        break;
+      }
     }
-    DO_(::google::protobuf::internal::WireFormat::SkipField(
-          input, tag, _internal_metadata_.mutable_unknown_fields()));
   }
 success:
   // @@protoc_insertion_point(parse_success:grpc_admin.ReqStart)
@@ -858,6 +1611,12 @@ void ReqStart::SerializeWithCachedSizes(
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
+  // .grpc_admin.ReqStart.Mode mode = 1;
+  if (this->mode() != 0) {
+    ::google::protobuf::internal::WireFormatLite::WriteEnum(
+      1, this->mode(), output);
+  }
+
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
@@ -871,6 +1630,12 @@ void ReqStart::SerializeWithCachedSizes(
   // @@protoc_insertion_point(serialize_to_array_start:grpc_admin.ReqStart)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
+
+  // .grpc_admin.ReqStart.Mode mode = 1;
+  if (this->mode() != 0) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteEnumToArray(
+      1, this->mode(), target);
+  }
 
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
@@ -889,6 +1654,12 @@ size_t ReqStart::ByteSizeLong() const {
       ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
   }
+  // .grpc_admin.ReqStart.Mode mode = 1;
+  if (this->mode() != 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::EnumSize(this->mode());
+  }
+
   int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
   SetCachedSize(cached_size);
   return total_size;
@@ -916,6 +1687,9 @@ void ReqStart::MergeFrom(const ReqStart& from) {
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
+  if (from.mode() != 0) {
+    set_mode(from.mode());
+  }
 }
 
 void ReqStart::CopyFrom(const ::google::protobuf::Message& from) {
@@ -942,6 +1716,7 @@ void ReqStart::Swap(ReqStart* other) {
 }
 void ReqStart::InternalSwap(ReqStart* other) {
   using std::swap;
+  swap(mode_, other->mode_);
   _internal_metadata_.Swap(&other->_internal_metadata_);
 }
 
@@ -957,6 +1732,7 @@ void ResStart::InitAsDefaultInstance() {
 }
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
 const int ResStart::kSuccessFieldNumber;
+const int ResStart::kInfoFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 ResStart::ResStart()
@@ -970,11 +1746,16 @@ ResStart::ResStart(const ResStart& from)
   : ::google::protobuf::Message(),
       _internal_metadata_(NULL) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  info_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.info().size() > 0) {
+    info_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.info_);
+  }
   success_ = from.success_;
   // @@protoc_insertion_point(copy_constructor:grpc_admin.ResStart)
 }
 
 void ResStart::SharedCtor() {
+  info_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   success_ = false;
 }
 
@@ -984,6 +1765,7 @@ ResStart::~ResStart() {
 }
 
 void ResStart::SharedDtor() {
+  info_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 
 void ResStart::SetCachedSize(int size) const {
@@ -1006,6 +1788,7 @@ void ResStart::Clear() {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
+  info_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   success_ = false;
   _internal_metadata_.Clear();
 }
@@ -1028,6 +1811,22 @@ bool ResStart::MergePartialFromCodedStream(
           DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
                    bool, ::google::protobuf::internal::WireFormatLite::TYPE_BOOL>(
                  input, &success_)));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // string info = 2;
+      case 2: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(18u /* 18 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_info()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->info().data(), static_cast<int>(this->info().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "grpc_admin.ResStart.info"));
         } else {
           goto handle_unusual;
         }
@@ -1065,6 +1864,16 @@ void ResStart::SerializeWithCachedSizes(
     ::google::protobuf::internal::WireFormatLite::WriteBool(1, this->success(), output);
   }
 
+  // string info = 2;
+  if (this->info().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->info().data(), static_cast<int>(this->info().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "grpc_admin.ResStart.info");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      2, this->info(), output);
+  }
+
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
@@ -1084,6 +1893,17 @@ void ResStart::SerializeWithCachedSizes(
     target = ::google::protobuf::internal::WireFormatLite::WriteBoolToArray(1, this->success(), target);
   }
 
+  // string info = 2;
+  if (this->info().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->info().data(), static_cast<int>(this->info().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "grpc_admin.ResStart.info");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        2, this->info(), target);
+  }
+
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
@@ -1101,6 +1921,13 @@ size_t ResStart::ByteSizeLong() const {
       ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
   }
+  // string info = 2;
+  if (this->info().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->info());
+  }
+
   // bool success = 1;
   if (this->success() != 0) {
     total_size += 1 + 1;
@@ -1133,6 +1960,10 @@ void ResStart::MergeFrom(const ResStart& from) {
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
+  if (from.info().size() > 0) {
+
+    info_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.info_);
+  }
   if (from.success() != 0) {
     set_success(from.success());
   }
@@ -1162,411 +1993,13 @@ void ResStart::Swap(ResStart* other) {
 }
 void ResStart::InternalSwap(ResStart* other) {
   using std::swap;
+  info_.Swap(&other->info_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
   swap(success_, other->success_);
   _internal_metadata_.Swap(&other->_internal_metadata_);
 }
 
 ::google::protobuf::Metadata ResStart::GetMetadata() const {
-  protobuf_admin_5fservice_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_admin_5fservice_2eproto::file_level_metadata[kIndexInFileMessages];
-}
-
-
-// ===================================================================
-
-void ReqStop::InitAsDefaultInstance() {
-}
-#if !defined(_MSC_VER) || _MSC_VER >= 1900
-#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
-
-ReqStop::ReqStop()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
-  ::google::protobuf::internal::InitSCC(
-      &protobuf_admin_5fservice_2eproto::scc_info_ReqStop.base);
-  SharedCtor();
-  // @@protoc_insertion_point(constructor:grpc_admin.ReqStop)
-}
-ReqStop::ReqStop(const ReqStop& from)
-  : ::google::protobuf::Message(),
-      _internal_metadata_(NULL) {
-  _internal_metadata_.MergeFrom(from._internal_metadata_);
-  // @@protoc_insertion_point(copy_constructor:grpc_admin.ReqStop)
-}
-
-void ReqStop::SharedCtor() {
-}
-
-ReqStop::~ReqStop() {
-  // @@protoc_insertion_point(destructor:grpc_admin.ReqStop)
-  SharedDtor();
-}
-
-void ReqStop::SharedDtor() {
-}
-
-void ReqStop::SetCachedSize(int size) const {
-  _cached_size_.Set(size);
-}
-const ::google::protobuf::Descriptor* ReqStop::descriptor() {
-  ::protobuf_admin_5fservice_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_admin_5fservice_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
-}
-
-const ReqStop& ReqStop::default_instance() {
-  ::google::protobuf::internal::InitSCC(&protobuf_admin_5fservice_2eproto::scc_info_ReqStop.base);
-  return *internal_default_instance();
-}
-
-
-void ReqStop::Clear() {
-// @@protoc_insertion_point(message_clear_start:grpc_admin.ReqStop)
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  // Prevent compiler warnings about cached_has_bits being unused
-  (void) cached_has_bits;
-
-  _internal_metadata_.Clear();
-}
-
-bool ReqStop::MergePartialFromCodedStream(
-    ::google::protobuf::io::CodedInputStream* input) {
-#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
-  ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:grpc_admin.ReqStop)
-  for (;;) {
-    ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
-    tag = p.first;
-    if (!p.second) goto handle_unusual;
-  handle_unusual:
-    if (tag == 0) {
-      goto success;
-    }
-    DO_(::google::protobuf::internal::WireFormat::SkipField(
-          input, tag, _internal_metadata_.mutable_unknown_fields()));
-  }
-success:
-  // @@protoc_insertion_point(parse_success:grpc_admin.ReqStop)
-  return true;
-failure:
-  // @@protoc_insertion_point(parse_failure:grpc_admin.ReqStop)
-  return false;
-#undef DO_
-}
-
-void ReqStop::SerializeWithCachedSizes(
-    ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:grpc_admin.ReqStop)
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  (void) cached_has_bits;
-
-  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
-    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
-        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
-  }
-  // @@protoc_insertion_point(serialize_end:grpc_admin.ReqStop)
-}
-
-::google::protobuf::uint8* ReqStop::InternalSerializeWithCachedSizesToArray(
-    bool deterministic, ::google::protobuf::uint8* target) const {
-  (void)deterministic; // Unused
-  // @@protoc_insertion_point(serialize_to_array_start:grpc_admin.ReqStop)
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  (void) cached_has_bits;
-
-  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
-    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
-        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
-  }
-  // @@protoc_insertion_point(serialize_to_array_end:grpc_admin.ReqStop)
-  return target;
-}
-
-size_t ReqStop::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:grpc_admin.ReqStop)
-  size_t total_size = 0;
-
-  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
-    total_size +=
-      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
-        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
-  }
-  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
-  SetCachedSize(cached_size);
-  return total_size;
-}
-
-void ReqStop::MergeFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:grpc_admin.ReqStop)
-  GOOGLE_DCHECK_NE(&from, this);
-  const ReqStop* source =
-      ::google::protobuf::internal::DynamicCastToGenerated<const ReqStop>(
-          &from);
-  if (source == NULL) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_admin.ReqStop)
-    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
-  } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_admin.ReqStop)
-    MergeFrom(*source);
-  }
-}
-
-void ReqStop::MergeFrom(const ReqStop& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:grpc_admin.ReqStop)
-  GOOGLE_DCHECK_NE(&from, this);
-  _internal_metadata_.MergeFrom(from._internal_metadata_);
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  (void) cached_has_bits;
-
-}
-
-void ReqStop::CopyFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:grpc_admin.ReqStop)
-  if (&from == this) return;
-  Clear();
-  MergeFrom(from);
-}
-
-void ReqStop::CopyFrom(const ReqStop& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:grpc_admin.ReqStop)
-  if (&from == this) return;
-  Clear();
-  MergeFrom(from);
-}
-
-bool ReqStop::IsInitialized() const {
-  return true;
-}
-
-void ReqStop::Swap(ReqStop* other) {
-  if (other == this) return;
-  InternalSwap(other);
-}
-void ReqStop::InternalSwap(ReqStop* other) {
-  using std::swap;
-  _internal_metadata_.Swap(&other->_internal_metadata_);
-}
-
-::google::protobuf::Metadata ReqStop::GetMetadata() const {
-  protobuf_admin_5fservice_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_admin_5fservice_2eproto::file_level_metadata[kIndexInFileMessages];
-}
-
-
-// ===================================================================
-
-void ResStop::InitAsDefaultInstance() {
-}
-#if !defined(_MSC_VER) || _MSC_VER >= 1900
-const int ResStop::kSuccessFieldNumber;
-#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
-
-ResStop::ResStop()
-  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
-  ::google::protobuf::internal::InitSCC(
-      &protobuf_admin_5fservice_2eproto::scc_info_ResStop.base);
-  SharedCtor();
-  // @@protoc_insertion_point(constructor:grpc_admin.ResStop)
-}
-ResStop::ResStop(const ResStop& from)
-  : ::google::protobuf::Message(),
-      _internal_metadata_(NULL) {
-  _internal_metadata_.MergeFrom(from._internal_metadata_);
-  success_ = from.success_;
-  // @@protoc_insertion_point(copy_constructor:grpc_admin.ResStop)
-}
-
-void ResStop::SharedCtor() {
-  success_ = false;
-}
-
-ResStop::~ResStop() {
-  // @@protoc_insertion_point(destructor:grpc_admin.ResStop)
-  SharedDtor();
-}
-
-void ResStop::SharedDtor() {
-}
-
-void ResStop::SetCachedSize(int size) const {
-  _cached_size_.Set(size);
-}
-const ::google::protobuf::Descriptor* ResStop::descriptor() {
-  ::protobuf_admin_5fservice_2eproto::protobuf_AssignDescriptorsOnce();
-  return ::protobuf_admin_5fservice_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
-}
-
-const ResStop& ResStop::default_instance() {
-  ::google::protobuf::internal::InitSCC(&protobuf_admin_5fservice_2eproto::scc_info_ResStop.base);
-  return *internal_default_instance();
-}
-
-
-void ResStop::Clear() {
-// @@protoc_insertion_point(message_clear_start:grpc_admin.ResStop)
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  // Prevent compiler warnings about cached_has_bits being unused
-  (void) cached_has_bits;
-
-  success_ = false;
-  _internal_metadata_.Clear();
-}
-
-bool ResStop::MergePartialFromCodedStream(
-    ::google::protobuf::io::CodedInputStream* input) {
-#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
-  ::google::protobuf::uint32 tag;
-  // @@protoc_insertion_point(parse_start:grpc_admin.ResStop)
-  for (;;) {
-    ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
-    tag = p.first;
-    if (!p.second) goto handle_unusual;
-    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
-      // bool success = 1;
-      case 1: {
-        if (static_cast< ::google::protobuf::uint8>(tag) ==
-            static_cast< ::google::protobuf::uint8>(8u /* 8 & 0xFF */)) {
-
-          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
-                   bool, ::google::protobuf::internal::WireFormatLite::TYPE_BOOL>(
-                 input, &success_)));
-        } else {
-          goto handle_unusual;
-        }
-        break;
-      }
-
-      default: {
-      handle_unusual:
-        if (tag == 0) {
-          goto success;
-        }
-        DO_(::google::protobuf::internal::WireFormat::SkipField(
-              input, tag, _internal_metadata_.mutable_unknown_fields()));
-        break;
-      }
-    }
-  }
-success:
-  // @@protoc_insertion_point(parse_success:grpc_admin.ResStop)
-  return true;
-failure:
-  // @@protoc_insertion_point(parse_failure:grpc_admin.ResStop)
-  return false;
-#undef DO_
-}
-
-void ResStop::SerializeWithCachedSizes(
-    ::google::protobuf::io::CodedOutputStream* output) const {
-  // @@protoc_insertion_point(serialize_start:grpc_admin.ResStop)
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  (void) cached_has_bits;
-
-  // bool success = 1;
-  if (this->success() != 0) {
-    ::google::protobuf::internal::WireFormatLite::WriteBool(1, this->success(), output);
-  }
-
-  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
-    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
-        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
-  }
-  // @@protoc_insertion_point(serialize_end:grpc_admin.ResStop)
-}
-
-::google::protobuf::uint8* ResStop::InternalSerializeWithCachedSizesToArray(
-    bool deterministic, ::google::protobuf::uint8* target) const {
-  (void)deterministic; // Unused
-  // @@protoc_insertion_point(serialize_to_array_start:grpc_admin.ResStop)
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  (void) cached_has_bits;
-
-  // bool success = 1;
-  if (this->success() != 0) {
-    target = ::google::protobuf::internal::WireFormatLite::WriteBoolToArray(1, this->success(), target);
-  }
-
-  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
-    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
-        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
-  }
-  // @@protoc_insertion_point(serialize_to_array_end:grpc_admin.ResStop)
-  return target;
-}
-
-size_t ResStop::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:grpc_admin.ResStop)
-  size_t total_size = 0;
-
-  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
-    total_size +=
-      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
-        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
-  }
-  // bool success = 1;
-  if (this->success() != 0) {
-    total_size += 1 + 1;
-  }
-
-  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
-  SetCachedSize(cached_size);
-  return total_size;
-}
-
-void ResStop::MergeFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_merge_from_start:grpc_admin.ResStop)
-  GOOGLE_DCHECK_NE(&from, this);
-  const ResStop* source =
-      ::google::protobuf::internal::DynamicCastToGenerated<const ResStop>(
-          &from);
-  if (source == NULL) {
-  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_admin.ResStop)
-    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
-  } else {
-  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_admin.ResStop)
-    MergeFrom(*source);
-  }
-}
-
-void ResStop::MergeFrom(const ResStop& from) {
-// @@protoc_insertion_point(class_specific_merge_from_start:grpc_admin.ResStop)
-  GOOGLE_DCHECK_NE(&from, this);
-  _internal_metadata_.MergeFrom(from._internal_metadata_);
-  ::google::protobuf::uint32 cached_has_bits = 0;
-  (void) cached_has_bits;
-
-  if (from.success() != 0) {
-    set_success(from.success());
-  }
-}
-
-void ResStop::CopyFrom(const ::google::protobuf::Message& from) {
-// @@protoc_insertion_point(generalized_copy_from_start:grpc_admin.ResStop)
-  if (&from == this) return;
-  Clear();
-  MergeFrom(from);
-}
-
-void ResStop::CopyFrom(const ResStop& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:grpc_admin.ResStop)
-  if (&from == this) return;
-  Clear();
-  MergeFrom(from);
-}
-
-bool ResStop::IsInitialized() const {
-  return true;
-}
-
-void ResStop::Swap(ResStop* other) {
-  if (other == this) return;
-  InternalSwap(other);
-}
-void ResStop::InternalSwap(ResStop* other) {
-  using std::swap;
-  swap(success_, other->success_);
-  _internal_metadata_.Swap(&other->_internal_metadata_);
-}
-
-::google::protobuf::Metadata ResStop::GetMetadata() const {
   protobuf_admin_5fservice_2eproto::protobuf_AssignDescriptorsOnce();
   return ::protobuf_admin_5fservice_2eproto::file_level_metadata[kIndexInFileMessages];
 }
@@ -1972,15 +2405,937 @@ void ResStatus::InternalSwap(ResStatus* other) {
 }
 
 
+// ===================================================================
+
+void ReqLoadWorld::InitAsDefaultInstance() {
+}
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+ReqLoadWorld::ReqLoadWorld()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  ::google::protobuf::internal::InitSCC(
+      &protobuf_admin_5fservice_2eproto::scc_info_ReqLoadWorld.base);
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:grpc_admin.ReqLoadWorld)
+}
+ReqLoadWorld::ReqLoadWorld(const ReqLoadWorld& from)
+  : ::google::protobuf::Message(),
+      _internal_metadata_(NULL) {
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  // @@protoc_insertion_point(copy_constructor:grpc_admin.ReqLoadWorld)
+}
+
+void ReqLoadWorld::SharedCtor() {
+}
+
+ReqLoadWorld::~ReqLoadWorld() {
+  // @@protoc_insertion_point(destructor:grpc_admin.ReqLoadWorld)
+  SharedDtor();
+}
+
+void ReqLoadWorld::SharedDtor() {
+}
+
+void ReqLoadWorld::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const ::google::protobuf::Descriptor* ReqLoadWorld::descriptor() {
+  ::protobuf_admin_5fservice_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_admin_5fservice_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
+}
+
+const ReqLoadWorld& ReqLoadWorld::default_instance() {
+  ::google::protobuf::internal::InitSCC(&protobuf_admin_5fservice_2eproto::scc_info_ReqLoadWorld.base);
+  return *internal_default_instance();
+}
+
+
+void ReqLoadWorld::Clear() {
+// @@protoc_insertion_point(message_clear_start:grpc_admin.ReqLoadWorld)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _internal_metadata_.Clear();
+}
+
+bool ReqLoadWorld::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:grpc_admin.ReqLoadWorld)
+  for (;;) {
+    ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+  handle_unusual:
+    if (tag == 0) {
+      goto success;
+    }
+    DO_(::google::protobuf::internal::WireFormat::SkipField(
+          input, tag, _internal_metadata_.mutable_unknown_fields()));
+  }
+success:
+  // @@protoc_insertion_point(parse_success:grpc_admin.ReqLoadWorld)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:grpc_admin.ReqLoadWorld)
+  return false;
+#undef DO_
+}
+
+void ReqLoadWorld::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:grpc_admin.ReqLoadWorld)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
+  }
+  // @@protoc_insertion_point(serialize_end:grpc_admin.ReqLoadWorld)
+}
+
+::google::protobuf::uint8* ReqLoadWorld::InternalSerializeWithCachedSizesToArray(
+    bool deterministic, ::google::protobuf::uint8* target) const {
+  (void)deterministic; // Unused
+  // @@protoc_insertion_point(serialize_to_array_start:grpc_admin.ReqLoadWorld)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:grpc_admin.ReqLoadWorld)
+  return target;
+}
+
+size_t ReqLoadWorld::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:grpc_admin.ReqLoadWorld)
+  size_t total_size = 0;
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
+  }
+  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void ReqLoadWorld::MergeFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:grpc_admin.ReqLoadWorld)
+  GOOGLE_DCHECK_NE(&from, this);
+  const ReqLoadWorld* source =
+      ::google::protobuf::internal::DynamicCastToGenerated<const ReqLoadWorld>(
+          &from);
+  if (source == NULL) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_admin.ReqLoadWorld)
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_admin.ReqLoadWorld)
+    MergeFrom(*source);
+  }
+}
+
+void ReqLoadWorld::MergeFrom(const ReqLoadWorld& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:grpc_admin.ReqLoadWorld)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+}
+
+void ReqLoadWorld::CopyFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:grpc_admin.ReqLoadWorld)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void ReqLoadWorld::CopyFrom(const ReqLoadWorld& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:grpc_admin.ReqLoadWorld)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool ReqLoadWorld::IsInitialized() const {
+  return true;
+}
+
+void ReqLoadWorld::Swap(ReqLoadWorld* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void ReqLoadWorld::InternalSwap(ReqLoadWorld* other) {
+  using std::swap;
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+}
+
+::google::protobuf::Metadata ReqLoadWorld::GetMetadata() const {
+  protobuf_admin_5fservice_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_admin_5fservice_2eproto::file_level_metadata[kIndexInFileMessages];
+}
+
+
+// ===================================================================
+
+void ResLoadWorld::InitAsDefaultInstance() {
+}
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int ResLoadWorld::kSuccessFieldNumber;
+const int ResLoadWorld::kInfoFieldNumber;
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+ResLoadWorld::ResLoadWorld()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  ::google::protobuf::internal::InitSCC(
+      &protobuf_admin_5fservice_2eproto::scc_info_ResLoadWorld.base);
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:grpc_admin.ResLoadWorld)
+}
+ResLoadWorld::ResLoadWorld(const ResLoadWorld& from)
+  : ::google::protobuf::Message(),
+      _internal_metadata_(NULL) {
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  info_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.info().size() > 0) {
+    info_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.info_);
+  }
+  success_ = from.success_;
+  // @@protoc_insertion_point(copy_constructor:grpc_admin.ResLoadWorld)
+}
+
+void ResLoadWorld::SharedCtor() {
+  info_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  success_ = false;
+}
+
+ResLoadWorld::~ResLoadWorld() {
+  // @@protoc_insertion_point(destructor:grpc_admin.ResLoadWorld)
+  SharedDtor();
+}
+
+void ResLoadWorld::SharedDtor() {
+  info_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+
+void ResLoadWorld::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const ::google::protobuf::Descriptor* ResLoadWorld::descriptor() {
+  ::protobuf_admin_5fservice_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_admin_5fservice_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
+}
+
+const ResLoadWorld& ResLoadWorld::default_instance() {
+  ::google::protobuf::internal::InitSCC(&protobuf_admin_5fservice_2eproto::scc_info_ResLoadWorld.base);
+  return *internal_default_instance();
+}
+
+
+void ResLoadWorld::Clear() {
+// @@protoc_insertion_point(message_clear_start:grpc_admin.ResLoadWorld)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  info_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  success_ = false;
+  _internal_metadata_.Clear();
+}
+
+bool ResLoadWorld::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:grpc_admin.ResLoadWorld)
+  for (;;) {
+    ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // bool success = 1;
+      case 1: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(8u /* 8 & 0xFF */)) {
+
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   bool, ::google::protobuf::internal::WireFormatLite::TYPE_BOOL>(
+                 input, &success_)));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // string info = 2;
+      case 2: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(18u /* 18 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_info()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->info().data(), static_cast<int>(this->info().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "grpc_admin.ResLoadWorld.info"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, _internal_metadata_.mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:grpc_admin.ResLoadWorld)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:grpc_admin.ResLoadWorld)
+  return false;
+#undef DO_
+}
+
+void ResLoadWorld::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:grpc_admin.ResLoadWorld)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // bool success = 1;
+  if (this->success() != 0) {
+    ::google::protobuf::internal::WireFormatLite::WriteBool(1, this->success(), output);
+  }
+
+  // string info = 2;
+  if (this->info().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->info().data(), static_cast<int>(this->info().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "grpc_admin.ResLoadWorld.info");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      2, this->info(), output);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
+  }
+  // @@protoc_insertion_point(serialize_end:grpc_admin.ResLoadWorld)
+}
+
+::google::protobuf::uint8* ResLoadWorld::InternalSerializeWithCachedSizesToArray(
+    bool deterministic, ::google::protobuf::uint8* target) const {
+  (void)deterministic; // Unused
+  // @@protoc_insertion_point(serialize_to_array_start:grpc_admin.ResLoadWorld)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // bool success = 1;
+  if (this->success() != 0) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteBoolToArray(1, this->success(), target);
+  }
+
+  // string info = 2;
+  if (this->info().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->info().data(), static_cast<int>(this->info().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "grpc_admin.ResLoadWorld.info");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        2, this->info(), target);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:grpc_admin.ResLoadWorld)
+  return target;
+}
+
+size_t ResLoadWorld::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:grpc_admin.ResLoadWorld)
+  size_t total_size = 0;
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
+  }
+  // string info = 2;
+  if (this->info().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->info());
+  }
+
+  // bool success = 1;
+  if (this->success() != 0) {
+    total_size += 1 + 1;
+  }
+
+  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void ResLoadWorld::MergeFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:grpc_admin.ResLoadWorld)
+  GOOGLE_DCHECK_NE(&from, this);
+  const ResLoadWorld* source =
+      ::google::protobuf::internal::DynamicCastToGenerated<const ResLoadWorld>(
+          &from);
+  if (source == NULL) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_admin.ResLoadWorld)
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_admin.ResLoadWorld)
+    MergeFrom(*source);
+  }
+}
+
+void ResLoadWorld::MergeFrom(const ResLoadWorld& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:grpc_admin.ResLoadWorld)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.info().size() > 0) {
+
+    info_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.info_);
+  }
+  if (from.success() != 0) {
+    set_success(from.success());
+  }
+}
+
+void ResLoadWorld::CopyFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:grpc_admin.ResLoadWorld)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void ResLoadWorld::CopyFrom(const ResLoadWorld& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:grpc_admin.ResLoadWorld)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool ResLoadWorld::IsInitialized() const {
+  return true;
+}
+
+void ResLoadWorld::Swap(ResLoadWorld* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void ResLoadWorld::InternalSwap(ResLoadWorld* other) {
+  using std::swap;
+  info_.Swap(&other->info_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
+  swap(success_, other->success_);
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+}
+
+::google::protobuf::Metadata ResLoadWorld::GetMetadata() const {
+  protobuf_admin_5fservice_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_admin_5fservice_2eproto::file_level_metadata[kIndexInFileMessages];
+}
+
+
+// ===================================================================
+
+void ReqLoadChain::InitAsDefaultInstance() {
+}
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+ReqLoadChain::ReqLoadChain()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  ::google::protobuf::internal::InitSCC(
+      &protobuf_admin_5fservice_2eproto::scc_info_ReqLoadChain.base);
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:grpc_admin.ReqLoadChain)
+}
+ReqLoadChain::ReqLoadChain(const ReqLoadChain& from)
+  : ::google::protobuf::Message(),
+      _internal_metadata_(NULL) {
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  // @@protoc_insertion_point(copy_constructor:grpc_admin.ReqLoadChain)
+}
+
+void ReqLoadChain::SharedCtor() {
+}
+
+ReqLoadChain::~ReqLoadChain() {
+  // @@protoc_insertion_point(destructor:grpc_admin.ReqLoadChain)
+  SharedDtor();
+}
+
+void ReqLoadChain::SharedDtor() {
+}
+
+void ReqLoadChain::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const ::google::protobuf::Descriptor* ReqLoadChain::descriptor() {
+  ::protobuf_admin_5fservice_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_admin_5fservice_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
+}
+
+const ReqLoadChain& ReqLoadChain::default_instance() {
+  ::google::protobuf::internal::InitSCC(&protobuf_admin_5fservice_2eproto::scc_info_ReqLoadChain.base);
+  return *internal_default_instance();
+}
+
+
+void ReqLoadChain::Clear() {
+// @@protoc_insertion_point(message_clear_start:grpc_admin.ReqLoadChain)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _internal_metadata_.Clear();
+}
+
+bool ReqLoadChain::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:grpc_admin.ReqLoadChain)
+  for (;;) {
+    ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+  handle_unusual:
+    if (tag == 0) {
+      goto success;
+    }
+    DO_(::google::protobuf::internal::WireFormat::SkipField(
+          input, tag, _internal_metadata_.mutable_unknown_fields()));
+  }
+success:
+  // @@protoc_insertion_point(parse_success:grpc_admin.ReqLoadChain)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:grpc_admin.ReqLoadChain)
+  return false;
+#undef DO_
+}
+
+void ReqLoadChain::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:grpc_admin.ReqLoadChain)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
+  }
+  // @@protoc_insertion_point(serialize_end:grpc_admin.ReqLoadChain)
+}
+
+::google::protobuf::uint8* ReqLoadChain::InternalSerializeWithCachedSizesToArray(
+    bool deterministic, ::google::protobuf::uint8* target) const {
+  (void)deterministic; // Unused
+  // @@protoc_insertion_point(serialize_to_array_start:grpc_admin.ReqLoadChain)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:grpc_admin.ReqLoadChain)
+  return target;
+}
+
+size_t ReqLoadChain::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:grpc_admin.ReqLoadChain)
+  size_t total_size = 0;
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
+  }
+  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void ReqLoadChain::MergeFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:grpc_admin.ReqLoadChain)
+  GOOGLE_DCHECK_NE(&from, this);
+  const ReqLoadChain* source =
+      ::google::protobuf::internal::DynamicCastToGenerated<const ReqLoadChain>(
+          &from);
+  if (source == NULL) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_admin.ReqLoadChain)
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_admin.ReqLoadChain)
+    MergeFrom(*source);
+  }
+}
+
+void ReqLoadChain::MergeFrom(const ReqLoadChain& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:grpc_admin.ReqLoadChain)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+}
+
+void ReqLoadChain::CopyFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:grpc_admin.ReqLoadChain)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void ReqLoadChain::CopyFrom(const ReqLoadChain& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:grpc_admin.ReqLoadChain)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool ReqLoadChain::IsInitialized() const {
+  return true;
+}
+
+void ReqLoadChain::Swap(ReqLoadChain* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void ReqLoadChain::InternalSwap(ReqLoadChain* other) {
+  using std::swap;
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+}
+
+::google::protobuf::Metadata ReqLoadChain::GetMetadata() const {
+  protobuf_admin_5fservice_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_admin_5fservice_2eproto::file_level_metadata[kIndexInFileMessages];
+}
+
+
+// ===================================================================
+
+void ResLoadChain::InitAsDefaultInstance() {
+}
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int ResLoadChain::kSuccessFieldNumber;
+const int ResLoadChain::kInfoFieldNumber;
+#endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
+
+ResLoadChain::ResLoadChain()
+  : ::google::protobuf::Message(), _internal_metadata_(NULL) {
+  ::google::protobuf::internal::InitSCC(
+      &protobuf_admin_5fservice_2eproto::scc_info_ResLoadChain.base);
+  SharedCtor();
+  // @@protoc_insertion_point(constructor:grpc_admin.ResLoadChain)
+}
+ResLoadChain::ResLoadChain(const ResLoadChain& from)
+  : ::google::protobuf::Message(),
+      _internal_metadata_(NULL) {
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  info_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.info().size() > 0) {
+    info_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.info_);
+  }
+  success_ = from.success_;
+  // @@protoc_insertion_point(copy_constructor:grpc_admin.ResLoadChain)
+}
+
+void ResLoadChain::SharedCtor() {
+  info_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  success_ = false;
+}
+
+ResLoadChain::~ResLoadChain() {
+  // @@protoc_insertion_point(destructor:grpc_admin.ResLoadChain)
+  SharedDtor();
+}
+
+void ResLoadChain::SharedDtor() {
+  info_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+
+void ResLoadChain::SetCachedSize(int size) const {
+  _cached_size_.Set(size);
+}
+const ::google::protobuf::Descriptor* ResLoadChain::descriptor() {
+  ::protobuf_admin_5fservice_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_admin_5fservice_2eproto::file_level_metadata[kIndexInFileMessages].descriptor;
+}
+
+const ResLoadChain& ResLoadChain::default_instance() {
+  ::google::protobuf::internal::InitSCC(&protobuf_admin_5fservice_2eproto::scc_info_ResLoadChain.base);
+  return *internal_default_instance();
+}
+
+
+void ResLoadChain::Clear() {
+// @@protoc_insertion_point(message_clear_start:grpc_admin.ResLoadChain)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  info_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  success_ = false;
+  _internal_metadata_.Clear();
+}
+
+bool ResLoadChain::MergePartialFromCodedStream(
+    ::google::protobuf::io::CodedInputStream* input) {
+#define DO_(EXPRESSION) if (!GOOGLE_PREDICT_TRUE(EXPRESSION)) goto failure
+  ::google::protobuf::uint32 tag;
+  // @@protoc_insertion_point(parse_start:grpc_admin.ResLoadChain)
+  for (;;) {
+    ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
+    tag = p.first;
+    if (!p.second) goto handle_unusual;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // bool success = 1;
+      case 1: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(8u /* 8 & 0xFF */)) {
+
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPrimitive<
+                   bool, ::google::protobuf::internal::WireFormatLite::TYPE_BOOL>(
+                 input, &success_)));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // string info = 2;
+      case 2: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(18u /* 18 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_info()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->info().data(), static_cast<int>(this->info().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "grpc_admin.ResLoadChain.info"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, _internal_metadata_.mutable_unknown_fields()));
+        break;
+      }
+    }
+  }
+success:
+  // @@protoc_insertion_point(parse_success:grpc_admin.ResLoadChain)
+  return true;
+failure:
+  // @@protoc_insertion_point(parse_failure:grpc_admin.ResLoadChain)
+  return false;
+#undef DO_
+}
+
+void ResLoadChain::SerializeWithCachedSizes(
+    ::google::protobuf::io::CodedOutputStream* output) const {
+  // @@protoc_insertion_point(serialize_start:grpc_admin.ResLoadChain)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // bool success = 1;
+  if (this->success() != 0) {
+    ::google::protobuf::internal::WireFormatLite::WriteBool(1, this->success(), output);
+  }
+
+  // string info = 2;
+  if (this->info().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->info().data(), static_cast<int>(this->info().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "grpc_admin.ResLoadChain.info");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      2, this->info(), output);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
+  }
+  // @@protoc_insertion_point(serialize_end:grpc_admin.ResLoadChain)
+}
+
+::google::protobuf::uint8* ResLoadChain::InternalSerializeWithCachedSizesToArray(
+    bool deterministic, ::google::protobuf::uint8* target) const {
+  (void)deterministic; // Unused
+  // @@protoc_insertion_point(serialize_to_array_start:grpc_admin.ResLoadChain)
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  // bool success = 1;
+  if (this->success() != 0) {
+    target = ::google::protobuf::internal::WireFormatLite::WriteBoolToArray(1, this->success(), target);
+  }
+
+  // string info = 2;
+  if (this->info().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->info().data(), static_cast<int>(this->info().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "grpc_admin.ResLoadChain.info");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        2, this->info(), target);
+  }
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:grpc_admin.ResLoadChain)
+  return target;
+}
+
+size_t ResLoadChain::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:grpc_admin.ResLoadChain)
+  size_t total_size = 0;
+
+  if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
+    total_size +=
+      ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
+        (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
+  }
+  // string info = 2;
+  if (this->info().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->info());
+  }
+
+  // bool success = 1;
+  if (this->success() != 0) {
+    total_size += 1 + 1;
+  }
+
+  int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
+  SetCachedSize(cached_size);
+  return total_size;
+}
+
+void ResLoadChain::MergeFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_merge_from_start:grpc_admin.ResLoadChain)
+  GOOGLE_DCHECK_NE(&from, this);
+  const ResLoadChain* source =
+      ::google::protobuf::internal::DynamicCastToGenerated<const ResLoadChain>(
+          &from);
+  if (source == NULL) {
+  // @@protoc_insertion_point(generalized_merge_from_cast_fail:grpc_admin.ResLoadChain)
+    ::google::protobuf::internal::ReflectionOps::Merge(from, this);
+  } else {
+  // @@protoc_insertion_point(generalized_merge_from_cast_success:grpc_admin.ResLoadChain)
+    MergeFrom(*source);
+  }
+}
+
+void ResLoadChain::MergeFrom(const ResLoadChain& from) {
+// @@protoc_insertion_point(class_specific_merge_from_start:grpc_admin.ResLoadChain)
+  GOOGLE_DCHECK_NE(&from, this);
+  _internal_metadata_.MergeFrom(from._internal_metadata_);
+  ::google::protobuf::uint32 cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from.info().size() > 0) {
+
+    info_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.info_);
+  }
+  if (from.success() != 0) {
+    set_success(from.success());
+  }
+}
+
+void ResLoadChain::CopyFrom(const ::google::protobuf::Message& from) {
+// @@protoc_insertion_point(generalized_copy_from_start:grpc_admin.ResLoadChain)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+void ResLoadChain::CopyFrom(const ResLoadChain& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:grpc_admin.ResLoadChain)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+bool ResLoadChain::IsInitialized() const {
+  return true;
+}
+
+void ResLoadChain::Swap(ResLoadChain* other) {
+  if (other == this) return;
+  InternalSwap(other);
+}
+void ResLoadChain::InternalSwap(ResLoadChain* other) {
+  using std::swap;
+  info_.Swap(&other->info_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
+  swap(success_, other->success_);
+  _internal_metadata_.Swap(&other->_internal_metadata_);
+}
+
+::google::protobuf::Metadata ResLoadChain::GetMetadata() const {
+  protobuf_admin_5fservice_2eproto::protobuf_AssignDescriptorsOnce();
+  return ::protobuf_admin_5fservice_2eproto::file_level_metadata[kIndexInFileMessages];
+}
+
+
 // @@protoc_insertion_point(namespace_scope)
 }  // namespace grpc_admin
 namespace google {
 namespace protobuf {
-template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::grpc_admin::ReqSetup* Arena::CreateMaybeMessage< ::grpc_admin::ReqSetup >(Arena* arena) {
-  return Arena::CreateInternal< ::grpc_admin::ReqSetup >(arena);
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::grpc_admin::ReqSetupKey* Arena::CreateMaybeMessage< ::grpc_admin::ReqSetupKey >(Arena* arena) {
+  return Arena::CreateInternal< ::grpc_admin::ReqSetupKey >(arena);
 }
-template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::grpc_admin::ResSetup* Arena::CreateMaybeMessage< ::grpc_admin::ResSetup >(Arena* arena) {
-  return Arena::CreateInternal< ::grpc_admin::ResSetup >(arena);
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::grpc_admin::ResSetupKey* Arena::CreateMaybeMessage< ::grpc_admin::ResSetupKey >(Arena* arena) {
+  return Arena::CreateInternal< ::grpc_admin::ResSetupKey >(arena);
+}
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::grpc_admin::ReqLogin* Arena::CreateMaybeMessage< ::grpc_admin::ReqLogin >(Arena* arena) {
+  return Arena::CreateInternal< ::grpc_admin::ReqLogin >(arena);
+}
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::grpc_admin::ResLogin* Arena::CreateMaybeMessage< ::grpc_admin::ResLogin >(Arena* arena) {
+  return Arena::CreateInternal< ::grpc_admin::ResLogin >(arena);
 }
 template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::grpc_admin::ReqStart* Arena::CreateMaybeMessage< ::grpc_admin::ReqStart >(Arena* arena) {
   return Arena::CreateInternal< ::grpc_admin::ReqStart >(arena);
@@ -1988,17 +3343,23 @@ template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::grpc_admin::ReqStart* Arena::Cre
 template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::grpc_admin::ResStart* Arena::CreateMaybeMessage< ::grpc_admin::ResStart >(Arena* arena) {
   return Arena::CreateInternal< ::grpc_admin::ResStart >(arena);
 }
-template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::grpc_admin::ReqStop* Arena::CreateMaybeMessage< ::grpc_admin::ReqStop >(Arena* arena) {
-  return Arena::CreateInternal< ::grpc_admin::ReqStop >(arena);
-}
-template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::grpc_admin::ResStop* Arena::CreateMaybeMessage< ::grpc_admin::ResStop >(Arena* arena) {
-  return Arena::CreateInternal< ::grpc_admin::ResStop >(arena);
-}
 template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::grpc_admin::ReqStatus* Arena::CreateMaybeMessage< ::grpc_admin::ReqStatus >(Arena* arena) {
   return Arena::CreateInternal< ::grpc_admin::ReqStatus >(arena);
 }
 template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::grpc_admin::ResStatus* Arena::CreateMaybeMessage< ::grpc_admin::ResStatus >(Arena* arena) {
   return Arena::CreateInternal< ::grpc_admin::ResStatus >(arena);
+}
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::grpc_admin::ReqLoadWorld* Arena::CreateMaybeMessage< ::grpc_admin::ReqLoadWorld >(Arena* arena) {
+  return Arena::CreateInternal< ::grpc_admin::ReqLoadWorld >(arena);
+}
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::grpc_admin::ResLoadWorld* Arena::CreateMaybeMessage< ::grpc_admin::ResLoadWorld >(Arena* arena) {
+  return Arena::CreateInternal< ::grpc_admin::ResLoadWorld >(arena);
+}
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::grpc_admin::ReqLoadChain* Arena::CreateMaybeMessage< ::grpc_admin::ReqLoadChain >(Arena* arena) {
+  return Arena::CreateInternal< ::grpc_admin::ReqLoadChain >(arena);
+}
+template<> GOOGLE_PROTOBUF_ATTRIBUTE_NOINLINE ::grpc_admin::ResLoadChain* Arena::CreateMaybeMessage< ::grpc_admin::ResLoadChain >(Arena* arena) {
+  return Arena::CreateInternal< ::grpc_admin::ResLoadChain >(arena);
 }
 }  // namespace protobuf
 }  // namespace google

--- a/src/plugins/admin_plugin/rpc_services/proto/include/admin_service.grpc.pb.h
+++ b/src/plugins/admin_plugin/rpc_services/proto/include/admin_service.grpc.pb.h
@@ -34,12 +34,19 @@ class GruutAdminService final {
   class StubInterface {
    public:
     virtual ~StubInterface() {}
-    virtual ::grpc::Status Setup(::grpc::ClientContext* context, const ::grpc_admin::ReqSetup& request, ::grpc_admin::ResSetup* response) = 0;
-    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResSetup>> AsyncSetup(::grpc::ClientContext* context, const ::grpc_admin::ReqSetup& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResSetup>>(AsyncSetupRaw(context, request, cq));
+    virtual ::grpc::Status SetupKey(::grpc::ClientContext* context, const ::grpc_admin::ReqSetupKey& request, ::grpc_admin::ResSetupKey* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResSetupKey>> AsyncSetupKey(::grpc::ClientContext* context, const ::grpc_admin::ReqSetupKey& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResSetupKey>>(AsyncSetupKeyRaw(context, request, cq));
     }
-    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResSetup>> PrepareAsyncSetup(::grpc::ClientContext* context, const ::grpc_admin::ReqSetup& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResSetup>>(PrepareAsyncSetupRaw(context, request, cq));
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResSetupKey>> PrepareAsyncSetupKey(::grpc::ClientContext* context, const ::grpc_admin::ReqSetupKey& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResSetupKey>>(PrepareAsyncSetupKeyRaw(context, request, cq));
+    }
+    virtual ::grpc::Status Login(::grpc::ClientContext* context, const ::grpc_admin::ReqLogin& request, ::grpc_admin::ResLogin* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResLogin>> AsyncLogin(::grpc::ClientContext* context, const ::grpc_admin::ReqLogin& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResLogin>>(AsyncLoginRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResLogin>> PrepareAsyncLogin(::grpc::ClientContext* context, const ::grpc_admin::ReqLogin& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResLogin>>(PrepareAsyncLoginRaw(context, request, cq));
     }
     virtual ::grpc::Status Start(::grpc::ClientContext* context, const ::grpc_admin::ReqStart& request, ::grpc_admin::ResStart* response) = 0;
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResStart>> AsyncStart(::grpc::ClientContext* context, const ::grpc_admin::ReqStart& request, ::grpc::CompletionQueue* cq) {
@@ -48,12 +55,19 @@ class GruutAdminService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResStart>> PrepareAsyncStart(::grpc::ClientContext* context, const ::grpc_admin::ReqStart& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResStart>>(PrepareAsyncStartRaw(context, request, cq));
     }
-    virtual ::grpc::Status Stop(::grpc::ClientContext* context, const ::grpc_admin::ReqStop& request, ::grpc_admin::ResStop* response) = 0;
-    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResStop>> AsyncStop(::grpc::ClientContext* context, const ::grpc_admin::ReqStop& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResStop>>(AsyncStopRaw(context, request, cq));
+    virtual ::grpc::Status LoadWorld(::grpc::ClientContext* context, const ::grpc_admin::ReqLoadWorld& request, ::grpc_admin::ResLoadWorld* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResLoadWorld>> AsyncLoadWorld(::grpc::ClientContext* context, const ::grpc_admin::ReqLoadWorld& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResLoadWorld>>(AsyncLoadWorldRaw(context, request, cq));
     }
-    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResStop>> PrepareAsyncStop(::grpc::ClientContext* context, const ::grpc_admin::ReqStop& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResStop>>(PrepareAsyncStopRaw(context, request, cq));
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResLoadWorld>> PrepareAsyncLoadWorld(::grpc::ClientContext* context, const ::grpc_admin::ReqLoadWorld& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResLoadWorld>>(PrepareAsyncLoadWorldRaw(context, request, cq));
+    }
+    virtual ::grpc::Status LoadChain(::grpc::ClientContext* context, const ::grpc_admin::ReqLoadChain& request, ::grpc_admin::ResLoadChain* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResLoadChain>> AsyncLoadChain(::grpc::ClientContext* context, const ::grpc_admin::ReqLoadChain& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResLoadChain>>(AsyncLoadChainRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResLoadChain>> PrepareAsyncLoadChain(::grpc::ClientContext* context, const ::grpc_admin::ReqLoadChain& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResLoadChain>>(PrepareAsyncLoadChainRaw(context, request, cq));
     }
     virtual ::grpc::Status CheckStatus(::grpc::ClientContext* context, const ::grpc_admin::ReqStatus& request, ::grpc_admin::ResStatus* response) = 0;
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResStatus>> AsyncCheckStatus(::grpc::ClientContext* context, const ::grpc_admin::ReqStatus& request, ::grpc::CompletionQueue* cq) {
@@ -63,24 +77,35 @@ class GruutAdminService final {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResStatus>>(PrepareAsyncCheckStatusRaw(context, request, cq));
     }
   private:
-    virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResSetup>* AsyncSetupRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqSetup& request, ::grpc::CompletionQueue* cq) = 0;
-    virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResSetup>* PrepareAsyncSetupRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqSetup& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResSetupKey>* AsyncSetupKeyRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqSetupKey& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResSetupKey>* PrepareAsyncSetupKeyRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqSetupKey& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResLogin>* AsyncLoginRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqLogin& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResLogin>* PrepareAsyncLoginRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqLogin& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResStart>* AsyncStartRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqStart& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResStart>* PrepareAsyncStartRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqStart& request, ::grpc::CompletionQueue* cq) = 0;
-    virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResStop>* AsyncStopRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqStop& request, ::grpc::CompletionQueue* cq) = 0;
-    virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResStop>* PrepareAsyncStopRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqStop& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResLoadWorld>* AsyncLoadWorldRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqLoadWorld& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResLoadWorld>* PrepareAsyncLoadWorldRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqLoadWorld& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResLoadChain>* AsyncLoadChainRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqLoadChain& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResLoadChain>* PrepareAsyncLoadChainRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqLoadChain& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResStatus>* AsyncCheckStatusRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqStatus& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_admin::ResStatus>* PrepareAsyncCheckStatusRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqStatus& request, ::grpc::CompletionQueue* cq) = 0;
   };
   class Stub final : public StubInterface {
    public:
     Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channel);
-    ::grpc::Status Setup(::grpc::ClientContext* context, const ::grpc_admin::ReqSetup& request, ::grpc_admin::ResSetup* response) override;
-    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResSetup>> AsyncSetup(::grpc::ClientContext* context, const ::grpc_admin::ReqSetup& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResSetup>>(AsyncSetupRaw(context, request, cq));
+    ::grpc::Status SetupKey(::grpc::ClientContext* context, const ::grpc_admin::ReqSetupKey& request, ::grpc_admin::ResSetupKey* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResSetupKey>> AsyncSetupKey(::grpc::ClientContext* context, const ::grpc_admin::ReqSetupKey& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResSetupKey>>(AsyncSetupKeyRaw(context, request, cq));
     }
-    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResSetup>> PrepareAsyncSetup(::grpc::ClientContext* context, const ::grpc_admin::ReqSetup& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResSetup>>(PrepareAsyncSetupRaw(context, request, cq));
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResSetupKey>> PrepareAsyncSetupKey(::grpc::ClientContext* context, const ::grpc_admin::ReqSetupKey& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResSetupKey>>(PrepareAsyncSetupKeyRaw(context, request, cq));
+    }
+    ::grpc::Status Login(::grpc::ClientContext* context, const ::grpc_admin::ReqLogin& request, ::grpc_admin::ResLogin* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResLogin>> AsyncLogin(::grpc::ClientContext* context, const ::grpc_admin::ReqLogin& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResLogin>>(AsyncLoginRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResLogin>> PrepareAsyncLogin(::grpc::ClientContext* context, const ::grpc_admin::ReqLogin& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResLogin>>(PrepareAsyncLoginRaw(context, request, cq));
     }
     ::grpc::Status Start(::grpc::ClientContext* context, const ::grpc_admin::ReqStart& request, ::grpc_admin::ResStart* response) override;
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResStart>> AsyncStart(::grpc::ClientContext* context, const ::grpc_admin::ReqStart& request, ::grpc::CompletionQueue* cq) {
@@ -89,12 +114,19 @@ class GruutAdminService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResStart>> PrepareAsyncStart(::grpc::ClientContext* context, const ::grpc_admin::ReqStart& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResStart>>(PrepareAsyncStartRaw(context, request, cq));
     }
-    ::grpc::Status Stop(::grpc::ClientContext* context, const ::grpc_admin::ReqStop& request, ::grpc_admin::ResStop* response) override;
-    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResStop>> AsyncStop(::grpc::ClientContext* context, const ::grpc_admin::ReqStop& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResStop>>(AsyncStopRaw(context, request, cq));
+    ::grpc::Status LoadWorld(::grpc::ClientContext* context, const ::grpc_admin::ReqLoadWorld& request, ::grpc_admin::ResLoadWorld* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResLoadWorld>> AsyncLoadWorld(::grpc::ClientContext* context, const ::grpc_admin::ReqLoadWorld& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResLoadWorld>>(AsyncLoadWorldRaw(context, request, cq));
     }
-    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResStop>> PrepareAsyncStop(::grpc::ClientContext* context, const ::grpc_admin::ReqStop& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResStop>>(PrepareAsyncStopRaw(context, request, cq));
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResLoadWorld>> PrepareAsyncLoadWorld(::grpc::ClientContext* context, const ::grpc_admin::ReqLoadWorld& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResLoadWorld>>(PrepareAsyncLoadWorldRaw(context, request, cq));
+    }
+    ::grpc::Status LoadChain(::grpc::ClientContext* context, const ::grpc_admin::ReqLoadChain& request, ::grpc_admin::ResLoadChain* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResLoadChain>> AsyncLoadChain(::grpc::ClientContext* context, const ::grpc_admin::ReqLoadChain& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResLoadChain>>(AsyncLoadChainRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResLoadChain>> PrepareAsyncLoadChain(::grpc::ClientContext* context, const ::grpc_admin::ReqLoadChain& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResLoadChain>>(PrepareAsyncLoadChainRaw(context, request, cq));
     }
     ::grpc::Status CheckStatus(::grpc::ClientContext* context, const ::grpc_admin::ReqStatus& request, ::grpc_admin::ResStatus* response) override;
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResStatus>> AsyncCheckStatus(::grpc::ClientContext* context, const ::grpc_admin::ReqStatus& request, ::grpc::CompletionQueue* cq) {
@@ -106,17 +138,23 @@ class GruutAdminService final {
 
    private:
     std::shared_ptr< ::grpc::ChannelInterface> channel_;
-    ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResSetup>* AsyncSetupRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqSetup& request, ::grpc::CompletionQueue* cq) override;
-    ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResSetup>* PrepareAsyncSetupRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqSetup& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResSetupKey>* AsyncSetupKeyRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqSetupKey& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResSetupKey>* PrepareAsyncSetupKeyRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqSetupKey& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResLogin>* AsyncLoginRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqLogin& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResLogin>* PrepareAsyncLoginRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqLogin& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResStart>* AsyncStartRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqStart& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResStart>* PrepareAsyncStartRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqStart& request, ::grpc::CompletionQueue* cq) override;
-    ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResStop>* AsyncStopRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqStop& request, ::grpc::CompletionQueue* cq) override;
-    ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResStop>* PrepareAsyncStopRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqStop& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResLoadWorld>* AsyncLoadWorldRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqLoadWorld& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResLoadWorld>* PrepareAsyncLoadWorldRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqLoadWorld& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResLoadChain>* AsyncLoadChainRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqLoadChain& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResLoadChain>* PrepareAsyncLoadChainRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqLoadChain& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResStatus>* AsyncCheckStatusRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqStatus& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::grpc_admin::ResStatus>* PrepareAsyncCheckStatusRaw(::grpc::ClientContext* context, const ::grpc_admin::ReqStatus& request, ::grpc::CompletionQueue* cq) override;
-    const ::grpc::internal::RpcMethod rpcmethod_Setup_;
+    const ::grpc::internal::RpcMethod rpcmethod_SetupKey_;
+    const ::grpc::internal::RpcMethod rpcmethod_Login_;
     const ::grpc::internal::RpcMethod rpcmethod_Start_;
-    const ::grpc::internal::RpcMethod rpcmethod_Stop_;
+    const ::grpc::internal::RpcMethod rpcmethod_LoadWorld_;
+    const ::grpc::internal::RpcMethod rpcmethod_LoadChain_;
     const ::grpc::internal::RpcMethod rpcmethod_CheckStatus_;
   };
   static std::unique_ptr<Stub> NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options = ::grpc::StubOptions());
@@ -125,29 +163,51 @@ class GruutAdminService final {
    public:
     Service();
     virtual ~Service();
-    virtual ::grpc::Status Setup(::grpc::ServerContext* context, const ::grpc_admin::ReqSetup* request, ::grpc_admin::ResSetup* response);
+    virtual ::grpc::Status SetupKey(::grpc::ServerContext* context, const ::grpc_admin::ReqSetupKey* request, ::grpc_admin::ResSetupKey* response);
+    virtual ::grpc::Status Login(::grpc::ServerContext* context, const ::grpc_admin::ReqLogin* request, ::grpc_admin::ResLogin* response);
     virtual ::grpc::Status Start(::grpc::ServerContext* context, const ::grpc_admin::ReqStart* request, ::grpc_admin::ResStart* response);
-    virtual ::grpc::Status Stop(::grpc::ServerContext* context, const ::grpc_admin::ReqStop* request, ::grpc_admin::ResStop* response);
+    virtual ::grpc::Status LoadWorld(::grpc::ServerContext* context, const ::grpc_admin::ReqLoadWorld* request, ::grpc_admin::ResLoadWorld* response);
+    virtual ::grpc::Status LoadChain(::grpc::ServerContext* context, const ::grpc_admin::ReqLoadChain* request, ::grpc_admin::ResLoadChain* response);
     virtual ::grpc::Status CheckStatus(::grpc::ServerContext* context, const ::grpc_admin::ReqStatus* request, ::grpc_admin::ResStatus* response);
   };
   template <class BaseClass>
-  class WithAsyncMethod_Setup : public BaseClass {
+  class WithAsyncMethod_SetupKey : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
-    WithAsyncMethod_Setup() {
+    WithAsyncMethod_SetupKey() {
       ::grpc::Service::MarkMethodAsync(0);
     }
-    ~WithAsyncMethod_Setup() override {
+    ~WithAsyncMethod_SetupKey() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status Setup(::grpc::ServerContext* context, const ::grpc_admin::ReqSetup* request, ::grpc_admin::ResSetup* response) override {
+    ::grpc::Status SetupKey(::grpc::ServerContext* context, const ::grpc_admin::ReqSetupKey* request, ::grpc_admin::ResSetupKey* response) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    void RequestSetup(::grpc::ServerContext* context, ::grpc_admin::ReqSetup* request, ::grpc::ServerAsyncResponseWriter< ::grpc_admin::ResSetup>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+    void RequestSetupKey(::grpc::ServerContext* context, ::grpc_admin::ReqSetupKey* request, ::grpc::ServerAsyncResponseWriter< ::grpc_admin::ResSetupKey>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
       ::grpc::Service::RequestAsyncUnary(0, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithAsyncMethod_Login : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithAsyncMethod_Login() {
+      ::grpc::Service::MarkMethodAsync(1);
+    }
+    ~WithAsyncMethod_Login() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status Login(::grpc::ServerContext* context, const ::grpc_admin::ReqLogin* request, ::grpc_admin::ResLogin* response) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestLogin(::grpc::ServerContext* context, ::grpc_admin::ReqLogin* request, ::grpc::ServerAsyncResponseWriter< ::grpc_admin::ResLogin>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(1, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -156,7 +216,7 @@ class GruutAdminService final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithAsyncMethod_Start() {
-      ::grpc::Service::MarkMethodAsync(1);
+      ::grpc::Service::MarkMethodAsync(2);
     }
     ~WithAsyncMethod_Start() override {
       BaseClassMustBeDerivedFromService(this);
@@ -167,27 +227,47 @@ class GruutAdminService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestStart(::grpc::ServerContext* context, ::grpc_admin::ReqStart* request, ::grpc::ServerAsyncResponseWriter< ::grpc_admin::ResStart>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(1, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(2, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
-  class WithAsyncMethod_Stop : public BaseClass {
+  class WithAsyncMethod_LoadWorld : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
-    WithAsyncMethod_Stop() {
-      ::grpc::Service::MarkMethodAsync(2);
+    WithAsyncMethod_LoadWorld() {
+      ::grpc::Service::MarkMethodAsync(3);
     }
-    ~WithAsyncMethod_Stop() override {
+    ~WithAsyncMethod_LoadWorld() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status Stop(::grpc::ServerContext* context, const ::grpc_admin::ReqStop* request, ::grpc_admin::ResStop* response) override {
+    ::grpc::Status LoadWorld(::grpc::ServerContext* context, const ::grpc_admin::ReqLoadWorld* request, ::grpc_admin::ResLoadWorld* response) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    void RequestStop(::grpc::ServerContext* context, ::grpc_admin::ReqStop* request, ::grpc::ServerAsyncResponseWriter< ::grpc_admin::ResStop>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(2, context, request, response, new_call_cq, notification_cq, tag);
+    void RequestLoadWorld(::grpc::ServerContext* context, ::grpc_admin::ReqLoadWorld* request, ::grpc::ServerAsyncResponseWriter< ::grpc_admin::ResLoadWorld>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(3, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithAsyncMethod_LoadChain : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithAsyncMethod_LoadChain() {
+      ::grpc::Service::MarkMethodAsync(4);
+    }
+    ~WithAsyncMethod_LoadChain() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status LoadChain(::grpc::ServerContext* context, const ::grpc_admin::ReqLoadChain* request, ::grpc_admin::ResLoadChain* response) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestLoadChain(::grpc::ServerContext* context, ::grpc_admin::ReqLoadChain* request, ::grpc::ServerAsyncResponseWriter< ::grpc_admin::ResLoadChain>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(4, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -196,7 +276,7 @@ class GruutAdminService final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithAsyncMethod_CheckStatus() {
-      ::grpc::Service::MarkMethodAsync(3);
+      ::grpc::Service::MarkMethodAsync(5);
     }
     ~WithAsyncMethod_CheckStatus() override {
       BaseClassMustBeDerivedFromService(this);
@@ -207,23 +287,40 @@ class GruutAdminService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestCheckStatus(::grpc::ServerContext* context, ::grpc_admin::ReqStatus* request, ::grpc::ServerAsyncResponseWriter< ::grpc_admin::ResStatus>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(3, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(5, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
-  typedef WithAsyncMethod_Setup<WithAsyncMethod_Start<WithAsyncMethod_Stop<WithAsyncMethod_CheckStatus<Service > > > > AsyncService;
+  typedef WithAsyncMethod_SetupKey<WithAsyncMethod_Login<WithAsyncMethod_Start<WithAsyncMethod_LoadWorld<WithAsyncMethod_LoadChain<WithAsyncMethod_CheckStatus<Service > > > > > > AsyncService;
   template <class BaseClass>
-  class WithGenericMethod_Setup : public BaseClass {
+  class WithGenericMethod_SetupKey : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
-    WithGenericMethod_Setup() {
+    WithGenericMethod_SetupKey() {
       ::grpc::Service::MarkMethodGeneric(0);
     }
-    ~WithGenericMethod_Setup() override {
+    ~WithGenericMethod_SetupKey() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status Setup(::grpc::ServerContext* context, const ::grpc_admin::ReqSetup* request, ::grpc_admin::ResSetup* response) override {
+    ::grpc::Status SetupKey(::grpc::ServerContext* context, const ::grpc_admin::ReqSetupKey* request, ::grpc_admin::ResSetupKey* response) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_Login : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithGenericMethod_Login() {
+      ::grpc::Service::MarkMethodGeneric(1);
+    }
+    ~WithGenericMethod_Login() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status Login(::grpc::ServerContext* context, const ::grpc_admin::ReqLogin* request, ::grpc_admin::ResLogin* response) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
@@ -234,7 +331,7 @@ class GruutAdminService final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithGenericMethod_Start() {
-      ::grpc::Service::MarkMethodGeneric(1);
+      ::grpc::Service::MarkMethodGeneric(2);
     }
     ~WithGenericMethod_Start() override {
       BaseClassMustBeDerivedFromService(this);
@@ -246,18 +343,35 @@ class GruutAdminService final {
     }
   };
   template <class BaseClass>
-  class WithGenericMethod_Stop : public BaseClass {
+  class WithGenericMethod_LoadWorld : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
-    WithGenericMethod_Stop() {
-      ::grpc::Service::MarkMethodGeneric(2);
+    WithGenericMethod_LoadWorld() {
+      ::grpc::Service::MarkMethodGeneric(3);
     }
-    ~WithGenericMethod_Stop() override {
+    ~WithGenericMethod_LoadWorld() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status Stop(::grpc::ServerContext* context, const ::grpc_admin::ReqStop* request, ::grpc_admin::ResStop* response) override {
+    ::grpc::Status LoadWorld(::grpc::ServerContext* context, const ::grpc_admin::ReqLoadWorld* request, ::grpc_admin::ResLoadWorld* response) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+  };
+  template <class BaseClass>
+  class WithGenericMethod_LoadChain : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithGenericMethod_LoadChain() {
+      ::grpc::Service::MarkMethodGeneric(4);
+    }
+    ~WithGenericMethod_LoadChain() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status LoadChain(::grpc::ServerContext* context, const ::grpc_admin::ReqLoadChain* request, ::grpc_admin::ResLoadChain* response) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
@@ -268,7 +382,7 @@ class GruutAdminService final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithGenericMethod_CheckStatus() {
-      ::grpc::Service::MarkMethodGeneric(3);
+      ::grpc::Service::MarkMethodGeneric(5);
     }
     ~WithGenericMethod_CheckStatus() override {
       BaseClassMustBeDerivedFromService(this);
@@ -280,23 +394,43 @@ class GruutAdminService final {
     }
   };
   template <class BaseClass>
-  class WithRawMethod_Setup : public BaseClass {
+  class WithRawMethod_SetupKey : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
-    WithRawMethod_Setup() {
+    WithRawMethod_SetupKey() {
       ::grpc::Service::MarkMethodRaw(0);
     }
-    ~WithRawMethod_Setup() override {
+    ~WithRawMethod_SetupKey() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status Setup(::grpc::ServerContext* context, const ::grpc_admin::ReqSetup* request, ::grpc_admin::ResSetup* response) override {
+    ::grpc::Status SetupKey(::grpc::ServerContext* context, const ::grpc_admin::ReqSetupKey* request, ::grpc_admin::ResSetupKey* response) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    void RequestSetup(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+    void RequestSetupKey(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
       ::grpc::Service::RequestAsyncUnary(0, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_Login : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithRawMethod_Login() {
+      ::grpc::Service::MarkMethodRaw(1);
+    }
+    ~WithRawMethod_Login() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status Login(::grpc::ServerContext* context, const ::grpc_admin::ReqLogin* request, ::grpc_admin::ResLogin* response) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestLogin(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(1, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -305,7 +439,7 @@ class GruutAdminService final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithRawMethod_Start() {
-      ::grpc::Service::MarkMethodRaw(1);
+      ::grpc::Service::MarkMethodRaw(2);
     }
     ~WithRawMethod_Start() override {
       BaseClassMustBeDerivedFromService(this);
@@ -316,27 +450,47 @@ class GruutAdminService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestStart(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(1, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(2, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
-  class WithRawMethod_Stop : public BaseClass {
+  class WithRawMethod_LoadWorld : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
-    WithRawMethod_Stop() {
-      ::grpc::Service::MarkMethodRaw(2);
+    WithRawMethod_LoadWorld() {
+      ::grpc::Service::MarkMethodRaw(3);
     }
-    ~WithRawMethod_Stop() override {
+    ~WithRawMethod_LoadWorld() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status Stop(::grpc::ServerContext* context, const ::grpc_admin::ReqStop* request, ::grpc_admin::ResStop* response) override {
+    ::grpc::Status LoadWorld(::grpc::ServerContext* context, const ::grpc_admin::ReqLoadWorld* request, ::grpc_admin::ResLoadWorld* response) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    void RequestStop(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(2, context, request, response, new_call_cq, notification_cq, tag);
+    void RequestLoadWorld(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(3, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
+  class WithRawMethod_LoadChain : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithRawMethod_LoadChain() {
+      ::grpc::Service::MarkMethodRaw(4);
+    }
+    ~WithRawMethod_LoadChain() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status LoadChain(::grpc::ServerContext* context, const ::grpc_admin::ReqLoadChain* request, ::grpc_admin::ResLoadChain* response) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestLoadChain(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(4, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -345,7 +499,7 @@ class GruutAdminService final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithRawMethod_CheckStatus() {
-      ::grpc::Service::MarkMethodRaw(3);
+      ::grpc::Service::MarkMethodRaw(5);
     }
     ~WithRawMethod_CheckStatus() override {
       BaseClassMustBeDerivedFromService(this);
@@ -356,28 +510,48 @@ class GruutAdminService final {
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     void RequestCheckStatus(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncUnary(3, context, request, response, new_call_cq, notification_cq, tag);
+      ::grpc::Service::RequestAsyncUnary(5, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
-  class WithStreamedUnaryMethod_Setup : public BaseClass {
+  class WithStreamedUnaryMethod_SetupKey : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
-    WithStreamedUnaryMethod_Setup() {
+    WithStreamedUnaryMethod_SetupKey() {
       ::grpc::Service::MarkMethodStreamed(0,
-        new ::grpc::internal::StreamedUnaryHandler< ::grpc_admin::ReqSetup, ::grpc_admin::ResSetup>(std::bind(&WithStreamedUnaryMethod_Setup<BaseClass>::StreamedSetup, this, std::placeholders::_1, std::placeholders::_2)));
+        new ::grpc::internal::StreamedUnaryHandler< ::grpc_admin::ReqSetupKey, ::grpc_admin::ResSetupKey>(std::bind(&WithStreamedUnaryMethod_SetupKey<BaseClass>::StreamedSetupKey, this, std::placeholders::_1, std::placeholders::_2)));
     }
-    ~WithStreamedUnaryMethod_Setup() override {
+    ~WithStreamedUnaryMethod_SetupKey() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable regular version of this method
-    ::grpc::Status Setup(::grpc::ServerContext* context, const ::grpc_admin::ReqSetup* request, ::grpc_admin::ResSetup* response) override {
+    ::grpc::Status SetupKey(::grpc::ServerContext* context, const ::grpc_admin::ReqSetupKey* request, ::grpc_admin::ResSetupKey* response) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     // replace default version of method with streamed unary
-    virtual ::grpc::Status StreamedSetup(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::grpc_admin::ReqSetup,::grpc_admin::ResSetup>* server_unary_streamer) = 0;
+    virtual ::grpc::Status StreamedSetupKey(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::grpc_admin::ReqSetupKey,::grpc_admin::ResSetupKey>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
+  class WithStreamedUnaryMethod_Login : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithStreamedUnaryMethod_Login() {
+      ::grpc::Service::MarkMethodStreamed(1,
+        new ::grpc::internal::StreamedUnaryHandler< ::grpc_admin::ReqLogin, ::grpc_admin::ResLogin>(std::bind(&WithStreamedUnaryMethod_Login<BaseClass>::StreamedLogin, this, std::placeholders::_1, std::placeholders::_2)));
+    }
+    ~WithStreamedUnaryMethod_Login() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status Login(::grpc::ServerContext* context, const ::grpc_admin::ReqLogin* request, ::grpc_admin::ResLogin* response) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedLogin(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::grpc_admin::ReqLogin,::grpc_admin::ResLogin>* server_unary_streamer) = 0;
   };
   template <class BaseClass>
   class WithStreamedUnaryMethod_Start : public BaseClass {
@@ -385,7 +559,7 @@ class GruutAdminService final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithStreamedUnaryMethod_Start() {
-      ::grpc::Service::MarkMethodStreamed(1,
+      ::grpc::Service::MarkMethodStreamed(2,
         new ::grpc::internal::StreamedUnaryHandler< ::grpc_admin::ReqStart, ::grpc_admin::ResStart>(std::bind(&WithStreamedUnaryMethod_Start<BaseClass>::StreamedStart, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_Start() override {
@@ -400,24 +574,44 @@ class GruutAdminService final {
     virtual ::grpc::Status StreamedStart(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::grpc_admin::ReqStart,::grpc_admin::ResStart>* server_unary_streamer) = 0;
   };
   template <class BaseClass>
-  class WithStreamedUnaryMethod_Stop : public BaseClass {
+  class WithStreamedUnaryMethod_LoadWorld : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
-    WithStreamedUnaryMethod_Stop() {
-      ::grpc::Service::MarkMethodStreamed(2,
-        new ::grpc::internal::StreamedUnaryHandler< ::grpc_admin::ReqStop, ::grpc_admin::ResStop>(std::bind(&WithStreamedUnaryMethod_Stop<BaseClass>::StreamedStop, this, std::placeholders::_1, std::placeholders::_2)));
+    WithStreamedUnaryMethod_LoadWorld() {
+      ::grpc::Service::MarkMethodStreamed(3,
+        new ::grpc::internal::StreamedUnaryHandler< ::grpc_admin::ReqLoadWorld, ::grpc_admin::ResLoadWorld>(std::bind(&WithStreamedUnaryMethod_LoadWorld<BaseClass>::StreamedLoadWorld, this, std::placeholders::_1, std::placeholders::_2)));
     }
-    ~WithStreamedUnaryMethod_Stop() override {
+    ~WithStreamedUnaryMethod_LoadWorld() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable regular version of this method
-    ::grpc::Status Stop(::grpc::ServerContext* context, const ::grpc_admin::ReqStop* request, ::grpc_admin::ResStop* response) override {
+    ::grpc::Status LoadWorld(::grpc::ServerContext* context, const ::grpc_admin::ReqLoadWorld* request, ::grpc_admin::ResLoadWorld* response) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     // replace default version of method with streamed unary
-    virtual ::grpc::Status StreamedStop(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::grpc_admin::ReqStop,::grpc_admin::ResStop>* server_unary_streamer) = 0;
+    virtual ::grpc::Status StreamedLoadWorld(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::grpc_admin::ReqLoadWorld,::grpc_admin::ResLoadWorld>* server_unary_streamer) = 0;
+  };
+  template <class BaseClass>
+  class WithStreamedUnaryMethod_LoadChain : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithStreamedUnaryMethod_LoadChain() {
+      ::grpc::Service::MarkMethodStreamed(4,
+        new ::grpc::internal::StreamedUnaryHandler< ::grpc_admin::ReqLoadChain, ::grpc_admin::ResLoadChain>(std::bind(&WithStreamedUnaryMethod_LoadChain<BaseClass>::StreamedLoadChain, this, std::placeholders::_1, std::placeholders::_2)));
+    }
+    ~WithStreamedUnaryMethod_LoadChain() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status LoadChain(::grpc::ServerContext* context, const ::grpc_admin::ReqLoadChain* request, ::grpc_admin::ResLoadChain* response) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedLoadChain(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::grpc_admin::ReqLoadChain,::grpc_admin::ResLoadChain>* server_unary_streamer) = 0;
   };
   template <class BaseClass>
   class WithStreamedUnaryMethod_CheckStatus : public BaseClass {
@@ -425,7 +619,7 @@ class GruutAdminService final {
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
     WithStreamedUnaryMethod_CheckStatus() {
-      ::grpc::Service::MarkMethodStreamed(3,
+      ::grpc::Service::MarkMethodStreamed(5,
         new ::grpc::internal::StreamedUnaryHandler< ::grpc_admin::ReqStatus, ::grpc_admin::ResStatus>(std::bind(&WithStreamedUnaryMethod_CheckStatus<BaseClass>::StreamedCheckStatus, this, std::placeholders::_1, std::placeholders::_2)));
     }
     ~WithStreamedUnaryMethod_CheckStatus() override {
@@ -439,9 +633,9 @@ class GruutAdminService final {
     // replace default version of method with streamed unary
     virtual ::grpc::Status StreamedCheckStatus(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::grpc_admin::ReqStatus,::grpc_admin::ResStatus>* server_unary_streamer) = 0;
   };
-  typedef WithStreamedUnaryMethod_Setup<WithStreamedUnaryMethod_Start<WithStreamedUnaryMethod_Stop<WithStreamedUnaryMethod_CheckStatus<Service > > > > StreamedUnaryService;
+  typedef WithStreamedUnaryMethod_SetupKey<WithStreamedUnaryMethod_Login<WithStreamedUnaryMethod_Start<WithStreamedUnaryMethod_LoadWorld<WithStreamedUnaryMethod_LoadChain<WithStreamedUnaryMethod_CheckStatus<Service > > > > > > StreamedUnaryService;
   typedef Service SplitStreamedService;
-  typedef WithStreamedUnaryMethod_Setup<WithStreamedUnaryMethod_Start<WithStreamedUnaryMethod_Stop<WithStreamedUnaryMethod_CheckStatus<Service > > > > StreamedService;
+  typedef WithStreamedUnaryMethod_SetupKey<WithStreamedUnaryMethod_Login<WithStreamedUnaryMethod_Start<WithStreamedUnaryMethod_LoadWorld<WithStreamedUnaryMethod_LoadChain<WithStreamedUnaryMethod_CheckStatus<Service > > > > > > StreamedService;
 };
 
 }  // namespace grpc_admin

--- a/src/plugins/admin_plugin/rpc_services/proto/include/admin_service.pb.h
+++ b/src/plugins/admin_plugin/rpc_services/proto/include/admin_service.pb.h
@@ -29,6 +29,7 @@
 #include <google/protobuf/message.h>
 #include <google/protobuf/repeated_field.h>  // IWYU pragma: export
 #include <google/protobuf/extension_set.h>  // IWYU pragma: export
+#include <google/protobuf/generated_enum_reflection.h>
 #include <google/protobuf/unknown_field_set.h>
 // @@protoc_insertion_point(includes)
 #define PROTOBUF_INTERNAL_EXPORT_protobuf_admin_5fservice_2eproto 
@@ -38,7 +39,7 @@ namespace protobuf_admin_5fservice_2eproto {
 struct TableStruct {
   static const ::google::protobuf::internal::ParseTableField entries[];
   static const ::google::protobuf::internal::AuxillaryParseTableField aux[];
-  static const ::google::protobuf::internal::ParseTable schema[8];
+  static const ::google::protobuf::internal::ParseTable schema[12];
   static const ::google::protobuf::internal::FieldMetadata field_metadata[];
   static const ::google::protobuf::internal::SerializationTable serialization_table[];
   static const ::google::protobuf::uint32 offsets[];
@@ -46,65 +47,102 @@ struct TableStruct {
 void AddDescriptors();
 }  // namespace protobuf_admin_5fservice_2eproto
 namespace grpc_admin {
-class ReqSetup;
-class ReqSetupDefaultTypeInternal;
-extern ReqSetupDefaultTypeInternal _ReqSetup_default_instance_;
+class ReqLoadChain;
+class ReqLoadChainDefaultTypeInternal;
+extern ReqLoadChainDefaultTypeInternal _ReqLoadChain_default_instance_;
+class ReqLoadWorld;
+class ReqLoadWorldDefaultTypeInternal;
+extern ReqLoadWorldDefaultTypeInternal _ReqLoadWorld_default_instance_;
+class ReqLogin;
+class ReqLoginDefaultTypeInternal;
+extern ReqLoginDefaultTypeInternal _ReqLogin_default_instance_;
+class ReqSetupKey;
+class ReqSetupKeyDefaultTypeInternal;
+extern ReqSetupKeyDefaultTypeInternal _ReqSetupKey_default_instance_;
 class ReqStart;
 class ReqStartDefaultTypeInternal;
 extern ReqStartDefaultTypeInternal _ReqStart_default_instance_;
 class ReqStatus;
 class ReqStatusDefaultTypeInternal;
 extern ReqStatusDefaultTypeInternal _ReqStatus_default_instance_;
-class ReqStop;
-class ReqStopDefaultTypeInternal;
-extern ReqStopDefaultTypeInternal _ReqStop_default_instance_;
-class ResSetup;
-class ResSetupDefaultTypeInternal;
-extern ResSetupDefaultTypeInternal _ResSetup_default_instance_;
+class ResLoadChain;
+class ResLoadChainDefaultTypeInternal;
+extern ResLoadChainDefaultTypeInternal _ResLoadChain_default_instance_;
+class ResLoadWorld;
+class ResLoadWorldDefaultTypeInternal;
+extern ResLoadWorldDefaultTypeInternal _ResLoadWorld_default_instance_;
+class ResLogin;
+class ResLoginDefaultTypeInternal;
+extern ResLoginDefaultTypeInternal _ResLogin_default_instance_;
+class ResSetupKey;
+class ResSetupKeyDefaultTypeInternal;
+extern ResSetupKeyDefaultTypeInternal _ResSetupKey_default_instance_;
 class ResStart;
 class ResStartDefaultTypeInternal;
 extern ResStartDefaultTypeInternal _ResStart_default_instance_;
 class ResStatus;
 class ResStatusDefaultTypeInternal;
 extern ResStatusDefaultTypeInternal _ResStatus_default_instance_;
-class ResStop;
-class ResStopDefaultTypeInternal;
-extern ResStopDefaultTypeInternal _ResStop_default_instance_;
 }  // namespace grpc_admin
 namespace google {
 namespace protobuf {
-template<> ::grpc_admin::ReqSetup* Arena::CreateMaybeMessage<::grpc_admin::ReqSetup>(Arena*);
+template<> ::grpc_admin::ReqLoadChain* Arena::CreateMaybeMessage<::grpc_admin::ReqLoadChain>(Arena*);
+template<> ::grpc_admin::ReqLoadWorld* Arena::CreateMaybeMessage<::grpc_admin::ReqLoadWorld>(Arena*);
+template<> ::grpc_admin::ReqLogin* Arena::CreateMaybeMessage<::grpc_admin::ReqLogin>(Arena*);
+template<> ::grpc_admin::ReqSetupKey* Arena::CreateMaybeMessage<::grpc_admin::ReqSetupKey>(Arena*);
 template<> ::grpc_admin::ReqStart* Arena::CreateMaybeMessage<::grpc_admin::ReqStart>(Arena*);
 template<> ::grpc_admin::ReqStatus* Arena::CreateMaybeMessage<::grpc_admin::ReqStatus>(Arena*);
-template<> ::grpc_admin::ReqStop* Arena::CreateMaybeMessage<::grpc_admin::ReqStop>(Arena*);
-template<> ::grpc_admin::ResSetup* Arena::CreateMaybeMessage<::grpc_admin::ResSetup>(Arena*);
+template<> ::grpc_admin::ResLoadChain* Arena::CreateMaybeMessage<::grpc_admin::ResLoadChain>(Arena*);
+template<> ::grpc_admin::ResLoadWorld* Arena::CreateMaybeMessage<::grpc_admin::ResLoadWorld>(Arena*);
+template<> ::grpc_admin::ResLogin* Arena::CreateMaybeMessage<::grpc_admin::ResLogin>(Arena*);
+template<> ::grpc_admin::ResSetupKey* Arena::CreateMaybeMessage<::grpc_admin::ResSetupKey>(Arena*);
 template<> ::grpc_admin::ResStart* Arena::CreateMaybeMessage<::grpc_admin::ResStart>(Arena*);
 template<> ::grpc_admin::ResStatus* Arena::CreateMaybeMessage<::grpc_admin::ResStatus>(Arena*);
-template<> ::grpc_admin::ResStop* Arena::CreateMaybeMessage<::grpc_admin::ResStop>(Arena*);
 }  // namespace protobuf
 }  // namespace google
 namespace grpc_admin {
 
+enum ReqStart_Mode {
+  ReqStart_Mode_DEFAULT = 0,
+  ReqStart_Mode_MONITOR = 1,
+  ReqStart_Mode_ReqStart_Mode_INT_MIN_SENTINEL_DO_NOT_USE_ = ::google::protobuf::kint32min,
+  ReqStart_Mode_ReqStart_Mode_INT_MAX_SENTINEL_DO_NOT_USE_ = ::google::protobuf::kint32max
+};
+bool ReqStart_Mode_IsValid(int value);
+const ReqStart_Mode ReqStart_Mode_Mode_MIN = ReqStart_Mode_DEFAULT;
+const ReqStart_Mode ReqStart_Mode_Mode_MAX = ReqStart_Mode_MONITOR;
+const int ReqStart_Mode_Mode_ARRAYSIZE = ReqStart_Mode_Mode_MAX + 1;
+
+const ::google::protobuf::EnumDescriptor* ReqStart_Mode_descriptor();
+inline const ::std::string& ReqStart_Mode_Name(ReqStart_Mode value) {
+  return ::google::protobuf::internal::NameOfEnum(
+    ReqStart_Mode_descriptor(), value);
+}
+inline bool ReqStart_Mode_Parse(
+    const ::std::string& name, ReqStart_Mode* value) {
+  return ::google::protobuf::internal::ParseNamedEnum<ReqStart_Mode>(
+    ReqStart_Mode_descriptor(), name, value);
+}
 // ===================================================================
 
-class ReqSetup : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:grpc_admin.ReqSetup) */ {
+class ReqSetupKey : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:grpc_admin.ReqSetupKey) */ {
  public:
-  ReqSetup();
-  virtual ~ReqSetup();
+  ReqSetupKey();
+  virtual ~ReqSetupKey();
 
-  ReqSetup(const ReqSetup& from);
+  ReqSetupKey(const ReqSetupKey& from);
 
-  inline ReqSetup& operator=(const ReqSetup& from) {
+  inline ReqSetupKey& operator=(const ReqSetupKey& from) {
     CopyFrom(from);
     return *this;
   }
   #if LANG_CXX11
-  ReqSetup(ReqSetup&& from) noexcept
-    : ReqSetup() {
+  ReqSetupKey(ReqSetupKey&& from) noexcept
+    : ReqSetupKey() {
     *this = ::std::move(from);
   }
 
-  inline ReqSetup& operator=(ReqSetup&& from) noexcept {
+  inline ReqSetupKey& operator=(ReqSetupKey&& from) noexcept {
     if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
       if (this != &from) InternalSwap(&from);
     } else {
@@ -114,34 +152,34 @@ class ReqSetup : public ::google::protobuf::Message /* @@protoc_insertion_point(
   }
   #endif
   static const ::google::protobuf::Descriptor* descriptor();
-  static const ReqSetup& default_instance();
+  static const ReqSetupKey& default_instance();
 
   static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
-  static inline const ReqSetup* internal_default_instance() {
-    return reinterpret_cast<const ReqSetup*>(
-               &_ReqSetup_default_instance_);
+  static inline const ReqSetupKey* internal_default_instance() {
+    return reinterpret_cast<const ReqSetupKey*>(
+               &_ReqSetupKey_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
     0;
 
-  void Swap(ReqSetup* other);
-  friend void swap(ReqSetup& a, ReqSetup& b) {
+  void Swap(ReqSetupKey* other);
+  friend void swap(ReqSetupKey& a, ReqSetupKey& b) {
     a.Swap(&b);
   }
 
   // implements Message ----------------------------------------------
 
-  inline ReqSetup* New() const final {
-    return CreateMaybeMessage<ReqSetup>(NULL);
+  inline ReqSetupKey* New() const final {
+    return CreateMaybeMessage<ReqSetupKey>(NULL);
   }
 
-  ReqSetup* New(::google::protobuf::Arena* arena) const final {
-    return CreateMaybeMessage<ReqSetup>(arena);
+  ReqSetupKey* New(::google::protobuf::Arena* arena) const final {
+    return CreateMaybeMessage<ReqSetupKey>(arena);
   }
   void CopyFrom(const ::google::protobuf::Message& from) final;
   void MergeFrom(const ::google::protobuf::Message& from) final;
-  void CopyFrom(const ReqSetup& from);
-  void MergeFrom(const ReqSetup& from);
+  void CopyFrom(const ReqSetupKey& from);
+  void MergeFrom(const ReqSetupKey& from);
   void Clear() final;
   bool IsInitialized() const final;
 
@@ -158,7 +196,236 @@ class ReqSetup : public ::google::protobuf::Message /* @@protoc_insertion_point(
   void SharedCtor();
   void SharedDtor();
   void SetCachedSize(int size) const final;
-  void InternalSwap(ReqSetup* other);
+  void InternalSwap(ReqSetupKey* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return NULL;
+  }
+  inline void* MaybeArenaPtr() const {
+    return NULL;
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // string setup_port = 1;
+  void clear_setup_port();
+  static const int kSetupPortFieldNumber = 1;
+  const ::std::string& setup_port() const;
+  void set_setup_port(const ::std::string& value);
+  #if LANG_CXX11
+  void set_setup_port(::std::string&& value);
+  #endif
+  void set_setup_port(const char* value);
+  void set_setup_port(const char* value, size_t size);
+  ::std::string* mutable_setup_port();
+  ::std::string* release_setup_port();
+  void set_allocated_setup_port(::std::string* setup_port);
+
+  // @@protoc_insertion_point(class_scope:grpc_admin.ReqSetupKey)
+ private:
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::internal::ArenaStringPtr setup_port_;
+  mutable ::google::protobuf::internal::CachedSize _cached_size_;
+  friend struct ::protobuf_admin_5fservice_2eproto::TableStruct;
+};
+// -------------------------------------------------------------------
+
+class ResSetupKey : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:grpc_admin.ResSetupKey) */ {
+ public:
+  ResSetupKey();
+  virtual ~ResSetupKey();
+
+  ResSetupKey(const ResSetupKey& from);
+
+  inline ResSetupKey& operator=(const ResSetupKey& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  #if LANG_CXX11
+  ResSetupKey(ResSetupKey&& from) noexcept
+    : ResSetupKey() {
+    *this = ::std::move(from);
+  }
+
+  inline ResSetupKey& operator=(ResSetupKey&& from) noexcept {
+    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+  #endif
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const ResSetupKey& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const ResSetupKey* internal_default_instance() {
+    return reinterpret_cast<const ResSetupKey*>(
+               &_ResSetupKey_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    1;
+
+  void Swap(ResSetupKey* other);
+  friend void swap(ResSetupKey& a, ResSetupKey& b) {
+    a.Swap(&b);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline ResSetupKey* New() const final {
+    return CreateMaybeMessage<ResSetupKey>(NULL);
+  }
+
+  ResSetupKey* New(::google::protobuf::Arena* arena) const final {
+    return CreateMaybeMessage<ResSetupKey>(arena);
+  }
+  void CopyFrom(const ::google::protobuf::Message& from) final;
+  void MergeFrom(const ::google::protobuf::Message& from) final;
+  void CopyFrom(const ResSetupKey& from);
+  void MergeFrom(const ResSetupKey& from);
+  void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input) final;
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const final;
+  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
+      bool deterministic, ::google::protobuf::uint8* target) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(ResSetupKey* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return NULL;
+  }
+  inline void* MaybeArenaPtr() const {
+    return NULL;
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // string info = 2;
+  void clear_info();
+  static const int kInfoFieldNumber = 2;
+  const ::std::string& info() const;
+  void set_info(const ::std::string& value);
+  #if LANG_CXX11
+  void set_info(::std::string&& value);
+  #endif
+  void set_info(const char* value);
+  void set_info(const char* value, size_t size);
+  ::std::string* mutable_info();
+  ::std::string* release_info();
+  void set_allocated_info(::std::string* info);
+
+  // bool success = 1;
+  void clear_success();
+  static const int kSuccessFieldNumber = 1;
+  bool success() const;
+  void set_success(bool value);
+
+  // @@protoc_insertion_point(class_scope:grpc_admin.ResSetupKey)
+ private:
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::internal::ArenaStringPtr info_;
+  bool success_;
+  mutable ::google::protobuf::internal::CachedSize _cached_size_;
+  friend struct ::protobuf_admin_5fservice_2eproto::TableStruct;
+};
+// -------------------------------------------------------------------
+
+class ReqLogin : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:grpc_admin.ReqLogin) */ {
+ public:
+  ReqLogin();
+  virtual ~ReqLogin();
+
+  ReqLogin(const ReqLogin& from);
+
+  inline ReqLogin& operator=(const ReqLogin& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  #if LANG_CXX11
+  ReqLogin(ReqLogin&& from) noexcept
+    : ReqLogin() {
+    *this = ::std::move(from);
+  }
+
+  inline ReqLogin& operator=(ReqLogin&& from) noexcept {
+    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+  #endif
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const ReqLogin& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const ReqLogin* internal_default_instance() {
+    return reinterpret_cast<const ReqLogin*>(
+               &_ReqLogin_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    2;
+
+  void Swap(ReqLogin* other);
+  friend void swap(ReqLogin& a, ReqLogin& b) {
+    a.Swap(&b);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline ReqLogin* New() const final {
+    return CreateMaybeMessage<ReqLogin>(NULL);
+  }
+
+  ReqLogin* New(::google::protobuf::Arena* arena) const final {
+    return CreateMaybeMessage<ReqLogin>(arena);
+  }
+  void CopyFrom(const ::google::protobuf::Message& from) final;
+  void MergeFrom(const ::google::protobuf::Message& from) final;
+  void CopyFrom(const ReqLogin& from);
+  void MergeFrom(const ReqLogin& from);
+  void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input) final;
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const final;
+  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
+      bool deterministic, ::google::protobuf::uint8* target) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(ReqLogin* other);
   private:
   inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
     return NULL;
@@ -188,7 +455,7 @@ class ReqSetup : public ::google::protobuf::Message /* @@protoc_insertion_point(
   ::std::string* release_password();
   void set_allocated_password(::std::string* password);
 
-  // @@protoc_insertion_point(class_scope:grpc_admin.ReqSetup)
+  // @@protoc_insertion_point(class_scope:grpc_admin.ReqLogin)
  private:
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
@@ -198,24 +465,24 @@ class ReqSetup : public ::google::protobuf::Message /* @@protoc_insertion_point(
 };
 // -------------------------------------------------------------------
 
-class ResSetup : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:grpc_admin.ResSetup) */ {
+class ResLogin : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:grpc_admin.ResLogin) */ {
  public:
-  ResSetup();
-  virtual ~ResSetup();
+  ResLogin();
+  virtual ~ResLogin();
 
-  ResSetup(const ResSetup& from);
+  ResLogin(const ResLogin& from);
 
-  inline ResSetup& operator=(const ResSetup& from) {
+  inline ResLogin& operator=(const ResLogin& from) {
     CopyFrom(from);
     return *this;
   }
   #if LANG_CXX11
-  ResSetup(ResSetup&& from) noexcept
-    : ResSetup() {
+  ResLogin(ResLogin&& from) noexcept
+    : ResLogin() {
     *this = ::std::move(from);
   }
 
-  inline ResSetup& operator=(ResSetup&& from) noexcept {
+  inline ResLogin& operator=(ResLogin&& from) noexcept {
     if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
       if (this != &from) InternalSwap(&from);
     } else {
@@ -225,34 +492,34 @@ class ResSetup : public ::google::protobuf::Message /* @@protoc_insertion_point(
   }
   #endif
   static const ::google::protobuf::Descriptor* descriptor();
-  static const ResSetup& default_instance();
+  static const ResLogin& default_instance();
 
   static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
-  static inline const ResSetup* internal_default_instance() {
-    return reinterpret_cast<const ResSetup*>(
-               &_ResSetup_default_instance_);
+  static inline const ResLogin* internal_default_instance() {
+    return reinterpret_cast<const ResLogin*>(
+               &_ResLogin_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    1;
+    3;
 
-  void Swap(ResSetup* other);
-  friend void swap(ResSetup& a, ResSetup& b) {
+  void Swap(ResLogin* other);
+  friend void swap(ResLogin& a, ResLogin& b) {
     a.Swap(&b);
   }
 
   // implements Message ----------------------------------------------
 
-  inline ResSetup* New() const final {
-    return CreateMaybeMessage<ResSetup>(NULL);
+  inline ResLogin* New() const final {
+    return CreateMaybeMessage<ResLogin>(NULL);
   }
 
-  ResSetup* New(::google::protobuf::Arena* arena) const final {
-    return CreateMaybeMessage<ResSetup>(arena);
+  ResLogin* New(::google::protobuf::Arena* arena) const final {
+    return CreateMaybeMessage<ResLogin>(arena);
   }
   void CopyFrom(const ::google::protobuf::Message& from) final;
   void MergeFrom(const ::google::protobuf::Message& from) final;
-  void CopyFrom(const ResSetup& from);
-  void MergeFrom(const ResSetup& from);
+  void CopyFrom(const ResLogin& from);
+  void MergeFrom(const ResLogin& from);
   void Clear() final;
   bool IsInitialized() const final;
 
@@ -269,7 +536,7 @@ class ResSetup : public ::google::protobuf::Message /* @@protoc_insertion_point(
   void SharedCtor();
   void SharedDtor();
   void SetCachedSize(int size) const final;
-  void InternalSwap(ResSetup* other);
+  void InternalSwap(ResLogin* other);
   private:
   inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
     return NULL;
@@ -285,16 +552,31 @@ class ResSetup : public ::google::protobuf::Message /* @@protoc_insertion_point(
 
   // accessors -------------------------------------------------------
 
+  // string info = 2;
+  void clear_info();
+  static const int kInfoFieldNumber = 2;
+  const ::std::string& info() const;
+  void set_info(const ::std::string& value);
+  #if LANG_CXX11
+  void set_info(::std::string&& value);
+  #endif
+  void set_info(const char* value);
+  void set_info(const char* value, size_t size);
+  ::std::string* mutable_info();
+  ::std::string* release_info();
+  void set_allocated_info(::std::string* info);
+
   // bool success = 1;
   void clear_success();
   static const int kSuccessFieldNumber = 1;
   bool success() const;
   void set_success(bool value);
 
-  // @@protoc_insertion_point(class_scope:grpc_admin.ResSetup)
+  // @@protoc_insertion_point(class_scope:grpc_admin.ResLogin)
  private:
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::internal::ArenaStringPtr info_;
   bool success_;
   mutable ::google::protobuf::internal::CachedSize _cached_size_;
   friend struct ::protobuf_admin_5fservice_2eproto::TableStruct;
@@ -336,7 +618,7 @@ class ReqStart : public ::google::protobuf::Message /* @@protoc_insertion_point(
                &_ReqStart_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    2;
+    4;
 
   void Swap(ReqStart* other);
   friend void swap(ReqStart& a, ReqStart& b) {
@@ -386,12 +668,45 @@ class ReqStart : public ::google::protobuf::Message /* @@protoc_insertion_point(
 
   // nested types ----------------------------------------------------
 
+  typedef ReqStart_Mode Mode;
+  static const Mode DEFAULT =
+    ReqStart_Mode_DEFAULT;
+  static const Mode MONITOR =
+    ReqStart_Mode_MONITOR;
+  static inline bool Mode_IsValid(int value) {
+    return ReqStart_Mode_IsValid(value);
+  }
+  static const Mode Mode_MIN =
+    ReqStart_Mode_Mode_MIN;
+  static const Mode Mode_MAX =
+    ReqStart_Mode_Mode_MAX;
+  static const int Mode_ARRAYSIZE =
+    ReqStart_Mode_Mode_ARRAYSIZE;
+  static inline const ::google::protobuf::EnumDescriptor*
+  Mode_descriptor() {
+    return ReqStart_Mode_descriptor();
+  }
+  static inline const ::std::string& Mode_Name(Mode value) {
+    return ReqStart_Mode_Name(value);
+  }
+  static inline bool Mode_Parse(const ::std::string& name,
+      Mode* value) {
+    return ReqStart_Mode_Parse(name, value);
+  }
+
   // accessors -------------------------------------------------------
+
+  // .grpc_admin.ReqStart.Mode mode = 1;
+  void clear_mode();
+  static const int kModeFieldNumber = 1;
+  ::grpc_admin::ReqStart_Mode mode() const;
+  void set_mode(::grpc_admin::ReqStart_Mode value);
 
   // @@protoc_insertion_point(class_scope:grpc_admin.ReqStart)
  private:
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  int mode_;
   mutable ::google::protobuf::internal::CachedSize _cached_size_;
   friend struct ::protobuf_admin_5fservice_2eproto::TableStruct;
 };
@@ -432,7 +747,7 @@ class ResStart : public ::google::protobuf::Message /* @@protoc_insertion_point(
                &_ResStart_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    3;
+    5;
 
   void Swap(ResStart* other);
   friend void swap(ResStart& a, ResStart& b) {
@@ -484,6 +799,20 @@ class ResStart : public ::google::protobuf::Message /* @@protoc_insertion_point(
 
   // accessors -------------------------------------------------------
 
+  // string info = 2;
+  void clear_info();
+  static const int kInfoFieldNumber = 2;
+  const ::std::string& info() const;
+  void set_info(const ::std::string& value);
+  #if LANG_CXX11
+  void set_info(::std::string&& value);
+  #endif
+  void set_info(const char* value);
+  void set_info(const char* value, size_t size);
+  ::std::string* mutable_info();
+  ::std::string* release_info();
+  void set_allocated_info(::std::string* info);
+
   // bool success = 1;
   void clear_success();
   static const int kSuccessFieldNumber = 1;
@@ -494,205 +823,7 @@ class ResStart : public ::google::protobuf::Message /* @@protoc_insertion_point(
  private:
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
-  bool success_;
-  mutable ::google::protobuf::internal::CachedSize _cached_size_;
-  friend struct ::protobuf_admin_5fservice_2eproto::TableStruct;
-};
-// -------------------------------------------------------------------
-
-class ReqStop : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:grpc_admin.ReqStop) */ {
- public:
-  ReqStop();
-  virtual ~ReqStop();
-
-  ReqStop(const ReqStop& from);
-
-  inline ReqStop& operator=(const ReqStop& from) {
-    CopyFrom(from);
-    return *this;
-  }
-  #if LANG_CXX11
-  ReqStop(ReqStop&& from) noexcept
-    : ReqStop() {
-    *this = ::std::move(from);
-  }
-
-  inline ReqStop& operator=(ReqStop&& from) noexcept {
-    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
-      if (this != &from) InternalSwap(&from);
-    } else {
-      CopyFrom(from);
-    }
-    return *this;
-  }
-  #endif
-  static const ::google::protobuf::Descriptor* descriptor();
-  static const ReqStop& default_instance();
-
-  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
-  static inline const ReqStop* internal_default_instance() {
-    return reinterpret_cast<const ReqStop*>(
-               &_ReqStop_default_instance_);
-  }
-  static constexpr int kIndexInFileMessages =
-    4;
-
-  void Swap(ReqStop* other);
-  friend void swap(ReqStop& a, ReqStop& b) {
-    a.Swap(&b);
-  }
-
-  // implements Message ----------------------------------------------
-
-  inline ReqStop* New() const final {
-    return CreateMaybeMessage<ReqStop>(NULL);
-  }
-
-  ReqStop* New(::google::protobuf::Arena* arena) const final {
-    return CreateMaybeMessage<ReqStop>(arena);
-  }
-  void CopyFrom(const ::google::protobuf::Message& from) final;
-  void MergeFrom(const ::google::protobuf::Message& from) final;
-  void CopyFrom(const ReqStop& from);
-  void MergeFrom(const ReqStop& from);
-  void Clear() final;
-  bool IsInitialized() const final;
-
-  size_t ByteSizeLong() const final;
-  bool MergePartialFromCodedStream(
-      ::google::protobuf::io::CodedInputStream* input) final;
-  void SerializeWithCachedSizes(
-      ::google::protobuf::io::CodedOutputStream* output) const final;
-  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
-      bool deterministic, ::google::protobuf::uint8* target) const final;
-  int GetCachedSize() const final { return _cached_size_.Get(); }
-
-  private:
-  void SharedCtor();
-  void SharedDtor();
-  void SetCachedSize(int size) const final;
-  void InternalSwap(ReqStop* other);
-  private:
-  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
-    return NULL;
-  }
-  inline void* MaybeArenaPtr() const {
-    return NULL;
-  }
-  public:
-
-  ::google::protobuf::Metadata GetMetadata() const final;
-
-  // nested types ----------------------------------------------------
-
-  // accessors -------------------------------------------------------
-
-  // @@protoc_insertion_point(class_scope:grpc_admin.ReqStop)
- private:
-
-  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
-  mutable ::google::protobuf::internal::CachedSize _cached_size_;
-  friend struct ::protobuf_admin_5fservice_2eproto::TableStruct;
-};
-// -------------------------------------------------------------------
-
-class ResStop : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:grpc_admin.ResStop) */ {
- public:
-  ResStop();
-  virtual ~ResStop();
-
-  ResStop(const ResStop& from);
-
-  inline ResStop& operator=(const ResStop& from) {
-    CopyFrom(from);
-    return *this;
-  }
-  #if LANG_CXX11
-  ResStop(ResStop&& from) noexcept
-    : ResStop() {
-    *this = ::std::move(from);
-  }
-
-  inline ResStop& operator=(ResStop&& from) noexcept {
-    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
-      if (this != &from) InternalSwap(&from);
-    } else {
-      CopyFrom(from);
-    }
-    return *this;
-  }
-  #endif
-  static const ::google::protobuf::Descriptor* descriptor();
-  static const ResStop& default_instance();
-
-  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
-  static inline const ResStop* internal_default_instance() {
-    return reinterpret_cast<const ResStop*>(
-               &_ResStop_default_instance_);
-  }
-  static constexpr int kIndexInFileMessages =
-    5;
-
-  void Swap(ResStop* other);
-  friend void swap(ResStop& a, ResStop& b) {
-    a.Swap(&b);
-  }
-
-  // implements Message ----------------------------------------------
-
-  inline ResStop* New() const final {
-    return CreateMaybeMessage<ResStop>(NULL);
-  }
-
-  ResStop* New(::google::protobuf::Arena* arena) const final {
-    return CreateMaybeMessage<ResStop>(arena);
-  }
-  void CopyFrom(const ::google::protobuf::Message& from) final;
-  void MergeFrom(const ::google::protobuf::Message& from) final;
-  void CopyFrom(const ResStop& from);
-  void MergeFrom(const ResStop& from);
-  void Clear() final;
-  bool IsInitialized() const final;
-
-  size_t ByteSizeLong() const final;
-  bool MergePartialFromCodedStream(
-      ::google::protobuf::io::CodedInputStream* input) final;
-  void SerializeWithCachedSizes(
-      ::google::protobuf::io::CodedOutputStream* output) const final;
-  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
-      bool deterministic, ::google::protobuf::uint8* target) const final;
-  int GetCachedSize() const final { return _cached_size_.Get(); }
-
-  private:
-  void SharedCtor();
-  void SharedDtor();
-  void SetCachedSize(int size) const final;
-  void InternalSwap(ResStop* other);
-  private:
-  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
-    return NULL;
-  }
-  inline void* MaybeArenaPtr() const {
-    return NULL;
-  }
-  public:
-
-  ::google::protobuf::Metadata GetMetadata() const final;
-
-  // nested types ----------------------------------------------------
-
-  // accessors -------------------------------------------------------
-
-  // bool success = 1;
-  void clear_success();
-  static const int kSuccessFieldNumber = 1;
-  bool success() const;
-  void set_success(bool value);
-
-  // @@protoc_insertion_point(class_scope:grpc_admin.ResStop)
- private:
-
-  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::internal::ArenaStringPtr info_;
   bool success_;
   mutable ::google::protobuf::internal::CachedSize _cached_size_;
   friend struct ::protobuf_admin_5fservice_2eproto::TableStruct;
@@ -896,6 +1027,434 @@ class ResStatus : public ::google::protobuf::Message /* @@protoc_insertion_point
   mutable ::google::protobuf::internal::CachedSize _cached_size_;
   friend struct ::protobuf_admin_5fservice_2eproto::TableStruct;
 };
+// -------------------------------------------------------------------
+
+class ReqLoadWorld : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:grpc_admin.ReqLoadWorld) */ {
+ public:
+  ReqLoadWorld();
+  virtual ~ReqLoadWorld();
+
+  ReqLoadWorld(const ReqLoadWorld& from);
+
+  inline ReqLoadWorld& operator=(const ReqLoadWorld& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  #if LANG_CXX11
+  ReqLoadWorld(ReqLoadWorld&& from) noexcept
+    : ReqLoadWorld() {
+    *this = ::std::move(from);
+  }
+
+  inline ReqLoadWorld& operator=(ReqLoadWorld&& from) noexcept {
+    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+  #endif
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const ReqLoadWorld& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const ReqLoadWorld* internal_default_instance() {
+    return reinterpret_cast<const ReqLoadWorld*>(
+               &_ReqLoadWorld_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    8;
+
+  void Swap(ReqLoadWorld* other);
+  friend void swap(ReqLoadWorld& a, ReqLoadWorld& b) {
+    a.Swap(&b);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline ReqLoadWorld* New() const final {
+    return CreateMaybeMessage<ReqLoadWorld>(NULL);
+  }
+
+  ReqLoadWorld* New(::google::protobuf::Arena* arena) const final {
+    return CreateMaybeMessage<ReqLoadWorld>(arena);
+  }
+  void CopyFrom(const ::google::protobuf::Message& from) final;
+  void MergeFrom(const ::google::protobuf::Message& from) final;
+  void CopyFrom(const ReqLoadWorld& from);
+  void MergeFrom(const ReqLoadWorld& from);
+  void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input) final;
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const final;
+  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
+      bool deterministic, ::google::protobuf::uint8* target) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(ReqLoadWorld* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return NULL;
+  }
+  inline void* MaybeArenaPtr() const {
+    return NULL;
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // @@protoc_insertion_point(class_scope:grpc_admin.ReqLoadWorld)
+ private:
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  mutable ::google::protobuf::internal::CachedSize _cached_size_;
+  friend struct ::protobuf_admin_5fservice_2eproto::TableStruct;
+};
+// -------------------------------------------------------------------
+
+class ResLoadWorld : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:grpc_admin.ResLoadWorld) */ {
+ public:
+  ResLoadWorld();
+  virtual ~ResLoadWorld();
+
+  ResLoadWorld(const ResLoadWorld& from);
+
+  inline ResLoadWorld& operator=(const ResLoadWorld& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  #if LANG_CXX11
+  ResLoadWorld(ResLoadWorld&& from) noexcept
+    : ResLoadWorld() {
+    *this = ::std::move(from);
+  }
+
+  inline ResLoadWorld& operator=(ResLoadWorld&& from) noexcept {
+    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+  #endif
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const ResLoadWorld& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const ResLoadWorld* internal_default_instance() {
+    return reinterpret_cast<const ResLoadWorld*>(
+               &_ResLoadWorld_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    9;
+
+  void Swap(ResLoadWorld* other);
+  friend void swap(ResLoadWorld& a, ResLoadWorld& b) {
+    a.Swap(&b);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline ResLoadWorld* New() const final {
+    return CreateMaybeMessage<ResLoadWorld>(NULL);
+  }
+
+  ResLoadWorld* New(::google::protobuf::Arena* arena) const final {
+    return CreateMaybeMessage<ResLoadWorld>(arena);
+  }
+  void CopyFrom(const ::google::protobuf::Message& from) final;
+  void MergeFrom(const ::google::protobuf::Message& from) final;
+  void CopyFrom(const ResLoadWorld& from);
+  void MergeFrom(const ResLoadWorld& from);
+  void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input) final;
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const final;
+  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
+      bool deterministic, ::google::protobuf::uint8* target) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(ResLoadWorld* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return NULL;
+  }
+  inline void* MaybeArenaPtr() const {
+    return NULL;
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // string info = 2;
+  void clear_info();
+  static const int kInfoFieldNumber = 2;
+  const ::std::string& info() const;
+  void set_info(const ::std::string& value);
+  #if LANG_CXX11
+  void set_info(::std::string&& value);
+  #endif
+  void set_info(const char* value);
+  void set_info(const char* value, size_t size);
+  ::std::string* mutable_info();
+  ::std::string* release_info();
+  void set_allocated_info(::std::string* info);
+
+  // bool success = 1;
+  void clear_success();
+  static const int kSuccessFieldNumber = 1;
+  bool success() const;
+  void set_success(bool value);
+
+  // @@protoc_insertion_point(class_scope:grpc_admin.ResLoadWorld)
+ private:
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::internal::ArenaStringPtr info_;
+  bool success_;
+  mutable ::google::protobuf::internal::CachedSize _cached_size_;
+  friend struct ::protobuf_admin_5fservice_2eproto::TableStruct;
+};
+// -------------------------------------------------------------------
+
+class ReqLoadChain : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:grpc_admin.ReqLoadChain) */ {
+ public:
+  ReqLoadChain();
+  virtual ~ReqLoadChain();
+
+  ReqLoadChain(const ReqLoadChain& from);
+
+  inline ReqLoadChain& operator=(const ReqLoadChain& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  #if LANG_CXX11
+  ReqLoadChain(ReqLoadChain&& from) noexcept
+    : ReqLoadChain() {
+    *this = ::std::move(from);
+  }
+
+  inline ReqLoadChain& operator=(ReqLoadChain&& from) noexcept {
+    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+  #endif
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const ReqLoadChain& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const ReqLoadChain* internal_default_instance() {
+    return reinterpret_cast<const ReqLoadChain*>(
+               &_ReqLoadChain_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    10;
+
+  void Swap(ReqLoadChain* other);
+  friend void swap(ReqLoadChain& a, ReqLoadChain& b) {
+    a.Swap(&b);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline ReqLoadChain* New() const final {
+    return CreateMaybeMessage<ReqLoadChain>(NULL);
+  }
+
+  ReqLoadChain* New(::google::protobuf::Arena* arena) const final {
+    return CreateMaybeMessage<ReqLoadChain>(arena);
+  }
+  void CopyFrom(const ::google::protobuf::Message& from) final;
+  void MergeFrom(const ::google::protobuf::Message& from) final;
+  void CopyFrom(const ReqLoadChain& from);
+  void MergeFrom(const ReqLoadChain& from);
+  void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input) final;
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const final;
+  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
+      bool deterministic, ::google::protobuf::uint8* target) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(ReqLoadChain* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return NULL;
+  }
+  inline void* MaybeArenaPtr() const {
+    return NULL;
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // @@protoc_insertion_point(class_scope:grpc_admin.ReqLoadChain)
+ private:
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  mutable ::google::protobuf::internal::CachedSize _cached_size_;
+  friend struct ::protobuf_admin_5fservice_2eproto::TableStruct;
+};
+// -------------------------------------------------------------------
+
+class ResLoadChain : public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:grpc_admin.ResLoadChain) */ {
+ public:
+  ResLoadChain();
+  virtual ~ResLoadChain();
+
+  ResLoadChain(const ResLoadChain& from);
+
+  inline ResLoadChain& operator=(const ResLoadChain& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  #if LANG_CXX11
+  ResLoadChain(ResLoadChain&& from) noexcept
+    : ResLoadChain() {
+    *this = ::std::move(from);
+  }
+
+  inline ResLoadChain& operator=(ResLoadChain&& from) noexcept {
+    if (GetArenaNoVirtual() == from.GetArenaNoVirtual()) {
+      if (this != &from) InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+  #endif
+  static const ::google::protobuf::Descriptor* descriptor();
+  static const ResLoadChain& default_instance();
+
+  static void InitAsDefaultInstance();  // FOR INTERNAL USE ONLY
+  static inline const ResLoadChain* internal_default_instance() {
+    return reinterpret_cast<const ResLoadChain*>(
+               &_ResLoadChain_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    11;
+
+  void Swap(ResLoadChain* other);
+  friend void swap(ResLoadChain& a, ResLoadChain& b) {
+    a.Swap(&b);
+  }
+
+  // implements Message ----------------------------------------------
+
+  inline ResLoadChain* New() const final {
+    return CreateMaybeMessage<ResLoadChain>(NULL);
+  }
+
+  ResLoadChain* New(::google::protobuf::Arena* arena) const final {
+    return CreateMaybeMessage<ResLoadChain>(arena);
+  }
+  void CopyFrom(const ::google::protobuf::Message& from) final;
+  void MergeFrom(const ::google::protobuf::Message& from) final;
+  void CopyFrom(const ResLoadChain& from);
+  void MergeFrom(const ResLoadChain& from);
+  void Clear() final;
+  bool IsInitialized() const final;
+
+  size_t ByteSizeLong() const final;
+  bool MergePartialFromCodedStream(
+      ::google::protobuf::io::CodedInputStream* input) final;
+  void SerializeWithCachedSizes(
+      ::google::protobuf::io::CodedOutputStream* output) const final;
+  ::google::protobuf::uint8* InternalSerializeWithCachedSizesToArray(
+      bool deterministic, ::google::protobuf::uint8* target) const final;
+  int GetCachedSize() const final { return _cached_size_.Get(); }
+
+  private:
+  void SharedCtor();
+  void SharedDtor();
+  void SetCachedSize(int size) const final;
+  void InternalSwap(ResLoadChain* other);
+  private:
+  inline ::google::protobuf::Arena* GetArenaNoVirtual() const {
+    return NULL;
+  }
+  inline void* MaybeArenaPtr() const {
+    return NULL;
+  }
+  public:
+
+  ::google::protobuf::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  // string info = 2;
+  void clear_info();
+  static const int kInfoFieldNumber = 2;
+  const ::std::string& info() const;
+  void set_info(const ::std::string& value);
+  #if LANG_CXX11
+  void set_info(::std::string&& value);
+  #endif
+  void set_info(const char* value);
+  void set_info(const char* value, size_t size);
+  ::std::string* mutable_info();
+  ::std::string* release_info();
+  void set_allocated_info(::std::string* info);
+
+  // bool success = 1;
+  void clear_success();
+  static const int kSuccessFieldNumber = 1;
+  bool success() const;
+  void set_success(bool value);
+
+  // @@protoc_insertion_point(class_scope:grpc_admin.ResLoadChain)
+ private:
+
+  ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::internal::ArenaStringPtr info_;
+  bool success_;
+  mutable ::google::protobuf::internal::CachedSize _cached_size_;
+  friend struct ::protobuf_admin_5fservice_2eproto::TableStruct;
+};
 // ===================================================================
 
 
@@ -905,82 +1464,277 @@ class ResStatus : public ::google::protobuf::Message /* @@protoc_insertion_point
   #pragma GCC diagnostic push
   #pragma GCC diagnostic ignored "-Wstrict-aliasing"
 #endif  // __GNUC__
-// ReqSetup
+// ReqSetupKey
 
-// string password = 1;
-inline void ReqSetup::clear_password() {
-  password_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+// string setup_port = 1;
+inline void ReqSetupKey::clear_setup_port() {
+  setup_port_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
-inline const ::std::string& ReqSetup::password() const {
-  // @@protoc_insertion_point(field_get:grpc_admin.ReqSetup.password)
-  return password_.GetNoArena();
+inline const ::std::string& ReqSetupKey::setup_port() const {
+  // @@protoc_insertion_point(field_get:grpc_admin.ReqSetupKey.setup_port)
+  return setup_port_.GetNoArena();
 }
-inline void ReqSetup::set_password(const ::std::string& value) {
+inline void ReqSetupKey::set_setup_port(const ::std::string& value) {
   
-  password_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
-  // @@protoc_insertion_point(field_set:grpc_admin.ReqSetup.password)
+  setup_port_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:grpc_admin.ReqSetupKey.setup_port)
 }
 #if LANG_CXX11
-inline void ReqSetup::set_password(::std::string&& value) {
+inline void ReqSetupKey::set_setup_port(::std::string&& value) {
+  
+  setup_port_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:grpc_admin.ReqSetupKey.setup_port)
+}
+#endif
+inline void ReqSetupKey::set_setup_port(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  setup_port_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:grpc_admin.ReqSetupKey.setup_port)
+}
+inline void ReqSetupKey::set_setup_port(const char* value, size_t size) {
+  
+  setup_port_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:grpc_admin.ReqSetupKey.setup_port)
+}
+inline ::std::string* ReqSetupKey::mutable_setup_port() {
+  
+  // @@protoc_insertion_point(field_mutable:grpc_admin.ReqSetupKey.setup_port)
+  return setup_port_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* ReqSetupKey::release_setup_port() {
+  // @@protoc_insertion_point(field_release:grpc_admin.ReqSetupKey.setup_port)
+  
+  return setup_port_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void ReqSetupKey::set_allocated_setup_port(::std::string* setup_port) {
+  if (setup_port != NULL) {
+    
+  } else {
+    
+  }
+  setup_port_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), setup_port);
+  // @@protoc_insertion_point(field_set_allocated:grpc_admin.ReqSetupKey.setup_port)
+}
+
+// -------------------------------------------------------------------
+
+// ResSetupKey
+
+// bool success = 1;
+inline void ResSetupKey::clear_success() {
+  success_ = false;
+}
+inline bool ResSetupKey::success() const {
+  // @@protoc_insertion_point(field_get:grpc_admin.ResSetupKey.success)
+  return success_;
+}
+inline void ResSetupKey::set_success(bool value) {
+  
+  success_ = value;
+  // @@protoc_insertion_point(field_set:grpc_admin.ResSetupKey.success)
+}
+
+// string info = 2;
+inline void ResSetupKey::clear_info() {
+  info_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& ResSetupKey::info() const {
+  // @@protoc_insertion_point(field_get:grpc_admin.ResSetupKey.info)
+  return info_.GetNoArena();
+}
+inline void ResSetupKey::set_info(const ::std::string& value) {
+  
+  info_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:grpc_admin.ResSetupKey.info)
+}
+#if LANG_CXX11
+inline void ResSetupKey::set_info(::std::string&& value) {
+  
+  info_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:grpc_admin.ResSetupKey.info)
+}
+#endif
+inline void ResSetupKey::set_info(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  info_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:grpc_admin.ResSetupKey.info)
+}
+inline void ResSetupKey::set_info(const char* value, size_t size) {
+  
+  info_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:grpc_admin.ResSetupKey.info)
+}
+inline ::std::string* ResSetupKey::mutable_info() {
+  
+  // @@protoc_insertion_point(field_mutable:grpc_admin.ResSetupKey.info)
+  return info_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* ResSetupKey::release_info() {
+  // @@protoc_insertion_point(field_release:grpc_admin.ResSetupKey.info)
+  
+  return info_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void ResSetupKey::set_allocated_info(::std::string* info) {
+  if (info != NULL) {
+    
+  } else {
+    
+  }
+  info_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), info);
+  // @@protoc_insertion_point(field_set_allocated:grpc_admin.ResSetupKey.info)
+}
+
+// -------------------------------------------------------------------
+
+// ReqLogin
+
+// string password = 1;
+inline void ReqLogin::clear_password() {
+  password_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& ReqLogin::password() const {
+  // @@protoc_insertion_point(field_get:grpc_admin.ReqLogin.password)
+  return password_.GetNoArena();
+}
+inline void ReqLogin::set_password(const ::std::string& value) {
+  
+  password_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:grpc_admin.ReqLogin.password)
+}
+#if LANG_CXX11
+inline void ReqLogin::set_password(::std::string&& value) {
   
   password_.SetNoArena(
     &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
-  // @@protoc_insertion_point(field_set_rvalue:grpc_admin.ReqSetup.password)
+  // @@protoc_insertion_point(field_set_rvalue:grpc_admin.ReqLogin.password)
 }
 #endif
-inline void ReqSetup::set_password(const char* value) {
+inline void ReqLogin::set_password(const char* value) {
   GOOGLE_DCHECK(value != NULL);
   
   password_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
-  // @@protoc_insertion_point(field_set_char:grpc_admin.ReqSetup.password)
+  // @@protoc_insertion_point(field_set_char:grpc_admin.ReqLogin.password)
 }
-inline void ReqSetup::set_password(const char* value, size_t size) {
+inline void ReqLogin::set_password(const char* value, size_t size) {
   
   password_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
       ::std::string(reinterpret_cast<const char*>(value), size));
-  // @@protoc_insertion_point(field_set_pointer:grpc_admin.ReqSetup.password)
+  // @@protoc_insertion_point(field_set_pointer:grpc_admin.ReqLogin.password)
 }
-inline ::std::string* ReqSetup::mutable_password() {
+inline ::std::string* ReqLogin::mutable_password() {
   
-  // @@protoc_insertion_point(field_mutable:grpc_admin.ReqSetup.password)
+  // @@protoc_insertion_point(field_mutable:grpc_admin.ReqLogin.password)
   return password_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
-inline ::std::string* ReqSetup::release_password() {
-  // @@protoc_insertion_point(field_release:grpc_admin.ReqSetup.password)
+inline ::std::string* ReqLogin::release_password() {
+  // @@protoc_insertion_point(field_release:grpc_admin.ReqLogin.password)
   
   return password_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
-inline void ReqSetup::set_allocated_password(::std::string* password) {
+inline void ReqLogin::set_allocated_password(::std::string* password) {
   if (password != NULL) {
     
   } else {
     
   }
   password_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), password);
-  // @@protoc_insertion_point(field_set_allocated:grpc_admin.ReqSetup.password)
+  // @@protoc_insertion_point(field_set_allocated:grpc_admin.ReqLogin.password)
 }
 
 // -------------------------------------------------------------------
 
-// ResSetup
+// ResLogin
 
 // bool success = 1;
-inline void ResSetup::clear_success() {
+inline void ResLogin::clear_success() {
   success_ = false;
 }
-inline bool ResSetup::success() const {
-  // @@protoc_insertion_point(field_get:grpc_admin.ResSetup.success)
+inline bool ResLogin::success() const {
+  // @@protoc_insertion_point(field_get:grpc_admin.ResLogin.success)
   return success_;
 }
-inline void ResSetup::set_success(bool value) {
+inline void ResLogin::set_success(bool value) {
   
   success_ = value;
-  // @@protoc_insertion_point(field_set:grpc_admin.ResSetup.success)
+  // @@protoc_insertion_point(field_set:grpc_admin.ResLogin.success)
+}
+
+// string info = 2;
+inline void ResLogin::clear_info() {
+  info_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& ResLogin::info() const {
+  // @@protoc_insertion_point(field_get:grpc_admin.ResLogin.info)
+  return info_.GetNoArena();
+}
+inline void ResLogin::set_info(const ::std::string& value) {
+  
+  info_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:grpc_admin.ResLogin.info)
+}
+#if LANG_CXX11
+inline void ResLogin::set_info(::std::string&& value) {
+  
+  info_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:grpc_admin.ResLogin.info)
+}
+#endif
+inline void ResLogin::set_info(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  info_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:grpc_admin.ResLogin.info)
+}
+inline void ResLogin::set_info(const char* value, size_t size) {
+  
+  info_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:grpc_admin.ResLogin.info)
+}
+inline ::std::string* ResLogin::mutable_info() {
+  
+  // @@protoc_insertion_point(field_mutable:grpc_admin.ResLogin.info)
+  return info_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* ResLogin::release_info() {
+  // @@protoc_insertion_point(field_release:grpc_admin.ResLogin.info)
+  
+  return info_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void ResLogin::set_allocated_info(::std::string* info) {
+  if (info != NULL) {
+    
+  } else {
+    
+  }
+  info_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), info);
+  // @@protoc_insertion_point(field_set_allocated:grpc_admin.ResLogin.info)
 }
 
 // -------------------------------------------------------------------
 
 // ReqStart
+
+// .grpc_admin.ReqStart.Mode mode = 1;
+inline void ReqStart::clear_mode() {
+  mode_ = 0;
+}
+inline ::grpc_admin::ReqStart_Mode ReqStart::mode() const {
+  // @@protoc_insertion_point(field_get:grpc_admin.ReqStart.mode)
+  return static_cast< ::grpc_admin::ReqStart_Mode >(mode_);
+}
+inline void ReqStart::set_mode(::grpc_admin::ReqStart_Mode value) {
+  
+  mode_ = value;
+  // @@protoc_insertion_point(field_set:grpc_admin.ReqStart.mode)
+}
 
 // -------------------------------------------------------------------
 
@@ -1000,26 +1754,57 @@ inline void ResStart::set_success(bool value) {
   // @@protoc_insertion_point(field_set:grpc_admin.ResStart.success)
 }
 
-// -------------------------------------------------------------------
-
-// ReqStop
-
-// -------------------------------------------------------------------
-
-// ResStop
-
-// bool success = 1;
-inline void ResStop::clear_success() {
-  success_ = false;
+// string info = 2;
+inline void ResStart::clear_info() {
+  info_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
-inline bool ResStop::success() const {
-  // @@protoc_insertion_point(field_get:grpc_admin.ResStop.success)
-  return success_;
+inline const ::std::string& ResStart::info() const {
+  // @@protoc_insertion_point(field_get:grpc_admin.ResStart.info)
+  return info_.GetNoArena();
 }
-inline void ResStop::set_success(bool value) {
+inline void ResStart::set_info(const ::std::string& value) {
   
-  success_ = value;
-  // @@protoc_insertion_point(field_set:grpc_admin.ResStop.success)
+  info_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:grpc_admin.ResStart.info)
+}
+#if LANG_CXX11
+inline void ResStart::set_info(::std::string&& value) {
+  
+  info_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:grpc_admin.ResStart.info)
+}
+#endif
+inline void ResStart::set_info(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  info_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:grpc_admin.ResStart.info)
+}
+inline void ResStart::set_info(const char* value, size_t size) {
+  
+  info_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:grpc_admin.ResStart.info)
+}
+inline ::std::string* ResStart::mutable_info() {
+  
+  // @@protoc_insertion_point(field_mutable:grpc_admin.ResStart.info)
+  return info_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* ResStart::release_info() {
+  // @@protoc_insertion_point(field_release:grpc_admin.ResStart.info)
+  
+  return info_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void ResStart::set_allocated_info(::std::string* info) {
+  if (info != NULL) {
+    
+  } else {
+    
+  }
+  info_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), info);
+  // @@protoc_insertion_point(field_set_allocated:grpc_admin.ResStart.info)
 }
 
 // -------------------------------------------------------------------
@@ -1044,9 +1829,167 @@ inline void ResStatus::set_alive(bool value) {
   // @@protoc_insertion_point(field_set:grpc_admin.ResStatus.alive)
 }
 
+// -------------------------------------------------------------------
+
+// ReqLoadWorld
+
+// -------------------------------------------------------------------
+
+// ResLoadWorld
+
+// bool success = 1;
+inline void ResLoadWorld::clear_success() {
+  success_ = false;
+}
+inline bool ResLoadWorld::success() const {
+  // @@protoc_insertion_point(field_get:grpc_admin.ResLoadWorld.success)
+  return success_;
+}
+inline void ResLoadWorld::set_success(bool value) {
+  
+  success_ = value;
+  // @@protoc_insertion_point(field_set:grpc_admin.ResLoadWorld.success)
+}
+
+// string info = 2;
+inline void ResLoadWorld::clear_info() {
+  info_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& ResLoadWorld::info() const {
+  // @@protoc_insertion_point(field_get:grpc_admin.ResLoadWorld.info)
+  return info_.GetNoArena();
+}
+inline void ResLoadWorld::set_info(const ::std::string& value) {
+  
+  info_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:grpc_admin.ResLoadWorld.info)
+}
+#if LANG_CXX11
+inline void ResLoadWorld::set_info(::std::string&& value) {
+  
+  info_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:grpc_admin.ResLoadWorld.info)
+}
+#endif
+inline void ResLoadWorld::set_info(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  info_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:grpc_admin.ResLoadWorld.info)
+}
+inline void ResLoadWorld::set_info(const char* value, size_t size) {
+  
+  info_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:grpc_admin.ResLoadWorld.info)
+}
+inline ::std::string* ResLoadWorld::mutable_info() {
+  
+  // @@protoc_insertion_point(field_mutable:grpc_admin.ResLoadWorld.info)
+  return info_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* ResLoadWorld::release_info() {
+  // @@protoc_insertion_point(field_release:grpc_admin.ResLoadWorld.info)
+  
+  return info_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void ResLoadWorld::set_allocated_info(::std::string* info) {
+  if (info != NULL) {
+    
+  } else {
+    
+  }
+  info_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), info);
+  // @@protoc_insertion_point(field_set_allocated:grpc_admin.ResLoadWorld.info)
+}
+
+// -------------------------------------------------------------------
+
+// ReqLoadChain
+
+// -------------------------------------------------------------------
+
+// ResLoadChain
+
+// bool success = 1;
+inline void ResLoadChain::clear_success() {
+  success_ = false;
+}
+inline bool ResLoadChain::success() const {
+  // @@protoc_insertion_point(field_get:grpc_admin.ResLoadChain.success)
+  return success_;
+}
+inline void ResLoadChain::set_success(bool value) {
+  
+  success_ = value;
+  // @@protoc_insertion_point(field_set:grpc_admin.ResLoadChain.success)
+}
+
+// string info = 2;
+inline void ResLoadChain::clear_info() {
+  info_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& ResLoadChain::info() const {
+  // @@protoc_insertion_point(field_get:grpc_admin.ResLoadChain.info)
+  return info_.GetNoArena();
+}
+inline void ResLoadChain::set_info(const ::std::string& value) {
+  
+  info_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:grpc_admin.ResLoadChain.info)
+}
+#if LANG_CXX11
+inline void ResLoadChain::set_info(::std::string&& value) {
+  
+  info_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:grpc_admin.ResLoadChain.info)
+}
+#endif
+inline void ResLoadChain::set_info(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  info_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:grpc_admin.ResLoadChain.info)
+}
+inline void ResLoadChain::set_info(const char* value, size_t size) {
+  
+  info_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:grpc_admin.ResLoadChain.info)
+}
+inline ::std::string* ResLoadChain::mutable_info() {
+  
+  // @@protoc_insertion_point(field_mutable:grpc_admin.ResLoadChain.info)
+  return info_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* ResLoadChain::release_info() {
+  // @@protoc_insertion_point(field_release:grpc_admin.ResLoadChain.info)
+  
+  return info_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void ResLoadChain::set_allocated_info(::std::string* info) {
+  if (info != NULL) {
+    
+  } else {
+    
+  }
+  info_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), info);
+  // @@protoc_insertion_point(field_set_allocated:grpc_admin.ResLoadChain.info)
+}
+
 #ifdef __GNUC__
   #pragma GCC diagnostic pop
 #endif  // __GNUC__
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
+// -------------------------------------------------------------------
+
 // -------------------------------------------------------------------
 
 // -------------------------------------------------------------------
@@ -1065,6 +2008,18 @@ inline void ResStatus::set_alive(bool value) {
 // @@protoc_insertion_point(namespace_scope)
 
 }  // namespace grpc_admin
+
+namespace google {
+namespace protobuf {
+
+template <> struct is_proto_enum< ::grpc_admin::ReqStart_Mode> : ::std::true_type {};
+template <>
+inline const EnumDescriptor* GetEnumDescriptor< ::grpc_admin::ReqStart_Mode>() {
+  return ::grpc_admin::ReqStart_Mode_descriptor();
+}
+
+}  // namespace protobuf
+}  // namespace google
 
 // @@protoc_insertion_point(global_scope)
 


### PR DESCRIPTION
- 수정한 protobuf compile
- 기존의 Setup 을 SetupKey / Login 두분으로 분리 함
https://thevaulters.atlassian.net/wiki/spaces/SGN/pages/103350293/VP8-1+Administrative+Client+Admin+Console
- SetupKey
  - Key을 전달 받을 때 이용할 port를 받도록 함.
  - 스마트폰으로 부터 key 정보를 받아 storage(leveldb)에 저장
- Login
  - sk를 확인할 password를 받도록 함
  - 넘겨받은 password로 storage에 저장된 sk를 꺼내 password가 맞는지 확인하도록 함.