### PR TITLE
# EDIT - AdminPlugin은 init과 동시에 실행하도록 함.

### DIFF
--- a/lib/appbase/application.cpp
+++ b/lib/appbase/application.cpp
@@ -31,6 +31,8 @@ Application &Application::instance() {
 bool Application::initializeImpl() {
   initializePlugins();
 
+  io_context_ptr->run();
+
   return true;
 }
 
@@ -125,8 +127,6 @@ void Application::start() {
     sigpipe_set->cancel();
     quit();
   });
-
-  io_context_ptr->run();
 
   shutdown();
 }

--- a/src/plugins/admin_plugin/admin_plugin.cpp
+++ b/src/plugins/admin_plugin/admin_plugin.cpp
@@ -35,6 +35,8 @@ public:
     initializeAdminServer();
     registerService();
     admin_req_check_timer = make_unique<boost::asio::steady_timer>(app().getIoContext());
+
+    monitorCompletionQueue();
   }
 
   void registerService() {
@@ -46,9 +48,7 @@ public:
     new AdminService<ReqStatus, ResStatus>(&admin_service, completion_queue.get(), merger_status);
   }
 
-  void start() {
-    monitorCompletionQueue();
-  }
+  void start() {}
 
   void initializeAdminServer() {
     ServerBuilder builder;


### PR DESCRIPTION
## 수정사항
- AdminPlugin은 다른 플러그인들과 다르게 멤버변수들의 초기화와 동시에 `monitorCompletionQueue` 가 동작해야 콘솔로부터 명령어를 받아 실행할 수 있다.
- io_context를 app 초기화 단계에서 run 하도록 수정하고(proactor를 initialize 단계에서 미리 실행함), AdminPlugin에서는 초기화 이후 CompletionQueue 에서 event를 꺼내오도록 함.