### PR TITLE
 # EDIT - MSG_SUCCESS json schema & message validator

### DIFF
--- a/src/plugins/net_plugin/config/include/message.hpp
+++ b/src/plugins/net_plugin/config/include/message.hpp
@@ -120,6 +120,7 @@ enum class MsgEntryType {
   PEM_PK,
   HEX_256,
   CONTRACT_ID,
+  USER_MODE,
   BOOL,
   NONE
 };

--- a/src/plugins/net_plugin/include/msg_schema.hpp
+++ b/src/plugins/net_plugin/include/msg_schema.hpp
@@ -536,6 +536,9 @@ static SchemaMap schema_map = {{MessageType::MSG_PING,
     "user": {
       "type": "string"
     },
+    "mode": {
+      "type": "string"
+    },
     "val": {
       "type": "boolean"
     }
@@ -543,6 +546,7 @@ static SchemaMap schema_map = {{MessageType::MSG_PING,
   "required": [
     "time",
     "user",
+    "mode",
     "val"
   ]
 })"_json},

--- a/src/plugins/net_plugin/rpc_services/rpc_services.cpp
+++ b/src/plugins/net_plugin/rpc_services/rpc_services.cpp
@@ -65,6 +65,9 @@ private:
   }
   bool validateEntry(MsgEntryType entry_type, const string &val) {
     switch (entry_type) {
+    case MsgEntryType::USER_MODE: {
+      return (val == "user" || val == "signer" || val == "all")
+    }
     case MsgEntryType::DECIMAL:
     case MsgEntryType::TIMESTAMP: {
       if (!all_of(val.begin(), val.end(), ::isdigit)) {
@@ -159,6 +162,8 @@ private:
       return MsgEntryType::HEX_256;
     else if (key == "val" || key == "confirm")
       return MsgEntryType::BOOL;
+    else if (key == "mode")
+      return MsgEntryType::USER_MODE;
     else
       return MsgEntryType::NONE;
   }


### PR DESCRIPTION
- MSG_SUCCESS `mode` 필드 추가 ( 해당 필드는 참여하려는 유형을 결정
user / signer / all )
https://thevaulters.atlassian.net/wiki/spaces/SGN/pages/87949319/Signer+User+ECDH+Messages
- message validator에서 `mode` key 에 대해서도 검증하도록 함