### PR TITLE
# FEATURE - [Admin Service] Handle start command

### DIFF
--- a/lib/appbase/application.cpp
+++ b/lib/appbase/application.cpp
@@ -162,6 +162,10 @@ const string &Application::getId() const {
   return id;
 }
 
+void Application::setRunFlag(){
+  running = true;
+}
+
 bool Application::isAppRunning() {
   return running;
 }

--- a/lib/appbase/include/application.hpp
+++ b/lib/appbase/include/application.hpp
@@ -78,6 +78,7 @@ public:
   }
 
   void setId(string_view _id);
+  void setRunFlag();
   const string &getId() const;
 
   bool isAppRunning();

--- a/src/plugins/admin_plugin/include/admin_type.hpp
+++ b/src/plugins/admin_plugin/include/admin_type.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace gruut {
+namespace admin_plugin {
+
+enum class PluginName : int { NET, CHAIN };
+enum class ControlType : int { LOGIN = 1, START = 2 };
+enum class ModeType : int { NONE = -1, DEFAULT = 0, MONITOR = 1 };
+
+} // namespace admin_plugin
+} // namespace gruut

--- a/src/plugins/admin_plugin/rpc_services/include/rpc_services.hpp
+++ b/src/plugins/admin_plugin/rpc_services/include/rpc_services.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../../../net_plugin/rpc_services/protos/include/user_service.grpc.pb.h"
+#include "../../include/admin_type.hpp"
 #include "../proto/include/admin_service.grpc.pb.h"
 #include <atomic>
 #include <future>
@@ -21,8 +22,9 @@ struct MergerStatus {
   atomic<bool> user_setup;
   atomic<bool> user_login;
   atomic<bool> is_running;
+  atomic<ModeType> run_mode;
 
-  MergerStatus() : user_setup(false), user_login(false), is_running(true) {}
+  MergerStatus() : user_setup(false), user_login(false), is_running(false), run_mode(ModeType::NONE) {}
 };
 
 class SetupService final : public GruutUserService::Service {
@@ -106,7 +108,6 @@ private:
   ResLogin res;
   ServerAsyncResponseWriter<ResLogin> responder;
   bool checkPassword(const string &enc_sk_pem, const string &pass);
-  void sendKeyInfoToNet(const string &cert, const string &enc_sk_pem, const string &pass);
 };
 
 } // namespace admin_plugin

--- a/src/plugins/net_plugin/config/include/network_type.hpp
+++ b/src/plugins/net_plugin/config/include/network_type.hpp
@@ -7,12 +7,6 @@
 namespace gruut {
 namespace net_plugin {
 
-enum class NetControlType : int{
-  SETUP = 1,
-  START = 2,
-  STOP = 3
-};
-
 struct IpEndpoint {
   std::string address;
   std::string port;


### PR DESCRIPTION
- Application
  - setRunFlag() 추가 

- Admin plugin
  - CommandForwarder 객채 추가. 명령을 각 plugin에 전달하는 역할을 함.
  - Start 명령을 처리 하도록함. 정상 처리 할 경우 Start 명령을 처리하는
과정에서 Application::setRunFlag()를 호출 하도록 함.

- Net plugin
  - Start 이전에는 plugin이 시작하지 않으므로 getPeerFromTracker()의
호출 위치를 controlNet() -> start() 로 이동

 #### TODO :
- Net plugin 에서 Mode에 따라서 Message를 어떻게 처리해야할 지 결정해야
한다.