### PR TITLE
# EDIT - START 명령어가 들어왔을때의 처리

### DIFF
--- a/lib/appbase/application.cpp
+++ b/lib/appbase/application.cpp
@@ -31,8 +31,6 @@ Application &Application::instance() {
 bool Application::initializeImpl() {
   initializePlugins();
 
-  io_context_ptr->run();
-
   return true;
 }
 
@@ -127,6 +125,8 @@ void Application::start() {
     sigpipe_set->cancel();
     quit();
   });
+
+  io_context_ptr->run();
 
   shutdown();
 }

--- a/src/plugins/admin_plugin/rpc_services/rpc_services.cpp
+++ b/src/plugins/admin_plugin/rpc_services/rpc_services.cpp
@@ -311,6 +311,7 @@ void AdminService<ReqStart, ResStart>::proceed() {
       app().setRunFlag();
 
       string mode_type = mode == ReqStart_Mode_DEFAULT ? "default" : "monitor";
+      res.set_info("Start to running the node on " + mode_type + " mode");
       logger::INFO("[START] Success / Mode : {}", mode_type);
     }
     receive_status = AdminRpcCallStatus::FINISH;


### PR DESCRIPTION
## 수정사항
- `monitorCompletionQueue`를 다시 start() 함수 위치로 rollback 시키고, `handleStartCommand` 추가
  + `handleStartCommand`
    + START 명령어가 들어올때까지 Block 된다.
- `monitorCompletionQueue`를 다시 start() 함수 위치로 rollback 되면서 io_context_ptr가 초기화단계에서 `run()`를 호출할 필요가 없어서 io_context_ptr 위치도 rollback 시킴