### PR TITLE
# EDIT - Start Command가 들어온 이후에 Application이 start하도록 수정

### DIFF
--- a/lib/appbase/include/application.hpp
+++ b/lib/appbase/include/application.hpp
@@ -131,6 +131,11 @@ private:
   bool parseProgramOptions(int argc, char **argv);
 
   void initializePlugins();
+
+  void startInitializedPlugins();
+
+  void registerErrorSignalHandlers();
+
 };
 
 Application &app();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,8 +12,6 @@ int main(int argc, char **argv) {
   if (!appbase::app().initialize<AdminPlugin, NetPlugin, ChainPlugin, BlockProducerPlugin>(argc, argv))
     return -1;
 
-  while(!app().isAppRunning());
-
   appbase::app().start();
   return 0;
 }

--- a/src/plugins/admin_plugin/rpc_services/rpc_services.cpp
+++ b/src/plugins/admin_plugin/rpc_services/rpc_services.cpp
@@ -311,6 +311,9 @@ void AdminService<ReqStart, ResStart>::proceed() {
       app().setRunFlag();
 
       string mode_type = mode == ReqStart_Mode_DEFAULT ? "default" : "monitor";
+
+      res.set_info("Start to running the node on " + mode_type + " mode");
+
       logger::INFO("[START] Success / Mode : {}", mode_type);
     }
     receive_status = AdminRpcCallStatus::FINISH;


### PR DESCRIPTION
## 수정사항
- main.cpp 에서 app이 running 상태인지 검사하는건(isAppRunning) 의존성 관리 측면에서 좋지 않아서 제거하고, application 으로 옮김
- `Application#start`
  + io_context를 다른 thread로 실행시키고, main thread에서는 io_context가 끝날때까지 join.
  + `startInitializedPlugins`에서 플러그인들을 start하기 전에 application이 실행할 수 있는 상태인지 검사하는 loop 추가.
  + start() 기존에 있던 로직들을 추상화함