### PR TITLE
# REFACTOR - User Service rpc error message

### DIFF
--- a/src/plugins/admin_plugin/rpc_services/rpc_services.cpp
+++ b/src/plugins/admin_plugin/rpc_services/rpc_services.cpp
@@ -39,8 +39,8 @@ protected:
 
 class LoginCommandDelegator : public CommandDelegator<ReqLogin> {
 public:
-  LoginCommandDelegator(string_view _env_sk_pem, string_view _cert, string_view _pass):
-    secret_key(_env_sk_pem), cert(_cert), pass(_pass) {}
+  LoginCommandDelegator(string_view _env_sk_pem, string_view _cert, string_view _pass)
+      : secret_key(_env_sk_pem), cert(_cert), pass(_pass) {}
 
 private:
   nlohmann::json createControlCommand() override {
@@ -67,7 +67,7 @@ private:
 
 class StartCommandDelegator : public CommandDelegator<ReqStart> {
 public:
-  StartCommandDelegator(RunningMode _net_mode): net_mode(_net_mode) {}
+  StartCommandDelegator(RunningMode _net_mode) : net_mode(_net_mode) {}
 
 private:
   nlohmann::json createControlCommand() override {
@@ -91,18 +91,18 @@ private:
 };
 
 Status SetupService::UserService(ServerContext *context, const Request *request, Reply *response) {
-  Status rpc_status;
+  string err_info;
   MessageParser msg_parser;
-  auto input_data = msg_parser.parseMessage(request->message(), rpc_status);
+  auto input_data = msg_parser.parseMessage(request->message(), err_info);
 
   if (!input_data.has_value()) {
     user_key_info.set_value({});
+    response->set_err_info(err_info);
     response->set_status(Reply_Status_INVALID);
-    return rpc_status;
+  } else {
+    user_key_info.set_value(input_data.value().body);
+    response->set_status(Reply_Status_SUCCESS);
   }
-
-  user_key_info.set_value(input_data.value().body);
-  response->set_status(Reply_Status_SUCCESS);
   return Status::OK;
 }
 

--- a/src/plugins/net_plugin/include/message_parser.hpp
+++ b/src/plugins/net_plugin/include/message_parser.hpp
@@ -17,11 +17,11 @@ using namespace grpc;
 
 class MessageParser {
 public:
-  optional<InNetMsg> parseMessage(string_view packed_msg, Status &return_rpc_status) {
+  optional<InNetMsg> parseMessage(string_view packed_msg, string &return_err_info) {
     const string raw_header(packed_msg.begin(), packed_msg.begin() + HEADER_LENGTH);
     auto msg_header = parseHeader(raw_header);
     if (!validateMsgHdrFormat(msg_header)) {
-      return_rpc_status = Status(StatusCode::INVALID_ARGUMENT, "Bad request (Invalid parameter)");
+      return_err_info = "Bad request (Invalid message header format)";
       return {};
     }
     auto body_size = convertU8ToU32BE(msg_header.total_length) - HEADER_LENGTH;
@@ -29,11 +29,9 @@ public:
     auto json_body = getJson(msg_header.serialization_algo_type, msg_raw_body);
 
     if (!JsonValidator::validateSchema(json_body, msg_header.message_type)) {
-      return_rpc_status = Status(StatusCode::INVALID_ARGUMENT, "Bad request (Json schema error)");
+      return_err_info = "Bad request (Json schema error)";
       return {};
     }
-
-    return_rpc_status = Status::OK;
 
     InNetMsg in_msg;
     in_msg.type = msg_header.message_type;

--- a/src/plugins/net_plugin/net_plugin.cpp
+++ b/src/plugins/net_plugin/net_plugin.cpp
@@ -103,7 +103,7 @@ public:
     broadcast_check_table = make_shared<BroadcastMsgTable>();
     id_mapping_table = make_shared<IdMappingTable>();
 
-    new ReqSigService(&user_service, completion_queue.get(), user_conn_table, user_pool_manager);
+    new PushService(&user_service, completion_queue.get(), user_conn_table, user_pool_manager);
     new KeyExService(&user_service, completion_queue.get(), user_pool_manager);
     new SignerService(&user_service, completion_queue.get(), user_pool_manager);
     new UserService(&user_service, completion_queue.get(), user_pool_manager, routing_table);

--- a/src/plugins/net_plugin/rpc_services/include/rpc_services.hpp
+++ b/src/plugins/net_plugin/rpc_services/include/rpc_services.hpp
@@ -47,10 +47,10 @@ protected:
   RpcCallStatus m_receive_status;
 };
 
-class ReqSigService final : public CallData {
+class PushService final : public CallData {
 public:
-  ReqSigService(TethysUserService::AsyncService *service, ServerCompletionQueue *cq, shared_ptr<UserConnTable> user_conn_table,
-                shared_ptr<UserPoolManager> user_pool_manager)
+  PushService(TethysUserService::AsyncService *service, ServerCompletionQueue *cq, shared_ptr<UserConnTable> user_conn_table,
+              shared_ptr<UserPoolManager> user_pool_manager)
       : m_stream(&m_context), m_user_conn_table(move(user_conn_table)), m_user_pool_manager(move(user_pool_manager)) {
 
     m_service = service;

--- a/src/plugins/net_plugin/rpc_services/protos/include/user_service.grpc.pb.h
+++ b/src/plugins/net_plugin/rpc_services/protos/include/user_service.grpc.pb.h
@@ -34,14 +34,14 @@ class TethysUserService final {
   class StubInterface {
    public:
     virtual ~StubInterface() {}
-    std::unique_ptr< ::grpc::ClientReaderInterface< ::grpc_user::Message>> ReqSsigService(::grpc::ClientContext* context, const ::grpc_user::Identity& request) {
-      return std::unique_ptr< ::grpc::ClientReaderInterface< ::grpc_user::Message>>(ReqSsigServiceRaw(context, request));
+    std::unique_ptr< ::grpc::ClientReaderInterface< ::grpc_user::Message>> PushService(::grpc::ClientContext* context, const ::grpc_user::Identity& request) {
+      return std::unique_ptr< ::grpc::ClientReaderInterface< ::grpc_user::Message>>(PushServiceRaw(context, request));
     }
-    std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::grpc_user::Message>> AsyncReqSsigService(::grpc::ClientContext* context, const ::grpc_user::Identity& request, ::grpc::CompletionQueue* cq, void* tag) {
-      return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::grpc_user::Message>>(AsyncReqSsigServiceRaw(context, request, cq, tag));
+    std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::grpc_user::Message>> AsyncPushService(::grpc::ClientContext* context, const ::grpc_user::Identity& request, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::grpc_user::Message>>(AsyncPushServiceRaw(context, request, cq, tag));
     }
-    std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::grpc_user::Message>> PrepareAsyncReqSsigService(::grpc::ClientContext* context, const ::grpc_user::Identity& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::grpc_user::Message>>(PrepareAsyncReqSsigServiceRaw(context, request, cq));
+    std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::grpc_user::Message>> PrepareAsyncPushService(::grpc::ClientContext* context, const ::grpc_user::Identity& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReaderInterface< ::grpc_user::Message>>(PrepareAsyncPushServiceRaw(context, request, cq));
     }
     virtual ::grpc::Status KeyExService(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc_user::Reply* response) = 0;
     std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_user::Reply>> AsyncKeyExService(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) {
@@ -65,9 +65,9 @@ class TethysUserService final {
       return std::unique_ptr< ::grpc::ClientAsyncResponseReaderInterface< ::grpc_user::Reply>>(PrepareAsyncSignerServiceRaw(context, request, cq));
     }
   private:
-    virtual ::grpc::ClientReaderInterface< ::grpc_user::Message>* ReqSsigServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Identity& request) = 0;
-    virtual ::grpc::ClientAsyncReaderInterface< ::grpc_user::Message>* AsyncReqSsigServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Identity& request, ::grpc::CompletionQueue* cq, void* tag) = 0;
-    virtual ::grpc::ClientAsyncReaderInterface< ::grpc_user::Message>* PrepareAsyncReqSsigServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Identity& request, ::grpc::CompletionQueue* cq) = 0;
+    virtual ::grpc::ClientReaderInterface< ::grpc_user::Message>* PushServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Identity& request) = 0;
+    virtual ::grpc::ClientAsyncReaderInterface< ::grpc_user::Message>* AsyncPushServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Identity& request, ::grpc::CompletionQueue* cq, void* tag) = 0;
+    virtual ::grpc::ClientAsyncReaderInterface< ::grpc_user::Message>* PrepareAsyncPushServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Identity& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_user::Reply>* AsyncKeyExServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_user::Reply>* PrepareAsyncKeyExServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) = 0;
     virtual ::grpc::ClientAsyncResponseReaderInterface< ::grpc_user::Reply>* AsyncUserServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) = 0;
@@ -78,14 +78,14 @@ class TethysUserService final {
   class Stub final : public StubInterface {
    public:
     Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channel);
-    std::unique_ptr< ::grpc::ClientReader< ::grpc_user::Message>> ReqSsigService(::grpc::ClientContext* context, const ::grpc_user::Identity& request) {
-      return std::unique_ptr< ::grpc::ClientReader< ::grpc_user::Message>>(ReqSsigServiceRaw(context, request));
+    std::unique_ptr< ::grpc::ClientReader< ::grpc_user::Message>> PushService(::grpc::ClientContext* context, const ::grpc_user::Identity& request) {
+      return std::unique_ptr< ::grpc::ClientReader< ::grpc_user::Message>>(PushServiceRaw(context, request));
     }
-    std::unique_ptr< ::grpc::ClientAsyncReader< ::grpc_user::Message>> AsyncReqSsigService(::grpc::ClientContext* context, const ::grpc_user::Identity& request, ::grpc::CompletionQueue* cq, void* tag) {
-      return std::unique_ptr< ::grpc::ClientAsyncReader< ::grpc_user::Message>>(AsyncReqSsigServiceRaw(context, request, cq, tag));
+    std::unique_ptr< ::grpc::ClientAsyncReader< ::grpc_user::Message>> AsyncPushService(::grpc::ClientContext* context, const ::grpc_user::Identity& request, ::grpc::CompletionQueue* cq, void* tag) {
+      return std::unique_ptr< ::grpc::ClientAsyncReader< ::grpc_user::Message>>(AsyncPushServiceRaw(context, request, cq, tag));
     }
-    std::unique_ptr< ::grpc::ClientAsyncReader< ::grpc_user::Message>> PrepareAsyncReqSsigService(::grpc::ClientContext* context, const ::grpc_user::Identity& request, ::grpc::CompletionQueue* cq) {
-      return std::unique_ptr< ::grpc::ClientAsyncReader< ::grpc_user::Message>>(PrepareAsyncReqSsigServiceRaw(context, request, cq));
+    std::unique_ptr< ::grpc::ClientAsyncReader< ::grpc_user::Message>> PrepareAsyncPushService(::grpc::ClientContext* context, const ::grpc_user::Identity& request, ::grpc::CompletionQueue* cq) {
+      return std::unique_ptr< ::grpc::ClientAsyncReader< ::grpc_user::Message>>(PrepareAsyncPushServiceRaw(context, request, cq));
     }
     ::grpc::Status KeyExService(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc_user::Reply* response) override;
     std::unique_ptr< ::grpc::ClientAsyncResponseReader< ::grpc_user::Reply>> AsyncKeyExService(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) {
@@ -111,16 +111,16 @@ class TethysUserService final {
 
    private:
     std::shared_ptr< ::grpc::ChannelInterface> channel_;
-    ::grpc::ClientReader< ::grpc_user::Message>* ReqSsigServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Identity& request) override;
-    ::grpc::ClientAsyncReader< ::grpc_user::Message>* AsyncReqSsigServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Identity& request, ::grpc::CompletionQueue* cq, void* tag) override;
-    ::grpc::ClientAsyncReader< ::grpc_user::Message>* PrepareAsyncReqSsigServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Identity& request, ::grpc::CompletionQueue* cq) override;
+    ::grpc::ClientReader< ::grpc_user::Message>* PushServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Identity& request) override;
+    ::grpc::ClientAsyncReader< ::grpc_user::Message>* AsyncPushServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Identity& request, ::grpc::CompletionQueue* cq, void* tag) override;
+    ::grpc::ClientAsyncReader< ::grpc_user::Message>* PrepareAsyncPushServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Identity& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::grpc_user::Reply>* AsyncKeyExServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::grpc_user::Reply>* PrepareAsyncKeyExServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::grpc_user::Reply>* AsyncUserServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::grpc_user::Reply>* PrepareAsyncUserServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::grpc_user::Reply>* AsyncSignerServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) override;
     ::grpc::ClientAsyncResponseReader< ::grpc_user::Reply>* PrepareAsyncSignerServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc::CompletionQueue* cq) override;
-    const ::grpc::internal::RpcMethod rpcmethod_ReqSsigService_;
+    const ::grpc::internal::RpcMethod rpcmethod_PushService_;
     const ::grpc::internal::RpcMethod rpcmethod_KeyExService_;
     const ::grpc::internal::RpcMethod rpcmethod_UserService_;
     const ::grpc::internal::RpcMethod rpcmethod_SignerService_;
@@ -131,28 +131,28 @@ class TethysUserService final {
    public:
     Service();
     virtual ~Service();
-    virtual ::grpc::Status ReqSsigService(::grpc::ServerContext* context, const ::grpc_user::Identity* request, ::grpc::ServerWriter< ::grpc_user::Message>* writer);
+    virtual ::grpc::Status PushService(::grpc::ServerContext* context, const ::grpc_user::Identity* request, ::grpc::ServerWriter< ::grpc_user::Message>* writer);
     virtual ::grpc::Status KeyExService(::grpc::ServerContext* context, const ::grpc_user::Request* request, ::grpc_user::Reply* response);
     virtual ::grpc::Status UserService(::grpc::ServerContext* context, const ::grpc_user::Request* request, ::grpc_user::Reply* response);
     virtual ::grpc::Status SignerService(::grpc::ServerContext* context, const ::grpc_user::Request* request, ::grpc_user::Reply* response);
   };
   template <class BaseClass>
-  class WithAsyncMethod_ReqSsigService : public BaseClass {
+  class WithAsyncMethod_PushService : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
-    WithAsyncMethod_ReqSsigService() {
+    WithAsyncMethod_PushService() {
       ::grpc::Service::MarkMethodAsync(0);
     }
-    ~WithAsyncMethod_ReqSsigService() override {
+    ~WithAsyncMethod_PushService() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status ReqSsigService(::grpc::ServerContext* context, const ::grpc_user::Identity* request, ::grpc::ServerWriter< ::grpc_user::Message>* writer) override {
+    ::grpc::Status PushService(::grpc::ServerContext* context, const ::grpc_user::Identity* request, ::grpc::ServerWriter< ::grpc_user::Message>* writer) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    void RequestReqSsigService(::grpc::ServerContext* context, ::grpc_user::Identity* request, ::grpc::ServerAsyncWriter< ::grpc_user::Message>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+    void RequestPushService(::grpc::ServerContext* context, ::grpc_user::Identity* request, ::grpc::ServerAsyncWriter< ::grpc_user::Message>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
       ::grpc::Service::RequestAsyncServerStreaming(0, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
@@ -216,20 +216,20 @@ class TethysUserService final {
       ::grpc::Service::RequestAsyncUnary(3, context, request, response, new_call_cq, notification_cq, tag);
     }
   };
-  typedef WithAsyncMethod_ReqSsigService<WithAsyncMethod_KeyExService<WithAsyncMethod_UserService<WithAsyncMethod_SignerService<Service > > > > AsyncService;
+  typedef WithAsyncMethod_PushService<WithAsyncMethod_KeyExService<WithAsyncMethod_UserService<WithAsyncMethod_SignerService<Service > > > > AsyncService;
   template <class BaseClass>
-  class WithGenericMethod_ReqSsigService : public BaseClass {
+  class WithGenericMethod_PushService : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
-    WithGenericMethod_ReqSsigService() {
+    WithGenericMethod_PushService() {
       ::grpc::Service::MarkMethodGeneric(0);
     }
-    ~WithGenericMethod_ReqSsigService() override {
+    ~WithGenericMethod_PushService() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status ReqSsigService(::grpc::ServerContext* context, const ::grpc_user::Identity* request, ::grpc::ServerWriter< ::grpc_user::Message>* writer) override {
+    ::grpc::Status PushService(::grpc::ServerContext* context, const ::grpc_user::Identity* request, ::grpc::ServerWriter< ::grpc_user::Message>* writer) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
@@ -286,22 +286,22 @@ class TethysUserService final {
     }
   };
   template <class BaseClass>
-  class WithRawMethod_ReqSsigService : public BaseClass {
+  class WithRawMethod_PushService : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
-    WithRawMethod_ReqSsigService() {
+    WithRawMethod_PushService() {
       ::grpc::Service::MarkMethodRaw(0);
     }
-    ~WithRawMethod_ReqSsigService() override {
+    ~WithRawMethod_PushService() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable synchronous version of this method
-    ::grpc::Status ReqSsigService(::grpc::ServerContext* context, const ::grpc_user::Identity* request, ::grpc::ServerWriter< ::grpc_user::Message>* writer) override {
+    ::grpc::Status PushService(::grpc::ServerContext* context, const ::grpc_user::Identity* request, ::grpc::ServerWriter< ::grpc_user::Message>* writer) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
-    void RequestReqSsigService(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncWriter< ::grpc::ByteBuffer>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
+    void RequestPushService(::grpc::ServerContext* context, ::grpc::ByteBuffer* request, ::grpc::ServerAsyncWriter< ::grpc::ByteBuffer>* writer, ::grpc::CompletionQueue* new_call_cq, ::grpc::ServerCompletionQueue* notification_cq, void *tag) {
       ::grpc::Service::RequestAsyncServerStreaming(0, context, request, writer, new_call_cq, notification_cq, tag);
     }
   };
@@ -427,27 +427,27 @@ class TethysUserService final {
   };
   typedef WithStreamedUnaryMethod_KeyExService<WithStreamedUnaryMethod_UserService<WithStreamedUnaryMethod_SignerService<Service > > > StreamedUnaryService;
   template <class BaseClass>
-  class WithSplitStreamingMethod_ReqSsigService : public BaseClass {
+  class WithSplitStreamingMethod_PushService : public BaseClass {
    private:
     void BaseClassMustBeDerivedFromService(const Service *service) {}
    public:
-    WithSplitStreamingMethod_ReqSsigService() {
+    WithSplitStreamingMethod_PushService() {
       ::grpc::Service::MarkMethodStreamed(0,
-        new ::grpc::internal::SplitServerStreamingHandler< ::grpc_user::Identity, ::grpc_user::Message>(std::bind(&WithSplitStreamingMethod_ReqSsigService<BaseClass>::StreamedReqSsigService, this, std::placeholders::_1, std::placeholders::_2)));
+        new ::grpc::internal::SplitServerStreamingHandler< ::grpc_user::Identity, ::grpc_user::Message>(std::bind(&WithSplitStreamingMethod_PushService<BaseClass>::StreamedPushService, this, std::placeholders::_1, std::placeholders::_2)));
     }
-    ~WithSplitStreamingMethod_ReqSsigService() override {
+    ~WithSplitStreamingMethod_PushService() override {
       BaseClassMustBeDerivedFromService(this);
     }
     // disable regular version of this method
-    ::grpc::Status ReqSsigService(::grpc::ServerContext* context, const ::grpc_user::Identity* request, ::grpc::ServerWriter< ::grpc_user::Message>* writer) override {
+    ::grpc::Status PushService(::grpc::ServerContext* context, const ::grpc_user::Identity* request, ::grpc::ServerWriter< ::grpc_user::Message>* writer) override {
       abort();
       return ::grpc::Status(::grpc::StatusCode::UNIMPLEMENTED, "");
     }
     // replace default version of method with split streamed
-    virtual ::grpc::Status StreamedReqSsigService(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::grpc_user::Identity,::grpc_user::Message>* server_split_streamer) = 0;
+    virtual ::grpc::Status StreamedPushService(::grpc::ServerContext* context, ::grpc::ServerSplitStreamer< ::grpc_user::Identity,::grpc_user::Message>* server_split_streamer) = 0;
   };
-  typedef WithSplitStreamingMethod_ReqSsigService<Service > SplitStreamedService;
-  typedef WithSplitStreamingMethod_ReqSsigService<WithStreamedUnaryMethod_KeyExService<WithStreamedUnaryMethod_UserService<WithStreamedUnaryMethod_SignerService<Service > > > > StreamedService;
+  typedef WithSplitStreamingMethod_PushService<Service > SplitStreamedService;
+  typedef WithSplitStreamingMethod_PushService<WithStreamedUnaryMethod_KeyExService<WithStreamedUnaryMethod_UserService<WithStreamedUnaryMethod_SignerService<Service > > > > StreamedService;
 };
 
 }  // namespace grpc_user

--- a/src/plugins/net_plugin/rpc_services/protos/include/user_service.pb.h
+++ b/src/plugins/net_plugin/rpc_services/protos/include/user_service.pb.h
@@ -574,6 +574,20 @@ class Reply : public ::google::protobuf::Message /* @@protoc_insertion_point(cla
   ::std::string* release_message();
   void set_allocated_message(::std::string* message);
 
+  // string err_info = 3;
+  void clear_err_info();
+  static const int kErrInfoFieldNumber = 3;
+  const ::std::string& err_info() const;
+  void set_err_info(const ::std::string& value);
+  #if LANG_CXX11
+  void set_err_info(::std::string&& value);
+  #endif
+  void set_err_info(const char* value);
+  void set_err_info(const char* value, size_t size);
+  ::std::string* mutable_err_info();
+  ::std::string* release_err_info();
+  void set_allocated_err_info(::std::string* err_info);
+
   // .grpc_user.Reply.Status status = 1;
   void clear_status();
   static const int kStatusFieldNumber = 1;
@@ -585,6 +599,7 @@ class Reply : public ::google::protobuf::Message /* @@protoc_insertion_point(cla
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
   ::google::protobuf::internal::ArenaStringPtr message_;
+  ::google::protobuf::internal::ArenaStringPtr err_info_;
   int status_;
   mutable ::google::protobuf::internal::CachedSize _cached_size_;
   friend struct ::protobuf_user_5fservice_2eproto::TableStruct;
@@ -836,6 +851,59 @@ inline void Reply::set_allocated_message(::std::string* message) {
   }
   message_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), message);
   // @@protoc_insertion_point(field_set_allocated:grpc_user.Reply.message)
+}
+
+// string err_info = 3;
+inline void Reply::clear_err_info() {
+  err_info_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& Reply::err_info() const {
+  // @@protoc_insertion_point(field_get:grpc_user.Reply.err_info)
+  return err_info_.GetNoArena();
+}
+inline void Reply::set_err_info(const ::std::string& value) {
+  
+  err_info_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:grpc_user.Reply.err_info)
+}
+#if LANG_CXX11
+inline void Reply::set_err_info(::std::string&& value) {
+  
+  err_info_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:grpc_user.Reply.err_info)
+}
+#endif
+inline void Reply::set_err_info(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  err_info_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:grpc_user.Reply.err_info)
+}
+inline void Reply::set_err_info(const char* value, size_t size) {
+  
+  err_info_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:grpc_user.Reply.err_info)
+}
+inline ::std::string* Reply::mutable_err_info() {
+  
+  // @@protoc_insertion_point(field_mutable:grpc_user.Reply.err_info)
+  return err_info_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* Reply::release_err_info() {
+  // @@protoc_insertion_point(field_release:grpc_user.Reply.err_info)
+  
+  return err_info_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void Reply::set_allocated_err_info(::std::string* err_info) {
+  if (err_info != NULL) {
+    
+  } else {
+    
+  }
+  err_info_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), err_info);
+  // @@protoc_insertion_point(field_set_allocated:grpc_user.Reply.err_info)
 }
 
 #ifdef __GNUC__

--- a/src/plugins/net_plugin/rpc_services/protos/user_service.grpc.pb.cc
+++ b/src/plugins/net_plugin/rpc_services/protos/user_service.grpc.pb.cc
@@ -2,8 +2,8 @@
 // If you make any local change, they will be lost.
 // source: user_service.proto
 
-#include "include/user_service.grpc.pb.h"
 #include "include/user_service.pb.h"
+#include "include/user_service.grpc.pb.h"
 
 #include <grpcpp/impl/codegen/async_stream.h>
 #include <grpcpp/impl/codegen/async_unary_call.h>
@@ -16,7 +16,7 @@
 namespace grpc_user {
 
 static const char* TethysUserService_method_names[] = {
-  "/grpc_user.TethysUserService/ReqSsigService",
+  "/grpc_user.TethysUserService/PushService",
   "/grpc_user.TethysUserService/KeyExService",
   "/grpc_user.TethysUserService/UserService",
   "/grpc_user.TethysUserService/SignerService",
@@ -29,22 +29,22 @@ std::unique_ptr< TethysUserService::Stub> TethysUserService::NewStub(const std::
 }
 
 TethysUserService::Stub::Stub(const std::shared_ptr< ::grpc::ChannelInterface>& channel)
-  : channel_(channel), rpcmethod_ReqSsigService_(TethysUserService_method_names[0], ::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
+  : channel_(channel), rpcmethod_PushService_(TethysUserService_method_names[0], ::grpc::internal::RpcMethod::SERVER_STREAMING, channel)
   , rpcmethod_KeyExService_(TethysUserService_method_names[1], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_UserService_(TethysUserService_method_names[2], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   , rpcmethod_SignerService_(TethysUserService_method_names[3], ::grpc::internal::RpcMethod::NORMAL_RPC, channel)
   {}
 
-::grpc::ClientReader< ::grpc_user::Message>* TethysUserService::Stub::ReqSsigServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Identity& request) {
-  return ::grpc::internal::ClientReaderFactory< ::grpc_user::Message>::Create(channel_.get(), rpcmethod_ReqSsigService_, context, request);
+::grpc::ClientReader< ::grpc_user::Message>* TethysUserService::Stub::PushServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Identity& request) {
+  return ::grpc::internal::ClientReaderFactory< ::grpc_user::Message>::Create(channel_.get(), rpcmethod_PushService_, context, request);
 }
 
-::grpc::ClientAsyncReader< ::grpc_user::Message>* TethysUserService::Stub::AsyncReqSsigServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Identity& request, ::grpc::CompletionQueue* cq, void* tag) {
-  return ::grpc::internal::ClientAsyncReaderFactory< ::grpc_user::Message>::Create(channel_.get(), cq, rpcmethod_ReqSsigService_, context, request, true, tag);
+::grpc::ClientAsyncReader< ::grpc_user::Message>* TethysUserService::Stub::AsyncPushServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Identity& request, ::grpc::CompletionQueue* cq, void* tag) {
+  return ::grpc::internal::ClientAsyncReaderFactory< ::grpc_user::Message>::Create(channel_.get(), cq, rpcmethod_PushService_, context, request, true, tag);
 }
 
-::grpc::ClientAsyncReader< ::grpc_user::Message>* TethysUserService::Stub::PrepareAsyncReqSsigServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Identity& request, ::grpc::CompletionQueue* cq) {
-  return ::grpc::internal::ClientAsyncReaderFactory< ::grpc_user::Message>::Create(channel_.get(), cq, rpcmethod_ReqSsigService_, context, request, false, nullptr);
+::grpc::ClientAsyncReader< ::grpc_user::Message>* TethysUserService::Stub::PrepareAsyncPushServiceRaw(::grpc::ClientContext* context, const ::grpc_user::Identity& request, ::grpc::CompletionQueue* cq) {
+  return ::grpc::internal::ClientAsyncReaderFactory< ::grpc_user::Message>::Create(channel_.get(), cq, rpcmethod_PushService_, context, request, false, nullptr);
 }
 
 ::grpc::Status TethysUserService::Stub::KeyExService(::grpc::ClientContext* context, const ::grpc_user::Request& request, ::grpc_user::Reply* response) {
@@ -88,7 +88,7 @@ TethysUserService::Service::Service() {
       TethysUserService_method_names[0],
       ::grpc::internal::RpcMethod::SERVER_STREAMING,
       new ::grpc::internal::ServerStreamingHandler< TethysUserService::Service, ::grpc_user::Identity, ::grpc_user::Message>(
-          std::mem_fn(&TethysUserService::Service::ReqSsigService), this)));
+          std::mem_fn(&TethysUserService::Service::PushService), this)));
   AddMethod(new ::grpc::internal::RpcServiceMethod(
       TethysUserService_method_names[1],
       ::grpc::internal::RpcMethod::NORMAL_RPC,
@@ -109,7 +109,7 @@ TethysUserService::Service::Service() {
 TethysUserService::Service::~Service() {
 }
 
-::grpc::Status TethysUserService::Service::ReqSsigService(::grpc::ServerContext* context, const ::grpc_user::Identity* request, ::grpc::ServerWriter< ::grpc_user::Message>* writer) {
+::grpc::Status TethysUserService::Service::PushService(::grpc::ServerContext* context, const ::grpc_user::Identity* request, ::grpc::ServerWriter< ::grpc_user::Message>* writer) {
   (void) context;
   (void) request;
   (void) writer;

--- a/src/plugins/net_plugin/rpc_services/protos/user_service.pb.cc
+++ b/src/plugins/net_plugin/rpc_services/protos/user_service.pb.cc
@@ -134,6 +134,7 @@ const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUT
   ~0u,  // no _weak_field_map_
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_user::Reply, status_),
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_user::Reply, message_),
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_user::Reply, err_info_),
 };
 static const ::google::protobuf::internal::MigrationSchema schemas[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
   { 0, -1, sizeof(::grpc_user::Identity)},
@@ -172,24 +173,24 @@ void AddDescriptorsImpl() {
   static const char descriptor[] GOOGLE_PROTOBUF_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
       "\n\022user_service.proto\022\tgrpc_user\"\032\n\010Ident"
       "ity\022\016\n\006sender\030\001 \001(\014\"\032\n\007Message\022\017\n\007messag"
-      "e\030\001 \001(\014\"\032\n\007Request\022\017\n\007message\030\001 \001(\014\"\361\001\n\005"
+      "e\030\001 \001(\014\"\032\n\007Request\022\017\n\007message\030\001 \001(\014\"\203\002\n\005"
       "Reply\022\'\n\006status\030\001 \001(\0162\027.grpc_user.Reply."
-      "Status\022\017\n\007message\030\002 \001(\014\"\255\001\n\006Status\022\013\n\007UN"
-      "KNOWN\020\000\022\013\n\007SUCCESS\020\001\022\013\n\007INVALID\020\002\022\014\n\010INT"
-      "ERNAL\020\003\022\027\n\023ECDH_ILLEGAL_ACCESS\020\025\022\030\n\024ECDH"
-      "_MAX_SIGNER_POOL\020\026\022\020\n\014ECDH_TIMEOUT\020\027\022\024\n\020"
-      "ECDH_INVALID_SIG\020\030\022\023\n\017ECDH_INVALID_PK\020\0312"
-      "\372\001\n\021TethysUserService\022=\n\016ReqSsigService\022"
-      "\023.grpc_user.Identity\032\022.grpc_user.Message"
-      "\"\0000\001\0226\n\014KeyExService\022\022.grpc_user.Request"
-      "\032\020.grpc_user.Reply\"\000\0225\n\013UserService\022\022.gr"
-      "pc_user.Request\032\020.grpc_user.Reply\"\000\0227\n\rS"
-      "ignerService\022\022.grpc_user.Request\032\020.grpc_"
-      "user.Reply\"\000B\"\n\026io.tethys.tethyswalletB\006"
-      "TethysP\001b\006proto3"
+      "Status\022\017\n\007message\030\002 \001(\014\022\020\n\010err_info\030\003 \001("
+      "\t\"\255\001\n\006Status\022\013\n\007UNKNOWN\020\000\022\013\n\007SUCCESS\020\001\022\013"
+      "\n\007INVALID\020\002\022\014\n\010INTERNAL\020\003\022\027\n\023ECDH_ILLEGA"
+      "L_ACCESS\020\025\022\030\n\024ECDH_MAX_SIGNER_POOL\020\026\022\020\n\014"
+      "ECDH_TIMEOUT\020\027\022\024\n\020ECDH_INVALID_SIG\020\030\022\023\n\017"
+      "ECDH_INVALID_PK\020\0312\367\001\n\021TethysUserService\022"
+      ":\n\013PushService\022\023.grpc_user.Identity\032\022.gr"
+      "pc_user.Message\"\0000\001\0226\n\014KeyExService\022\022.gr"
+      "pc_user.Request\032\020.grpc_user.Reply\"\000\0225\n\013U"
+      "serService\022\022.grpc_user.Request\032\020.grpc_us"
+      "er.Reply\"\000\0227\n\rSignerService\022\022.grpc_user."
+      "Request\032\020.grpc_user.Reply\"\000B\"\n\026io.tethys"
+      ".tethyswalletB\006TethysP\001b\006proto3"
   };
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
-      descriptor, 656);
+      descriptor, 671);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "user_service.proto", &protobuf_RegisterTypes);
 }
@@ -939,6 +940,7 @@ void Reply::InitAsDefaultInstance() {
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
 const int Reply::kStatusFieldNumber;
 const int Reply::kMessageFieldNumber;
+const int Reply::kErrInfoFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 Reply::Reply()
@@ -956,12 +958,17 @@ Reply::Reply(const Reply& from)
   if (from.message().size() > 0) {
     message_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.message_);
   }
+  err_info_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.err_info().size() > 0) {
+    err_info_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.err_info_);
+  }
   status_ = from.status_;
   // @@protoc_insertion_point(copy_constructor:grpc_user.Reply)
 }
 
 void Reply::SharedCtor() {
   message_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  err_info_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   status_ = 0;
 }
 
@@ -972,6 +979,7 @@ Reply::~Reply() {
 
 void Reply::SharedDtor() {
   message_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  err_info_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 
 void Reply::SetCachedSize(int size) const {
@@ -995,6 +1003,7 @@ void Reply::Clear() {
   (void) cached_has_bits;
 
   message_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  err_info_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   status_ = 0;
   _internal_metadata_.Clear();
 }
@@ -1030,6 +1039,22 @@ bool Reply::MergePartialFromCodedStream(
             static_cast< ::google::protobuf::uint8>(18u /* 18 & 0xFF */)) {
           DO_(::google::protobuf::internal::WireFormatLite::ReadBytes(
                 input, this->mutable_message()));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // string err_info = 3;
+      case 3: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(26u /* 26 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_err_info()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->err_info().data(), static_cast<int>(this->err_info().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "grpc_user.Reply.err_info"));
         } else {
           goto handle_unusual;
         }
@@ -1074,6 +1099,16 @@ void Reply::SerializeWithCachedSizes(
       2, this->message(), output);
   }
 
+  // string err_info = 3;
+  if (this->err_info().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->err_info().data(), static_cast<int>(this->err_info().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "grpc_user.Reply.err_info");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      3, this->err_info(), output);
+  }
+
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
@@ -1101,6 +1136,17 @@ void Reply::SerializeWithCachedSizes(
         2, this->message(), target);
   }
 
+  // string err_info = 3;
+  if (this->err_info().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->err_info().data(), static_cast<int>(this->err_info().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "grpc_user.Reply.err_info");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        3, this->err_info(), target);
+  }
+
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), target);
@@ -1123,6 +1169,13 @@ size_t Reply::ByteSizeLong() const {
     total_size += 1 +
       ::google::protobuf::internal::WireFormatLite::BytesSize(
         this->message());
+  }
+
+  // string err_info = 3;
+  if (this->err_info().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->err_info());
   }
 
   // .grpc_user.Reply.Status status = 1;
@@ -1162,6 +1215,10 @@ void Reply::MergeFrom(const Reply& from) {
 
     message_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.message_);
   }
+  if (from.err_info().size() > 0) {
+
+    err_info_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.err_info_);
+  }
   if (from.status() != 0) {
     set_status(from.status());
   }
@@ -1192,6 +1249,8 @@ void Reply::Swap(Reply* other) {
 void Reply::InternalSwap(Reply* other) {
   using std::swap;
   message_.Swap(&other->message_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
+  err_info_.Swap(&other->err_info_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
     GetArenaNoVirtual());
   swap(status_, other->status_);
   _internal_metadata_.Swap(&other->_internal_metadata_);

--- a/src/plugins/net_plugin/rpc_services/protos/user_service.proto
+++ b/src/plugins/net_plugin/rpc_services/protos/user_service.proto
@@ -7,7 +7,7 @@ option java_outer_classname = "Tethys";
 package grpc_user;
 
 service TethysUserService {
-    rpc ReqSsigService (Identity) returns (stream Message) {}
+    rpc PushService (Identity) returns (stream Message) {}
     rpc KeyExService (Request) returns (Reply) {}
     rpc UserService (Request) returns (Reply) {}
     rpc SignerService (Request) returns (Reply) {}
@@ -38,4 +38,5 @@ message Reply {
     }
     Status status = 1;
     bytes message = 2;
+    string err_info = 3;
 }


### PR DESCRIPTION
 ### 수정 이유
 - 종전의 코드에서는 grpc::Status에 실패 이유를 담아서 답을 했다.
 답을 받는 쪽에서 이를 핸들링하는데 있어서 혼란이 있을 수 있다.
( grpc::Status 와 `Reply` 내부의 Status가 있음)

 - 따라서 grpc::Status는 해당 rpc를 정상적으로 받았음을 알리는 용도로
Status::OK를 보내도록 하고,
 메시지의 처리 상태를 `Reply` 내부의 status 값을 이용하여 보내도록 함. 이상이
있을 경우 err_info 에 내용을 추가하여 보내도록 함.

 ### 수정사항
- user_service protobuf 수정
  - Reply에 string `err_info` 추가 Status::SUCCESS 가 아닐경우 err_info에
요청이 실패한 이유에 대해 보내도록 함.
  - ReqSsigService -> PushService 해당 메시지(MSG_REQ_SSIG)만을 보내는것이 아닌 User
혹은 Signer에게 message를 push하는 개념이 되므로 rpc 명 수정

- MessageParser::parseMessage()에서 받는 타입 수정, 해당 함수 수정으로 인한 관련된 사항 수정 ( grpc::Status
return_rpc_status -> string return_err_info)

- 불필요한 코드 제거 및 간결화

- clang format 적용 (admin_plugin/rpc_services/rpc_services.cpp  )