### PR TITLE
# REFACTOR - User service rpc

### DIFF
--- a/src/plugins/admin_plugin/rpc_services/include/rpc_services.hpp
+++ b/src/plugins/admin_plugin/rpc_services/include/rpc_services.hpp
@@ -27,7 +27,7 @@ struct MergerStatus {
   MergerStatus() : user_setup(false), user_login(false), is_running(false), run_mode(ModeType::NONE) {}
 };
 
-class SetupService final : public GruutUserService::Service {
+class SetupService final : public TethysUserService::Service {
 public:
   SetupService() = default;
   Status UserService(ServerContext *context, const Request *request, Reply *response) override;

--- a/src/plugins/net_plugin/include/signer_conn_table.hpp
+++ b/src/plugins/net_plugin/include/signer_conn_table.hpp
@@ -16,7 +16,7 @@ using namespace std;
 
 struct SignerRpcInfo {
   void *tag_identity;
-  ServerAsyncReaderWriter<Message, Identity> *send_msg;
+  ServerAsyncWriter<Message> *send_msg;
 };
 
 class SignerConnTable {
@@ -33,7 +33,7 @@ public:
 
   ~SignerConnTable() = default;
 
-  void setRpcInfo(const string &recv_id_b58, ServerAsyncReaderWriter<Message, Identity> *reply_rpc, void *tag) {
+  void setRpcInfo(const string &recv_id_b58, ServerAsyncWriter<Message> *reply_rpc, void *tag) {
     {
       lock_guard<std::mutex> lock(table_mutex);
       signer_conn_table[recv_id_b58].send_msg = reply_rpc;

--- a/src/plugins/net_plugin/net_plugin.cpp
+++ b/src/plugins/net_plugin/net_plugin.cpp
@@ -37,7 +37,7 @@ constexpr auto FIND_NODE_TIMEOUT = std::chrono::milliseconds(100);
 class NetPluginImpl {
 public:
   GruutMergerService::AsyncService merger_service;
-  GruutUserService::AsyncService user_service;
+  TethysUserService::AsyncService user_service;
   KademliaService::AsyncService kademlia_service;
 
   string p2p_address;
@@ -107,8 +107,9 @@ public:
     broadcast_check_table = make_shared<BroadcastMsgTable>();
     id_mapping_table = make_shared<IdMappingTable>();
 
-    new OpenChannelWithSigner(&user_service, completion_queue.get(), signer_conn_table, signer_pool_manager);
+    new ReqSigService(&user_service, completion_queue.get(), signer_conn_table, signer_pool_manager);
     new KeyExService(&user_service, completion_queue.get(), signer_pool_manager);
+    new SignerService(&user_service, completion_queue.get(), signer_pool_manager);
     new UserService(&user_service, completion_queue.get(), signer_pool_manager, routing_table);
     new MergerService(&merger_service, completion_queue.get(), routing_table, broadcast_check_table, id_mapping_table);
     new FindNode(&kademlia_service, completion_queue.get(), routing_table);

--- a/src/plugins/net_plugin/rpc_services/protos/include/user_service.grpc.pb.h
+++ b/src/plugins/net_plugin/rpc_services/protos/include/user_service.grpc.pb.h
@@ -26,22 +26,22 @@ class ServerContext;
 
 namespace grpc_user {
 
-class GruutUserService final {
+class TethysUserService final {
  public:
   static constexpr char const* service_full_name() {
-    return "grpc_user.GruutUserService";
+    return "grpc_user.TethysUserService";
   }
   class StubInterface {
    public:
     virtual ~StubInterface() {}
-    std::unique_ptr< ::grpc::ClientReaderWriterInterface< ::grpc_user::Identity, ::grpc_user::Message>> OpenChannel(::grpc::ClientContext* context) {
-      return std::unique_ptr< ::grpc::ClientReaderWriterInterface< ::grpc_user::Identity, ::grpc_user::Message>>(OpenChannelRaw(context));
+    std::unique_ptr< ::grpc::ClientReaderInterface< ::grpc_user::Message>> ReqSsigService(::grpc::ClientContext* context, const ::grpc_user::Identity& request) {
+      return std::unique_ptr< ::grpc::ClientReaderInterface< ::grpc_user::Message>>(ReqSsigServiceRaw(context, request));
     }
-    std::unique_ptr< ::grpc::ClientAsyncReaderWriterInterface< ::grpc_user::Identity, ::grpc_user::Message>> AsyncOpenChannel(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq, void* tag) {
-      return std::unique_ptr< ::grpc::ClientAsyncReaderWriterInterface< ::grpc_user::Identity, ::grpc_user::Message>>(AsyncOpenChannelRaw(context, cq, tag));
+    std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::grpc_user::Message>> AsyncReqSsigService(::grpc::ClientContext* context, const ::grpc_user::Identity& request, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::grpc_user::Message>>(AsyncReqSsigServiceRaw(context, request, cq, tag));
     }
-    std::unique_ptr< ::grpc::ClientAsyncReaderWriterInterface< ::grpc_user::Identity, ::grpc_user::Message>> PrepareAsyncOpenChannel(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncReaderWriterInterface< ::grpc_user::Identity, ::grpc_user::Message>>(PrepareAsyncOpenChannelRaw(context, cq));
+    std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::grpc_user::Message>> PrepareAsyncReqSsigService(::grpc::ClientContext* context, const ::grpc_user::Identity& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::grpc_user::Message>>(PrepareAsyncReqSsigServiceRaw(context, request, cq));
     }
     virtual ::grpc::Status KeyExService(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc_user::Reply* response) = 0;
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_user::Reply>> AsyncKeyExService(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) {
@@ -57,26 +57,35 @@ class GruutUserService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_user::Reply>> PrepareAsyncUserService(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_user::Reply>>(PrepareAsyncUserServiceRaw(context, request, cq));
     }
+    virtual ::grpc::Status SignerService(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc_user::Reply* response) = 0;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_user::Reply>> AsyncSignerService(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_user::Reply>>(AsyncSignerServiceRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_user::Reply>> PrepareAsyncSignerService(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_user::Reply>>(PrepareAsyncSignerServiceRaw(context, request, cq));
+    }
   private:
-    virtual ::grpc::ClientReaderWriterInterface< ::grpc_user::Identity, ::grpc_user::Message>* OpenChannelRaw(::grpc::ClientContext* context) = 0;
-    virtual ::grpc::ClientAsyncReaderWriterInterface< ::grpc_user::Identity, ::grpc_user::Message>* AsyncOpenChannelRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq, void* tag) = 0;
-    virtual ::grpc::ClientAsyncReaderWriterInterface< ::grpc_user::Identity, ::grpc_user::Message>* PrepareAsyncOpenChannelRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientReaderInterface< ::grpc_user::Message>* ReqSsigServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Identity& request) = 0;
+    virtual ::grpc::ClientAsyncReaderInterface< ::grpc_user::Message>* AsyncReqSsigServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Identity& request, ::grpc::CompletionQueue* cq, void* tag) = 0;
+    virtual ::grpc::ClientAsyncReaderInterface< ::grpc_user::Message>* PrepareAsyncReqSsigServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Identity& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_user::Reply>* AsyncKeyExServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_user::Reply>* PrepareAsyncKeyExServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_user::Reply>* AsyncUserServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_user::Reply>* PrepareAsyncUserServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_user::Reply>* AsyncSignerServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_user::Reply>* PrepareAsyncSignerServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) = 0;
   };
   class Stub final : public StubInterface {
    public:
     Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channel);
-    std::unique_ptr< ::grpc::ClientReaderWriter< ::grpc_user::Identity, ::grpc_user::Message>> OpenChannel(::grpc::ClientContext* context) {
-      return std::unique_ptr< ::grpc::ClientReaderWriter< ::grpc_user::Identity, ::grpc_user::Message>>(OpenChannelRaw(context));
+    std::unique_ptr< ::grpc::ClientReader< ::grpc_user::Message>> ReqSsigService(::grpc::ClientContext* context, const ::grpc_user::Identity& request) {
+      return std::unique_ptr< ::grpc::ClientReader< ::grpc_user::Message>>(ReqSsigServiceRaw(context, request));
     }
-    std::unique_ptr<  ::grpc::ClientAsyncReaderWriter< ::grpc_user::Identity, ::grpc_user::Message>> AsyncOpenChannel(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq, void* tag) {
-      return std::unique_ptr< ::grpc::ClientAsyncReaderWriter< ::grpc_user::Identity, ::grpc_user::Message>>(AsyncOpenChannelRaw(context, cq, tag));
+    std::unique_ptr< ::grpc::ClientAsyncReader< ::grpc_user::Message>> AsyncReqSsigService(::grpc::ClientContext* context, const ::grpc_user::Identity& request, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReader< ::grpc_user::Message>>(AsyncReqSsigServiceRaw(context, request, cq, tag));
     }
-    std::unique_ptr<  ::grpc::ClientAsyncReaderWriter< ::grpc_user::Identity, ::grpc_user::Message>> PrepareAsyncOpenChannel(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncReaderWriter< ::grpc_user::Identity, ::grpc_user::Message>>(PrepareAsyncOpenChannelRaw(context, cq));
+    std::unique_ptr< ::grpc::ClientAsyncReader< ::grpc_user::Message>> PrepareAsyncReqSsigService(::grpc::ClientContext* context, const ::grpc_user::Identity& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReader< ::grpc_user::Message>>(PrepareAsyncReqSsigServiceRaw(context, request, cq));
     }
     ::grpc::Status KeyExService(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc_user::Reply* response) override;
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_user::Reply>> AsyncKeyExService(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) {
@@ -92,19 +101,29 @@ class GruutUserService final {
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_user::Reply>> PrepareAsyncUserService(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_user::Reply>>(PrepareAsyncUserServiceRaw(context, request, cq));
     }
+    ::grpc::Status SignerService(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc_user::Reply* response) override;
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_user::Reply>> AsyncSignerService(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_user::Reply>>(AsyncSignerServiceRaw(context, request, cq));
+    }
+    std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_user::Reply>> PrepareAsyncSignerService(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_user::Reply>>(PrepareAsyncSignerServiceRaw(context, request, cq));
+    }
 
    private:
     std::shared_ptr< ::grpc::ChannelInterface> channel_;
-    ::grpc::ClientReaderWriter< ::grpc_user::Identity, ::grpc_user::Message>* OpenChannelRaw(::grpc::ClientContext* context) override;
-    ::grpc::ClientAsyncReaderWriter< ::grpc_user::Identity, ::grpc_user::Message>* AsyncOpenChannelRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq, void* tag) override;
-    ::grpc::ClientAsyncReaderWriter< ::grpc_user::Identity, ::grpc_user::Message>* PrepareAsyncOpenChannelRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientReader< ::grpc_user::Message>* ReqSsigServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Identity& request) override;
+    ::grpc::ClientAsyncReader< ::grpc_user::Message>* AsyncReqSsigServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Identity& request, ::grpc::CompletionQueue* cq, void* tag) override;
+    ::grpc::ClientAsyncReader< ::grpc_user::Message>* PrepareAsyncReqSsigServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Identity& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::grpc_user::Reply>* AsyncKeyExServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::grpc_user::Reply>* PrepareAsyncKeyExServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::grpc_user::Reply>* AsyncUserServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::grpc_user::Reply>* PrepareAsyncUserServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) override;
-    const ::grpc::internal::RpcMethod rpcmethod_OpenChannel_;
+    ::grpc::ClientAsyncResponseReader< ::grpc_user::Reply>* AsyncSignerServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientAsyncResponseReader< ::grpc_user::Reply>* PrepareAsyncSignerServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) override;
+    const ::grpc::internal::RpcMethod rpcmethod_ReqSsigService_;
     const ::grpc::internal::RpcMethod rpcmethod_KeyExService_;
     const ::grpc::internal::RpcMethod rpcmethod_UserService_;
+    const ::grpc::internal::RpcMethod rpcmethod_SignerService_;
   };
   static std::unique_ptr<Stub> NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options = ::grpc::StubOptions());
 
@@ -112,28 +131,29 @@ class GruutUserService final {
    public:
     Service();
     virtual ~Service();
-    virtual ::grpc::Status OpenChannel(::grpc::ServerContext* context, ::grpc::ServerReaderWriter< ::grpc_user::Message, ::grpc_user::Identity>* stream);
+    virtual ::grpc::Status ReqSsigService(::grpc::ServerContext* context, const ::grpc_user::Identity* request, ::grpc::ServerWriter< ::grpc_user::Message>* writer);
     virtual ::grpc::Status KeyExService(::grpc::ServerContext* context, const ::grpc_user::Request* request, ::grpc_user::Reply* response);
     virtual ::grpc::Status UserService(::grpc::ServerContext* context, const ::grpc_user::Request* request, ::grpc_user::Reply* response);
+    virtual ::grpc::Status SignerService(::grpc::ServerContext* context, const ::grpc_user::Request* request, ::grpc_user::Reply* response);
   };
   template <class BaseClass>
-  class WithAsyncMethod_OpenChannel : public BaseClass {
+  class WithAsyncMethod_ReqSsigService : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
-    WithAsyncMethod_OpenChannel() {
+    WithAsyncMethod_ReqSsigService() {
       ::grpc::Service::MarkMethodAsync(0);
     }
-    ~WithAsyncMethod_OpenChannel() override {
+    ~WithAsyncMethod_ReqSsigService() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status OpenChannel(::grpc::ServerContext* context, ::grpc::ServerReaderWriter< ::grpc_user::Message, ::grpc_user::Identity>* stream)  override {
+    ::grpc::Status ReqSsigService(::grpc::ServerContext* context, const ::grpc_user::Identity* request, ::grpc::ServerWriter< ::grpc_user::Message>* writer) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    void RequestOpenChannel(::grpc::ServerContext* context, ::grpc::ServerAsyncReaderWriter< ::grpc_user::Message, ::grpc_user::Identity>* stream, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncBidiStreaming(0, context, stream, new_call_cq, notification_cq, tag);
+    void RequestReqSsigService(::grpc::ServerContext* context, ::grpc_user::Identity* request, ::grpc::ServerAsyncWriter< ::grpc_user::Message>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncServerStreaming(0, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -176,20 +196,40 @@ class GruutUserService final {
       ::grpc::Service::RequestAsyncUnary(2, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
-  typedef WithAsyncMethod_OpenChannel<WithAsyncMethod_KeyExService<WithAsyncMethod_UserService<Service > > > AsyncService;
   template <class BaseClass>
-  class WithGenericMethod_OpenChannel : public BaseClass {
+  class WithAsyncMethod_SignerService : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
-    WithGenericMethod_OpenChannel() {
-      ::grpc::Service::MarkMethodGeneric(0);
+    WithAsyncMethod_SignerService() {
+      ::grpc::Service::MarkMethodAsync(3);
     }
-    ~WithGenericMethod_OpenChannel() override {
+    ~WithAsyncMethod_SignerService() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status OpenChannel(::grpc::ServerContext* context, ::grpc::ServerReaderWriter< ::grpc_user::Message, ::grpc_user::Identity>* stream)  override {
+    ::grpc::Status SignerService(::grpc::ServerContext* context, const ::grpc_user::Request* request, ::grpc_user::Reply* response) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSignerService(::grpc::ServerContext* context, ::grpc_user::Request* request, ::grpc::ServerAsyncResponseWriter< ::grpc_user::Reply>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(3, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  typedef WithAsyncMethod_ReqSsigService<WithAsyncMethod_KeyExService<WithAsyncMethod_UserService<WithAsyncMethod_SignerService<Service > > > > AsyncService;
+  template <class BaseClass>
+  class WithGenericMethod_ReqSsigService : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithGenericMethod_ReqSsigService() {
+      ::grpc::Service::MarkMethodGeneric(0);
+    }
+    ~WithGenericMethod_ReqSsigService() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status ReqSsigService(::grpc::ServerContext* context, const ::grpc_user::Identity* request, ::grpc::ServerWriter< ::grpc_user::Message>* writer) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
@@ -229,23 +269,40 @@ class GruutUserService final {
     }
   };
   template <class BaseClass>
-  class WithRawMethod_OpenChannel : public BaseClass {
+  class WithGenericMethod_SignerService : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
-    WithRawMethod_OpenChannel() {
-      ::grpc::Service::MarkMethodRaw(0);
+    WithGenericMethod_SignerService() {
+      ::grpc::Service::MarkMethodGeneric(3);
     }
-    ~WithRawMethod_OpenChannel() override {
+    ~WithGenericMethod_SignerService() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status OpenChannel(::grpc::ServerContext* context, ::grpc::ServerReaderWriter< ::grpc_user::Message, ::grpc_user::Identity>* stream)  override {
+    ::grpc::Status SignerService(::grpc::ServerContext* context, const ::grpc_user::Request* request, ::grpc_user::Reply* response) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    void RequestOpenChannel(::grpc::ServerContext* context, ::grpc::ServerAsyncReaderWriter< ::grpc::ByteBuffer, ::grpc::ByteBuffer>* stream, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
-      ::grpc::Service::RequestAsyncBidiStreaming(0, context, stream, new_call_cq, notification_cq, tag);
+  };
+  template <class BaseClass>
+  class WithRawMethod_ReqSsigService : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithRawMethod_ReqSsigService() {
+      ::grpc::Service::MarkMethodRaw(0);
+    }
+    ~WithRawMethod_ReqSsigService() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status ReqSsigService(::grpc::ServerContext* context, const ::grpc_user::Identity* request, ::grpc::ServerWriter< ::grpc_user::Message>* writer) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestReqSsigService(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncWriter< ::grpc::ByteBuffer>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncServerStreaming(0, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
   template <class BaseClass>
@@ -289,6 +346,26 @@ class GruutUserService final {
     }
   };
   template <class BaseClass>
+  class WithRawMethod_SignerService : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithRawMethod_SignerService() {
+      ::grpc::Service::MarkMethodRaw(3);
+    }
+    ~WithRawMethod_SignerService() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable synchronous version of this method
+    ::grpc::Status SignerService(::grpc::ServerContext* context, const ::grpc_user::Request* request, ::grpc_user::Reply* response) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    void RequestSignerService(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncResponseWriter< ::grpc::ByteBuffer>* response, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+      ::grpc::Service::RequestAsyncUnary(3, context, request, response, new_call_cq, notification_cq, tag);
+    }
+  };
+  template <class BaseClass>
   class WithStreamedUnaryMethod_KeyExService : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service *service) {}
@@ -328,9 +405,49 @@ class GruutUserService final {
     // replace default version of method with streamed unary
     virtual ::grpc::Status StreamedUserService(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::grpc_user::Request,::grpc_user::Reply>* server_unary_streamer) = 0;
   };
-  typedef WithStreamedUnaryMethod_KeyExService<WithStreamedUnaryMethod_UserService<Service > > StreamedUnaryService;
-  typedef Service SplitStreamedService;
-  typedef WithStreamedUnaryMethod_KeyExService<WithStreamedUnaryMethod_UserService<Service > > StreamedService;
+  template <class BaseClass>
+  class WithStreamedUnaryMethod_SignerService : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithStreamedUnaryMethod_SignerService() {
+      ::grpc::Service::MarkMethodStreamed(3,
+        new ::grpc::internal::StreamedUnaryHandler< ::grpc_user::Request, ::grpc_user::Reply>(std::bind(&WithStreamedUnaryMethod_SignerService<BaseClass>::StreamedSignerService, this, std::placeholders::_1, std::placeholders::_2)));
+    }
+    ~WithStreamedUnaryMethod_SignerService() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status SignerService(::grpc::ServerContext* context, const ::grpc_user::Request* request, ::grpc_user::Reply* response) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with streamed unary
+    virtual ::grpc::Status StreamedSignerService(::grpc::ServerContext* context, ::grpc::ServerUnaryStreamer< ::grpc_user::Request,::grpc_user::Reply>* server_unary_streamer) = 0;
+  };
+  typedef WithStreamedUnaryMethod_KeyExService<WithStreamedUnaryMethod_UserService<WithStreamedUnaryMethod_SignerService<Service > > > StreamedUnaryService;
+  template <class BaseClass>
+  class WithSplitStreamingMethod_ReqSsigService : public BaseClass {
+   private:
+    void BaseClassMustBeDerivedFromService(const Service *service) {}
+   public:
+    WithSplitStreamingMethod_ReqSsigService() {
+      ::grpc::Service::MarkMethodStreamed(0,
+        new ::grpc::internal::SplitServerStreamingHandler< ::grpc_user::Identity, ::grpc_user::Message>(std::bind(&WithSplitStreamingMethod_ReqSsigService<BaseClass>::StreamedReqSsigService, this, std::placeholders::_1, std::placeholders::_2)));
+    }
+    ~WithSplitStreamingMethod_ReqSsigService() override {
+      BaseClassMustBeDerivedFromService(this);
+    }
+    // disable regular version of this method
+    ::grpc::Status ReqSsigService(::grpc::ServerContext* context, const ::grpc_user::Identity* request, ::grpc::ServerWriter< ::grpc_user::Message>* writer) override {
+      abort();
+      return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+    }
+    // replace default version of method with split streamed
+    virtual ::grpc::Status StreamedReqSsigService(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::grpc_user::Identity,::grpc_user::Message>* server_split_streamer) = 0;
+  };
+  typedef WithSplitStreamingMethod_ReqSsigService<Service > SplitStreamedService;
+  typedef WithSplitStreamingMethod_ReqSsigService<WithStreamedUnaryMethod_KeyExService<WithStreamedUnaryMethod_UserService<WithStreamedUnaryMethod_SignerService<Service > > > > StreamedService;
 };
 
 }  // namespace grpc_user

--- a/src/plugins/net_plugin/rpc_services/protos/user_service.grpc.pb.cc
+++ b/src/plugins/net_plugin/rpc_services/protos/user_service.grpc.pb.cc
@@ -15,95 +15,122 @@
 #include <grpcpp/impl/codegen/sync_stream.h>
 namespace grpc_user {
 
-static const char* GruutUserService_method_names[] = {
-  "/grpc_user.GruutUserService/OpenChannel",
-  "/grpc_user.GruutUserService/KeyExService",
-  "/grpc_user.GruutUserService/UserService",
+static const char* TethysUserService_method_names[] = {
+  "/grpc_user.TethysUserService/ReqSsigService",
+  "/grpc_user.TethysUserService/KeyExService",
+  "/grpc_user.TethysUserService/UserService",
+  "/grpc_user.TethysUserService/SignerService",
 };
 
-std::unique_ptr< GruutUserService::Stub> GruutUserService::NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options) {
+std::unique_ptr< TethysUserService::Stub> TethysUserService::NewStub(const std::shared_ptr< ::grpc::ChannelInterface>& channel, const ::grpc::StubOptions& options) {
   (void)options;
-  std::unique_ptr< GruutUserService::Stub> stub(new GruutUserService::Stub(channel));
+  std::unique_ptr< TethysUserService::Stub> stub(new TethysUserService::Stub(channel));
   return stub;
 }
 
-GruutUserService::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channel)
-  : channel_(channel), rpcmethod_OpenChannel_(GruutUserService_method_names[0], ::grpc::internal::RpcMethod::BIDI_STREAMING, channel)
-  , rpcmethod_KeyExService_(GruutUserService_method_names[1], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
-  , rpcmethod_UserService_(GruutUserService_method_names[2], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+TethysUserService::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channel)
+  : channel_(channel), rpcmethod_ReqSsigService_(TethysUserService_method_names[0], ::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
+  , rpcmethod_KeyExService_(TethysUserService_method_names[1], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_UserService_(TethysUserService_method_names[2], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
+  , rpcmethod_SignerService_(TethysUserService_method_names[3], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   {}
 
-::grpc::ClientReaderWriter< ::grpc_user::Identity, ::grpc_user::Message>* GruutUserService::Stub::OpenChannelRaw(::grpc::ClientContext* context) {
-  return ::grpc::internal::ClientReaderWriterFactory< ::grpc_user::Identity, ::grpc_user::Message>::Create(channel_.get(), rpcmethod_OpenChannel_, context);
+::grpc::ClientReader< ::grpc_user::Message>* TethysUserService::Stub::ReqSsigServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Identity& request) {
+  return ::grpc::internal::ClientReaderFactory< ::grpc_user::Message>::Create(channel_.get(), rpcmethod_ReqSsigService_, context, request);
 }
 
-::grpc::ClientAsyncReaderWriter< ::grpc_user::Identity, ::grpc_user::Message>* GruutUserService::Stub::AsyncOpenChannelRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq, void* tag) {
-  return ::grpc::internal::ClientAsyncReaderWriterFactory< ::grpc_user::Identity, ::grpc_user::Message>::Create(channel_.get(), cq, rpcmethod_OpenChannel_, context, true, tag);
+::grpc::ClientAsyncReader< ::grpc_user::Message>* TethysUserService::Stub::AsyncReqSsigServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Identity& request, ::grpc::CompletionQueue* cq, void* tag) {
+  return ::grpc::internal::ClientAsyncReaderFactory< ::grpc_user::Message>::Create(channel_.get(), cq, rpcmethod_ReqSsigService_, context, request, true, tag);
 }
 
-::grpc::ClientAsyncReaderWriter< ::grpc_user::Identity, ::grpc_user::Message>* GruutUserService::Stub::PrepareAsyncOpenChannelRaw(::grpc::ClientContext* context, ::grpc::CompletionQueue* cq) {
-  return ::grpc::internal::ClientAsyncReaderWriterFactory< ::grpc_user::Identity, ::grpc_user::Message>::Create(channel_.get(), cq, rpcmethod_OpenChannel_, context, false, nullptr);
+::grpc::ClientAsyncReader< ::grpc_user::Message>* TethysUserService::Stub::PrepareAsyncReqSsigServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Identity& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncReaderFactory< ::grpc_user::Message>::Create(channel_.get(), cq, rpcmethod_ReqSsigService_, context, request, false, nullptr);
 }
 
-::grpc::Status GruutUserService::Stub::KeyExService(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc_user::Reply* response) {
+::grpc::Status TethysUserService::Stub::KeyExService(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc_user::Reply* response) {
   return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_KeyExService_, context, request, response);
 }
 
-::grpc::ClientAsyncResponseReader< ::grpc_user::Reply>* GruutUserService::Stub::AsyncKeyExServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) {
+::grpc::ClientAsyncResponseReader< ::grpc_user::Reply>* TethysUserService::Stub::AsyncKeyExServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) {
   return ::grpc::internal::ClientAsyncResponseReaderFactory< ::grpc_user::Reply>::Create(channel_.get(), cq, rpcmethod_KeyExService_, context, request, true);
 }
 
-::grpc::ClientAsyncResponseReader< ::grpc_user::Reply>* GruutUserService::Stub::PrepareAsyncKeyExServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) {
+::grpc::ClientAsyncResponseReader< ::grpc_user::Reply>* TethysUserService::Stub::PrepareAsyncKeyExServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) {
   return ::grpc::internal::ClientAsyncResponseReaderFactory< ::grpc_user::Reply>::Create(channel_.get(), cq, rpcmethod_KeyExService_, context, request, false);
 }
 
-::grpc::Status GruutUserService::Stub::UserService(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc_user::Reply* response) {
+::grpc::Status TethysUserService::Stub::UserService(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc_user::Reply* response) {
   return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_UserService_, context, request, response);
 }
 
-::grpc::ClientAsyncResponseReader< ::grpc_user::Reply>* GruutUserService::Stub::AsyncUserServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) {
+::grpc::ClientAsyncResponseReader< ::grpc_user::Reply>* TethysUserService::Stub::AsyncUserServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) {
   return ::grpc::internal::ClientAsyncResponseReaderFactory< ::grpc_user::Reply>::Create(channel_.get(), cq, rpcmethod_UserService_, context, request, true);
 }
 
-::grpc::ClientAsyncResponseReader< ::grpc_user::Reply>* GruutUserService::Stub::PrepareAsyncUserServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) {
+::grpc::ClientAsyncResponseReader< ::grpc_user::Reply>* TethysUserService::Stub::PrepareAsyncUserServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) {
   return ::grpc::internal::ClientAsyncResponseReaderFactory< ::grpc_user::Reply>::Create(channel_.get(), cq, rpcmethod_UserService_, context, request, false);
 }
 
-GruutUserService::Service::Service() {
-  AddMethod(new ::grpc::internal::RpcServiceMethod(
-      GruutUserService_method_names[0],
-      ::grpc::internal::RpcMethod::BIDI_STREAMING,
-      new ::grpc::internal::BidiStreamingHandler< GruutUserService::Service, ::grpc_user::Identity, ::grpc_user::Message>(
-          std::mem_fn(&GruutUserService::Service::OpenChannel), this)));
-  AddMethod(new ::grpc::internal::RpcServiceMethod(
-      GruutUserService_method_names[1],
-      ::grpc::internal::RpcMethod::NORMAL_RPC,
-      new ::grpc::internal::RpcMethodHandler< GruutUserService::Service, ::grpc_user::Request, ::grpc_user::Reply>(
-          std::mem_fn(&GruutUserService::Service::KeyExService), this)));
-  AddMethod(new ::grpc::internal::RpcServiceMethod(
-      GruutUserService_method_names[2],
-      ::grpc::internal::RpcMethod::NORMAL_RPC,
-      new ::grpc::internal::RpcMethodHandler< GruutUserService::Service, ::grpc_user::Request, ::grpc_user::Reply>(
-          std::mem_fn(&GruutUserService::Service::UserService), this)));
+::grpc::Status TethysUserService::Stub::SignerService(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc_user::Reply* response) {
+  return ::grpc::internal::BlockingUnaryCall(channel_.get(), rpcmethod_SignerService_, context, request, response);
 }
 
-GruutUserService::Service::~Service() {
+::grpc::ClientAsyncResponseReader< ::grpc_user::Reply>* TethysUserService::Stub::AsyncSignerServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::grpc_user::Reply>::Create(channel_.get(), cq, rpcmethod_SignerService_, context, request, true);
 }
 
-::grpc::Status GruutUserService::Service::OpenChannel(::grpc::ServerContext* context, ::grpc::ServerReaderWriter< ::grpc_user::Message, ::grpc_user::Identity>* stream) {
+::grpc::ClientAsyncResponseReader< ::grpc_user::Reply>* TethysUserService::Stub::PrepareAsyncSignerServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncResponseReaderFactory< ::grpc_user::Reply>::Create(channel_.get(), cq, rpcmethod_SignerService_, context, request, false);
+}
+
+TethysUserService::Service::Service() {
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      TethysUserService_method_names[0],
+      ::grpc::internal::RpcMethod::SERVER_STREAMING,
+      new ::grpc::internal::ServerStreamingHandler< TethysUserService::Service, ::grpc_user::Identity, ::grpc_user::Message>(
+          std::mem_fn(&TethysUserService::Service::ReqSsigService), this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      TethysUserService_method_names[1],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< TethysUserService::Service, ::grpc_user::Request, ::grpc_user::Reply>(
+          std::mem_fn(&TethysUserService::Service::KeyExService), this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      TethysUserService_method_names[2],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< TethysUserService::Service, ::grpc_user::Request, ::grpc_user::Reply>(
+          std::mem_fn(&TethysUserService::Service::UserService), this)));
+  AddMethod(new ::grpc::internal::RpcServiceMethod(
+      TethysUserService_method_names[3],
+      ::grpc::internal::RpcMethod::NORMAL_RPC,
+      new ::grpc::internal::RpcMethodHandler< TethysUserService::Service, ::grpc_user::Request, ::grpc_user::Reply>(
+          std::mem_fn(&TethysUserService::Service::SignerService), this)));
+}
+
+TethysUserService::Service::~Service() {
+}
+
+::grpc::Status TethysUserService::Service::ReqSsigService(::grpc::ServerContext* context, const ::grpc_user::Identity* request, ::grpc::ServerWriter< ::grpc_user::Message>* writer) {
   (void) context;
-  (void) stream;
+  (void) request;
+  (void) writer;
   return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
 }
 
-::grpc::Status GruutUserService::Service::KeyExService(::grpc::ServerContext* context, const ::grpc_user::Request* request, ::grpc_user::Reply* response) {
+::grpc::Status TethysUserService::Service::KeyExService(::grpc::ServerContext* context, const ::grpc_user::Request* request, ::grpc_user::Reply* response) {
   (void) context;
   (void) request;
   (void) response;
   return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
 }
 
-::grpc::Status GruutUserService::Service::UserService(::grpc::ServerContext* context, const ::grpc_user::Request* request, ::grpc_user::Reply* response) {
+::grpc::Status TethysUserService::Service::UserService(::grpc::ServerContext* context, const ::grpc_user::Request* request, ::grpc_user::Reply* response) {
+  (void) context;
+  (void) request;
+  (void) response;
+  return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
+}
+
+::grpc::Status TethysUserService::Service::SignerService(::grpc::ServerContext* context, const ::grpc_user::Request* request, ::grpc_user::Reply* response) {
   (void) context;
   (void) request;
   (void) response;

--- a/src/plugins/net_plugin/rpc_services/protos/user_service.pb.cc
+++ b/src/plugins/net_plugin/rpc_services/protos/user_service.pb.cc
@@ -179,16 +179,17 @@ void AddDescriptorsImpl() {
       "ERNAL\020\003\022\027\n\023ECDH_ILLEGAL_ACCESS\020\025\022\030\n\024ECDH"
       "_MAX_SIGNER_POOL\020\026\022\020\n\014ECDH_TIMEOUT\020\027\022\024\n\020"
       "ECDH_INVALID_SIG\020\030\022\023\n\017ECDH_INVALID_PK\020\0312"
-      "\277\001\n\020GruutUserService\022<\n\013OpenChannel\022\023.gr"
-      "pc_user.Identity\032\022.grpc_user.Message\"\000(\001"
-      "0\001\0226\n\014KeyExService\022\022.grpc_user.Request\032\020"
-      ".grpc_user.Reply\"\000\0225\n\013UserService\022\022.grpc"
-      "_user.Request\032\020.grpc_user.Reply\"\000B-\n\033com"
-      ".gruutnetworks.gruutuserB\014GruutNetworkP\001"
-      "b\006proto3"
+      "\372\001\n\021TethysUserService\022=\n\016ReqSsigService\022"
+      "\023.grpc_user.Identity\032\022.grpc_user.Message"
+      "\"\0000\001\0226\n\014KeyExService\022\022.grpc_user.Request"
+      "\032\020.grpc_user.Reply\"\000\0225\n\013UserService\022\022.gr"
+      "pc_user.Request\032\020.grpc_user.Reply\"\000\0227\n\rS"
+      "ignerService\022\022.grpc_user.Request\032\020.grpc_"
+      "user.Reply\"\000B\"\n\026io.tethys.tethyswalletB\006"
+      "TethysP\001b\006proto3"
   };
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
-      descriptor, 608);
+      descriptor, 656);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "user_service.proto", &protobuf_RegisterTypes);
 }

--- a/src/plugins/net_plugin/rpc_services/protos/user_service.proto
+++ b/src/plugins/net_plugin/rpc_services/protos/user_service.proto
@@ -1,15 +1,16 @@
 syntax = "proto3";
 
 option java_multiple_files = true;
-option java_package = "com.gruutnetworks.gruutuser";
-option java_outer_classname = "GruutNetwork";
+option java_package = "io.tethys.tethyswallet";
+option java_outer_classname = "Tethys";
 
 package grpc_user;
 
-service GruutUserService {
-    rpc OpenChannel(stream Identity) returns (stream Message) {}
+service TethysUserService {
+    rpc ReqSsigService (Identity) returns (stream Message) {}
     rpc KeyExService (Request) returns (Reply) {}
     rpc UserService (Request) returns (Reply) {}
+    rpc SignerService (Request) returns (Reply) {}
 }
 message Identity {
     bytes sender = 1;


### PR DESCRIPTION
- user_service protobuf 수정
- 기존에는 User Service Rpc에서 Signer로서 역할을 한 부분에 대해서도
같이 처리 했었음.
- User / Signer 로 분리

- Signer Service Rpc의 경우 현재는 User Service Rpc와 동일한 구조이고,
Tx를 relay 하는 부분만 빠져있음. 분리한 이유는 차후 Signer로서 하는
역할이 커질 수도 있기 때문에 분리.

- openChannelService -> ReqSsigService 이름 변경 및 단방향 stream 으로
수정

- Gruut -> Tethys 이름 변경
