### PR TITLE
# FEATURE - START 이후 로그인하지 못하도록 구현

### DIFF
--- a/src/plugins/admin_plugin/CMakeLists.txt
+++ b/src/plugins/admin_plugin/CMakeLists.txt
@@ -8,6 +8,7 @@ file(GLOB HEADERS
         "include/*.hpp"
         "rpc_services/proto/include/*.h"
         "rpc_services/include/*.hpp"
+        "middlewares/include/*.hpp"
         )
 
 file(GLOB SOURCES

--- a/src/plugins/admin_plugin/middlewares/include/admin_middleware.hpp
+++ b/src/plugins/admin_plugin/middlewares/include/admin_middleware.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+namespace gruut::admin_plugin {
+using namespace std;
+
+using error_message = string;
+
+template <class Service>
+class AdminMiddleware {
+public:
+  pair<bool, error_message> next() {
+    // do nothing
+    return make_pair(true, "");
+  };
+};
+
+template <>
+class AdminMiddleware<LoginService> {
+public:
+  pair<bool, error_message> next() {
+    if (app().isAppRunning())
+      return make_pair(false, "Please sign in after stopping the node");
+
+    return make_pair(true, "");
+  }
+};
+} // namespace gruut::admin_plugin


### PR DESCRIPTION
## 구현사항
- START로 노드를 시작한 후에, LOGIN 명령이 실행되면 안된다. [참조](https://thevaulters.atlassian.net/wiki/spaces/SGN/pages/103350293/TP10.+Administrative+Client+Admin+Console)
- BEFORE_PROCEED 가 실행되기 전에 미들웨어(Request가 처리되기 전에 실행되는 서비스 Layer)에서 request를 선처리하도록 구현 (`AdminMiddleware`)