### PR TITLE
# REFACTOR - MergerStatus

### DIFF
--- a/lib/appbase/application.cpp
+++ b/lib/appbase/application.cpp
@@ -182,6 +182,22 @@ bool Application::isAppRunning() {
   return running;
 }
 
+bool Application::isUserSignedIn() {
+  return application_status.user_login;
+}
+
+void Application::completeUserSetup() {
+  application_status.user_setup = true;
+}
+
+void Application::completeUserSignedIn() {
+  application_status.user_login = true;
+}
+
+RunningMode &Application::runningMode() {
+  return application_status.run_mode;
+}
+
 Application &app() {
   return Application::instance();
 }

--- a/lib/appbase/include/application.hpp
+++ b/lib/appbase/include/application.hpp
@@ -22,6 +22,17 @@ namespace po = boost::program_options;
 
 class ProgramOptions;
 
+enum class RunningMode : int { NONE = -1, DEFAULT = 0, MONITOR = 1 };
+
+struct ApplicationStatus {
+    bool user_setup;
+    bool user_login;
+
+    RunningMode run_mode;
+
+    ApplicationStatus() : user_setup(false), user_login(false), run_mode(RunningMode::NONE) {}
+};
+
 class Application {
 public:
   ~Application();
@@ -82,6 +93,12 @@ public:
   const string &getId() const;
 
   bool isAppRunning();
+  bool isUserSignedIn();
+
+  void completeUserSetup();
+  void completeUserSignedIn();
+
+  RunningMode &runningMode();
 
   auto &getIoContext() {
     return *io_context_ptr;
@@ -135,6 +152,8 @@ private:
   void startInitializedPlugins();
 
   void registerErrorSignalHandlers();
+
+  ApplicationStatus application_status;
 
 };
 

--- a/src/plugins/admin_plugin/admin_plugin.cpp
+++ b/src/plugins/admin_plugin/admin_plugin.cpp
@@ -12,8 +12,6 @@ const auto ADMIN_REQ_CHECK_PERIOD = std::chrono::milliseconds(100);
 
 class AdminPluginImpl {
 public:
-  std::shared_ptr<MergerStatus> merger_status;
-
   GruutAdminService::AsyncService admin_service;
 
   unique_ptr<Server> admin_server;
@@ -40,12 +38,10 @@ public:
   }
 
   void registerService() {
-    merger_status = make_shared<MergerStatus>();
-
-    new AdminService<ReqSetupKey, ResSetupKey>(&admin_service, completion_queue.get(), merger_status, setup_port);
-    new AdminService<ReqLogin, ResLogin>(&admin_service, completion_queue.get(), merger_status);
-    new AdminService<ReqStart, ResStart>(&admin_service, completion_queue.get(), merger_status);
-    new AdminService<ReqStatus, ResStatus>(&admin_service, completion_queue.get(), merger_status);
+    new AdminService<ReqSetupKey, ResSetupKey>(&admin_service, completion_queue.get(), setup_port);
+    new AdminService<ReqLogin, ResLogin>(&admin_service, completion_queue.get());
+    new AdminService<ReqStart, ResStart>(&admin_service, completion_queue.get());
+    new AdminService<ReqStatus, ResStatus>(&admin_service, completion_queue.get());
   }
 
   void start() {}

--- a/src/plugins/admin_plugin/include/admin_type.hpp
+++ b/src/plugins/admin_plugin/include/admin_type.hpp
@@ -4,7 +4,6 @@ namespace gruut {
 namespace admin_plugin {
 
 enum class ControlType : int { LOGIN = 1, START = 2 };
-enum class ModeType : int { NONE = -1, DEFAULT = 0, MONITOR = 1 };
 
 } // namespace admin_plugin
 } // namespace gruut


### PR DESCRIPTION
## 수정사항
- `rpc_services.hpp` 에서 정의되었던 MergerStatus의 필드들이 중복으로 존재했었음 ( 예를 들면, user_login_flag, mode)
- admin_plugin 에서만 사용되지 않고, 여러 곳에서 사용되는 시그널이 있기 때문에 앞으로도 여러 plugin들에서 사용될 가능성이 있음. 그래서 application 쪽으로 코드를 옮김
- application에서 현재 MergerStatus를 가져올 수 있도록 여러 곳 코드 수정