### PR TITLE
# REFACTOR - admin_plugin/rpc_services#1

### DIFF
--- a/src/plugins/admin_plugin/admin_plugin.cpp
+++ b/src/plugins/admin_plugin/admin_plugin.cpp
@@ -38,10 +38,10 @@ public:
   }
 
   void registerService() {
-    new AdminService<ReqSetupKey, ResSetupKey>(&admin_service, completion_queue.get(), setup_port);
-    new AdminService<ReqLogin, ResLogin>(&admin_service, completion_queue.get());
-    new AdminService<ReqStart, ResStart>(&admin_service, completion_queue.get());
-    new AdminService<ReqStatus, ResStatus>(&admin_service, completion_queue.get());
+    new SetupKeyService(&admin_service, completion_queue.get(), setup_port);
+    new LoginService(&admin_service, completion_queue.get());
+    new StartService(&admin_service, completion_queue.get());
+    new StatusService(&admin_service, completion_queue.get());
   }
 
   void start() {}
@@ -70,7 +70,7 @@ public:
 
         auto queue_state = completion_queue->AsyncNext(&tag, &ok, deadline);
         if (ok && queue_state == CompletionQueue::NextStatus::GOT_EVENT) {
-          static_cast<CallService *>(tag)->proceed();
+          static_cast <CallService *>(tag)->proceed();
         }
       } else {
         logger::ERROR("Error from admin_req_check_timer: {}", ec.message());

--- a/src/plugins/admin_plugin/include/command_delegator.hpp
+++ b/src/plugins/admin_plugin/include/command_delegator.hpp
@@ -1,0 +1,85 @@
+#pragma once
+
+namespace gruut {
+namespace admin_plugin {
+
+template <typename T>
+class CommandDelegator {
+public:
+  CommandDelegator() = default;
+
+  void delegate() {
+    setControlType();
+    nlohmann::json control_command = createControlCommand();
+
+    sendCommand(control_command);
+  }
+
+  const int getControlType() const {
+    return control_type;
+  }
+
+private:
+  virtual nlohmann::json createControlCommand() = 0;
+  virtual void sendCommand(nlohmann::json control_command) = 0;
+  virtual void setControlType() = 0;
+
+protected:
+  int control_type;
+};
+
+class LoginCommandDelegator : public CommandDelegator<ReqLogin> {
+public:
+  LoginCommandDelegator(string_view _env_sk_pem, string_view _cert, string_view _pass)
+      : secret_key(_env_sk_pem), cert(_cert), pass(_pass) {}
+
+private:
+  nlohmann::json createControlCommand() override {
+    nlohmann::json control_command;
+
+    control_command["type"] = getControlType();
+    control_command["enc_sk"] = secret_key;
+    control_command["cert"] = cert;
+    control_command["pass"] = pass;
+
+    return control_command;
+  }
+
+  void sendCommand(nlohmann::json control_command) override {
+    app().getChannel<incoming::channels::net_control>().publish(control_command);
+  }
+
+  void setControlType() override {
+    control_type = static_cast<int>(ControlType::LOGIN);
+  }
+
+  string secret_key, cert, pass;
+};
+
+class StartCommandDelegator : public CommandDelegator<ReqStart> {
+public:
+  StartCommandDelegator(RunningMode _net_mode) : net_mode(_net_mode) {}
+
+private:
+  nlohmann::json createControlCommand() override {
+    nlohmann::json control_command;
+
+    control_command["type"] = getControlType();
+    control_command["mode"] = net_mode;
+
+    return control_command;
+  }
+
+  void sendCommand(nlohmann::json control_command) override {
+    app().getChannel<incoming::channels::net_control>().publish(control_command);
+  }
+
+  void setControlType() override {
+    control_type = static_cast<int>(ControlType::START);
+  }
+
+  RunningMode net_mode;
+};
+
+} // namespace admin_plugin
+}


### PR DESCRIPTION
## 수정사항
- CallService 에 순수 가상함수만 남겨두고, 멤버 변수들은 AdminService로 이동.
- 중복으로 존재할 필요가 없는 코드들을 AdminServices로 옮겨서 응집도를 높임.
- rpc_services.cpp 에서 중복되는 코드들, 예를 들면
```
receive_status = AdminRpcCallStatus::FINISH;
responder.Finish(res, Status::OK, this);
```
를 sendFinishedMsg 함수로 만들어서 추상화시킴

- command_delegator 를 하나의 파일로 분리


## TODO
- `proceed` 에서 `new XXService`를 새롭게 생성하고, `if(call_status == AdminRpcCallStatus::FINISH)` 조건 검사를 하는 코드부분이 중복으로 존재해서 다음 PR에서 제거예정