### PR TITLE
# EDIT - AdminPlugin 이 필수적으로 등록되었는지 확인하는 코드 추가

### DIFF
--- a/lib/appbase/application.cpp
+++ b/lib/appbase/application.cpp
@@ -82,6 +82,12 @@ bool Application::parseProgramOptions(int argc, char **argv) {
 void Application::initializePlugins() {
   auto plugin_names = program_options->options_map.at("plugin").as<vector<string>>();
 
+  auto result = find(plugin_names.begin(), plugin_names.end(), "AdminPlugin");
+  if (result == plugin_names.end()) {
+    logger::ERROR("'AdminPlugin' is necessarily required. Please make sure that 'AdminPlugin' is configured in the configuration file.");
+
+    exit(1);
+  }
   for_each(begin(plugin_names), end(plugin_names), [this](const string &plugin_name) {
     auto it = app_plugins_map.find(plugin_name);
     if (it != app_plugins_map.end()) {


### PR DESCRIPTION
## 수정사항
- 콘솔로 해당 프로그램을 제어하게 됨으로써 AdminPlugin 없이는 아무런 동작을 수행할 수 없다.
- AdminPlugin이 config에 등록되어있지 않으면 프로그램이 실행되지 않도록 수정