### PR TITLE
# REFACTOR - CommandDelegate

### DIFF
--- a/src/plugins/admin_plugin/include/admin_type.hpp
+++ b/src/plugins/admin_plugin/include/admin_type.hpp
@@ -3,7 +3,6 @@
 namespace gruut {
 namespace admin_plugin {
 
-enum class PluginName : int { NET, CHAIN };
 enum class ControlType : int { LOGIN = 1, START = 2 };
 enum class ModeType : int { NONE = -1, DEFAULT = 0, MONITOR = 1 };
 


### PR DESCRIPTION
## 수정사항
- 종전의 코드에서는 `PluginName`, `ControlType` 조합에 따라서 동작이 결정됨(`operator()`)
- 추상화가 적절하지 않아서 타입에 따른 동작을 명확하게 하기 위해서 `CommandDelegator`의 순수함수를 구현하는 LoginCommandDelegator, StartCommandDelegator 클래스를 각각 만듦
- `operator()`에서 중복코드를 base class로 만들고, 나머지 세부동작들은 각 derived class 에서 구현하도록 함
- 앞으로 추가되는 Control Type은 `CommandDelegator`의 인터페이스를 보고 구현하기만 하면 동작하도록 수정