### PR TITLE
# FEATURE - AdminService LoadWorld command

### DIFF
--- a/lib/appbase/application.cpp
+++ b/lib/appbase/application.cpp
@@ -166,8 +166,16 @@ AbstractPlugin* Application::getPlugin(const string &name) const {
   }
 }
 
+void Application::setWorldId(string_view _id){
+  world_id = _id;
+}
+
 void Application::setId(string_view _id){
   id = _id;
+}
+
+const string &Application::getWorldId() const {
+  return world_id;
 }
 
 const string &Application::getId() const {
@@ -184,6 +192,14 @@ bool Application::isAppRunning() {
 
 bool Application::isUserSignedIn() {
   return application_status.user_login;
+}
+
+bool Application::isWorldLoaded() {
+  return application_status.load_world;
+}
+
+void Application::completeLoadWorld() {
+  application_status.load_world = true;
 }
 
 void Application::completeUserSetup() {

--- a/lib/appbase/include/application.hpp
+++ b/lib/appbase/include/application.hpp
@@ -25,12 +25,13 @@ class ProgramOptions;
 enum class RunningMode : int { NONE = -1, DEFAULT = 0, MONITOR = 1 };
 
 struct ApplicationStatus {
-    bool user_setup;
-    bool user_login;
+  bool load_world;
+  bool user_setup;
+  bool user_login;
 
-    RunningMode run_mode;
+  RunningMode run_mode;
 
-    ApplicationStatus() : user_setup(false), user_login(false), run_mode(RunningMode::NONE) {}
+  ApplicationStatus() : load_world(false), user_setup(false), user_login(false), run_mode(RunningMode::NONE) {}
 };
 
 class Application {
@@ -88,13 +89,19 @@ public:
     }
   }
 
+  void setWorldId(string_view _id);
   void setId(string_view _id);
-  void setRunFlag();
+
+  const string &getWorldId() const;
   const string &getId() const;
+
+  void setRunFlag();
 
   bool isAppRunning();
   bool isUserSignedIn();
+  bool isWorldLoaded();
 
+  void completeLoadWorld();
   void completeUserSetup();
   void completeUserSignedIn();
 
@@ -104,7 +111,7 @@ public:
     return *io_context_ptr;
   }
 
-  AbstractPlugin* getPlugin(const string &name) const;
+  AbstractPlugin *getPlugin(const string &name) const;
 
   static Application &instance();
 
@@ -140,6 +147,7 @@ private:
 
   unique_ptr<ProgramOptions> program_options;
 
+  string world_id;
   string id;
 
   bool running = false;
@@ -154,7 +162,6 @@ private:
   void registerErrorSignalHandlers();
 
   ApplicationStatus application_status;
-
 };
 
 Application &app();

--- a/src/plugins/admin_plugin/middlewares/include/admin_middleware.hpp
+++ b/src/plugins/admin_plugin/middlewares/include/admin_middleware.hpp
@@ -24,4 +24,15 @@ public:
     return make_pair(true, "");
   }
 };
+
+template <>
+class AdminMiddleware<LoadWorldService> {
+public:
+  pair<bool, error_message> next() {
+    if (app().isAppRunning())
+      return make_pair(false, "If you want to join the world, stop node and then load different world");
+
+    return make_pair(true, "");
+  }
+};
 } // namespace gruut::admin_plugin

--- a/src/plugins/admin_plugin/rpc_services/include/rpc_services.hpp
+++ b/src/plugins/admin_plugin/rpc_services/include/rpc_services.hpp
@@ -118,5 +118,15 @@ public:
   void proceed() override;
 };
 
+class LoadWorldService final : public AdminService<ReqLoadWorld, ResLoadWorld> {
+  using super = AdminService<ReqLoadWorld, ResLoadWorld>;
+
+public:
+  LoadWorldService(GruutAdminService::AsyncService *admin_service, ServerCompletionQueue *cq) : super(admin_service, cq) {
+    service->RequestLoadWorld(&context, &req, &responder, completion_queue, completion_queue, this);
+  }
+  void proceed() override;
+};
+
 } // namespace admin_plugin
 } // namespace gruut

--- a/src/plugins/admin_plugin/rpc_services/proto/admin_service.grpc.pb.cc
+++ b/src/plugins/admin_plugin/rpc_services/proto/admin_service.grpc.pb.cc
@@ -2,8 +2,8 @@
 // If you make any local change, they will be lost.
 // source: admin_service.proto
 
-#include "include/admin_service.grpc.pb.h"
 #include "include/admin_service.pb.h"
+#include "include/admin_service.grpc.pb.h"
 
 #include <grpcpp/impl/codegen/async_stream.h>
 #include <grpcpp/impl/codegen/async_unary_call.h>

--- a/src/plugins/admin_plugin/rpc_services/proto/admin_service.pb.cc
+++ b/src/plugins/admin_plugin/rpc_services/proto/admin_service.pb.cc
@@ -324,6 +324,7 @@ const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUT
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_admin::ReqLoadWorld, path_),
   ~0u,  // no _has_bits_
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_admin::ResLoadWorld, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -336,6 +337,7 @@ const ::google::protobuf::uint32 TableStruct::offsets[] GOOGLE_PROTOBUF_ATTRIBUT
   ~0u,  // no _extensions_
   ~0u,  // no _oneof_case_
   ~0u,  // no _weak_field_map_
+  GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_admin::ReqLoadChain, path_),
   ~0u,  // no _has_bits_
   GOOGLE_PROTOBUF_GENERATED_MESSAGE_FIELD_OFFSET(::grpc_admin::ResLoadChain, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -354,9 +356,9 @@ static const ::google::protobuf::internal::MigrationSchema schemas[] GOOGLE_PROT
   { 39, -1, sizeof(::grpc_admin::ReqStatus)},
   { 44, -1, sizeof(::grpc_admin::ResStatus)},
   { 50, -1, sizeof(::grpc_admin::ReqLoadWorld)},
-  { 55, -1, sizeof(::grpc_admin::ResLoadWorld)},
-  { 62, -1, sizeof(::grpc_admin::ReqLoadChain)},
-  { 67, -1, sizeof(::grpc_admin::ResLoadChain)},
+  { 56, -1, sizeof(::grpc_admin::ResLoadWorld)},
+  { 63, -1, sizeof(::grpc_admin::ReqLoadChain)},
+  { 69, -1, sizeof(::grpc_admin::ResLoadChain)},
 };
 
 static ::google::protobuf::Message const * const file_default_instances[] = {
@@ -403,24 +405,24 @@ void AddDescriptorsImpl() {
       "\'\n\004mode\030\001 \001(\0162\031.grpc_admin.ReqStart.Mode"
       "\" \n\004Mode\022\013\n\007DEFAULT\020\000\022\013\n\007MONITOR\020\001\")\n\010Re"
       "sStart\022\017\n\007success\030\001 \001(\010\022\014\n\004info\030\002 \001(\t\"\013\n"
-      "\tReqStatus\"\032\n\tResStatus\022\r\n\005alive\030\001 \001(\010\"\016"
-      "\n\014ReqLoadWorld\"-\n\014ResLoadWorld\022\017\n\007succes"
-      "s\030\001 \001(\010\022\014\n\004info\030\002 \001(\t\"\016\n\014ReqLoadChain\"-\n"
-      "\014ResLoadChain\022\017\n\007success\030\001 \001(\010\022\014\n\004info\030\002"
-      " \001(\t2\206\003\n\021GruutAdminService\022>\n\010SetupKey\022\027"
-      ".grpc_admin.ReqSetupKey\032\027.grpc_admin.Res"
-      "SetupKey\"\000\0225\n\005Login\022\024.grpc_admin.ReqLogi"
-      "n\032\024.grpc_admin.ResLogin\"\000\0225\n\005Start\022\024.grp"
-      "c_admin.ReqStart\032\024.grpc_admin.ResStart\"\000"
-      "\022A\n\tLoadWorld\022\030.grpc_admin.ReqLoadWorld\032"
-      "\030.grpc_admin.ResLoadWorld\"\000\022A\n\tLoadChain"
-      "\022\030.grpc_admin.ReqLoadChain\032\030.grpc_admin."
-      "ResLoadChain\"\000\022=\n\013CheckStatus\022\025.grpc_adm"
-      "in.ReqStatus\032\025.grpc_admin.ResStatus\"\000b\006p"
-      "roto3"
+      "\tReqStatus\"\032\n\tResStatus\022\r\n\005alive\030\001 \001(\010\"\034"
+      "\n\014ReqLoadWorld\022\014\n\004path\030\001 \001(\t\"-\n\014ResLoadW"
+      "orld\022\017\n\007success\030\001 \001(\010\022\014\n\004info\030\002 \001(\t\"\034\n\014R"
+      "eqLoadChain\022\014\n\004path\030\001 \001(\t\"-\n\014ResLoadChai"
+      "n\022\017\n\007success\030\001 \001(\010\022\014\n\004info\030\002 \001(\t2\206\003\n\021Gru"
+      "utAdminService\022>\n\010SetupKey\022\027.grpc_admin."
+      "ReqSetupKey\032\027.grpc_admin.ResSetupKey\"\000\0225"
+      "\n\005Login\022\024.grpc_admin.ReqLogin\032\024.grpc_adm"
+      "in.ResLogin\"\000\0225\n\005Start\022\024.grpc_admin.ReqS"
+      "tart\032\024.grpc_admin.ResStart\"\000\022A\n\tLoadWorl"
+      "d\022\030.grpc_admin.ReqLoadWorld\032\030.grpc_admin"
+      ".ResLoadWorld\"\000\022A\n\tLoadChain\022\030.grpc_admi"
+      "n.ReqLoadChain\032\030.grpc_admin.ResLoadChain"
+      "\"\000\022=\n\013CheckStatus\022\025.grpc_admin.ReqStatus"
+      "\032\025.grpc_admin.ResStatus\"\000b\006proto3"
   };
   ::google::protobuf::DescriptorPool::InternalAddGeneratedFile(
-      descriptor, 885);
+      descriptor, 913);
   ::google::protobuf::MessageFactory::InternalRegisterGeneratedFile(
     "admin_service.proto", &protobuf_RegisterTypes);
 }
@@ -2410,6 +2412,7 @@ void ResStatus::InternalSwap(ResStatus* other) {
 void ReqLoadWorld::InitAsDefaultInstance() {
 }
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int ReqLoadWorld::kPathFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 ReqLoadWorld::ReqLoadWorld()
@@ -2423,10 +2426,15 @@ ReqLoadWorld::ReqLoadWorld(const ReqLoadWorld& from)
   : ::google::protobuf::Message(),
       _internal_metadata_(NULL) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  path_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.path().size() > 0) {
+    path_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.path_);
+  }
   // @@protoc_insertion_point(copy_constructor:grpc_admin.ReqLoadWorld)
 }
 
 void ReqLoadWorld::SharedCtor() {
+  path_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 
 ReqLoadWorld::~ReqLoadWorld() {
@@ -2435,6 +2443,7 @@ ReqLoadWorld::~ReqLoadWorld() {
 }
 
 void ReqLoadWorld::SharedDtor() {
+  path_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 
 void ReqLoadWorld::SetCachedSize(int size) const {
@@ -2457,6 +2466,7 @@ void ReqLoadWorld::Clear() {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
+  path_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   _internal_metadata_.Clear();
 }
 
@@ -2469,12 +2479,33 @@ bool ReqLoadWorld::MergePartialFromCodedStream(
     ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
     tag = p.first;
     if (!p.second) goto handle_unusual;
-  handle_unusual:
-    if (tag == 0) {
-      goto success;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // string path = 1;
+      case 1: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_path()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->path().data(), static_cast<int>(this->path().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "grpc_admin.ReqLoadWorld.path"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, _internal_metadata_.mutable_unknown_fields()));
+        break;
+      }
     }
-    DO_(::google::protobuf::internal::WireFormat::SkipField(
-          input, tag, _internal_metadata_.mutable_unknown_fields()));
   }
 success:
   // @@protoc_insertion_point(parse_success:grpc_admin.ReqLoadWorld)
@@ -2491,6 +2522,16 @@ void ReqLoadWorld::SerializeWithCachedSizes(
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
+  // string path = 1;
+  if (this->path().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->path().data(), static_cast<int>(this->path().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "grpc_admin.ReqLoadWorld.path");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      1, this->path(), output);
+  }
+
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
@@ -2504,6 +2545,17 @@ void ReqLoadWorld::SerializeWithCachedSizes(
   // @@protoc_insertion_point(serialize_to_array_start:grpc_admin.ReqLoadWorld)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
+
+  // string path = 1;
+  if (this->path().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->path().data(), static_cast<int>(this->path().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "grpc_admin.ReqLoadWorld.path");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        1, this->path(), target);
+  }
 
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
@@ -2522,6 +2574,13 @@ size_t ReqLoadWorld::ByteSizeLong() const {
       ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
   }
+  // string path = 1;
+  if (this->path().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->path());
+  }
+
   int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
   SetCachedSize(cached_size);
   return total_size;
@@ -2549,6 +2608,10 @@ void ReqLoadWorld::MergeFrom(const ReqLoadWorld& from) {
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
+  if (from.path().size() > 0) {
+
+    path_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.path_);
+  }
 }
 
 void ReqLoadWorld::CopyFrom(const ::google::protobuf::Message& from) {
@@ -2575,6 +2638,8 @@ void ReqLoadWorld::Swap(ReqLoadWorld* other) {
 }
 void ReqLoadWorld::InternalSwap(ReqLoadWorld* other) {
   using std::swap;
+  path_.Swap(&other->path_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
   _internal_metadata_.Swap(&other->_internal_metadata_);
 }
 
@@ -2868,6 +2933,7 @@ void ResLoadWorld::InternalSwap(ResLoadWorld* other) {
 void ReqLoadChain::InitAsDefaultInstance() {
 }
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
+const int ReqLoadChain::kPathFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 ReqLoadChain::ReqLoadChain()
@@ -2881,10 +2947,15 @@ ReqLoadChain::ReqLoadChain(const ReqLoadChain& from)
   : ::google::protobuf::Message(),
       _internal_metadata_(NULL) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
+  path_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+  if (from.path().size() > 0) {
+    path_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.path_);
+  }
   // @@protoc_insertion_point(copy_constructor:grpc_admin.ReqLoadChain)
 }
 
 void ReqLoadChain::SharedCtor() {
+  path_.UnsafeSetDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 
 ReqLoadChain::~ReqLoadChain() {
@@ -2893,6 +2964,7 @@ ReqLoadChain::~ReqLoadChain() {
 }
 
 void ReqLoadChain::SharedDtor() {
+  path_.DestroyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
 }
 
 void ReqLoadChain::SetCachedSize(int size) const {
@@ -2915,6 +2987,7 @@ void ReqLoadChain::Clear() {
   // Prevent compiler warnings about cached_has_bits being unused
   (void) cached_has_bits;
 
+  path_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
   _internal_metadata_.Clear();
 }
 
@@ -2927,12 +3000,33 @@ bool ReqLoadChain::MergePartialFromCodedStream(
     ::std::pair<::google::protobuf::uint32, bool> p = input->ReadTagWithCutoffNoLastTag(127u);
     tag = p.first;
     if (!p.second) goto handle_unusual;
-  handle_unusual:
-    if (tag == 0) {
-      goto success;
+    switch (::google::protobuf::internal::WireFormatLite::GetTagFieldNumber(tag)) {
+      // string path = 1;
+      case 1: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(10u /* 10 & 0xFF */)) {
+          DO_(::google::protobuf::internal::WireFormatLite::ReadString(
+                input, this->mutable_path()));
+          DO_(::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+            this->path().data(), static_cast<int>(this->path().length()),
+            ::google::protobuf::internal::WireFormatLite::PARSE,
+            "grpc_admin.ReqLoadChain.path"));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      default: {
+      handle_unusual:
+        if (tag == 0) {
+          goto success;
+        }
+        DO_(::google::protobuf::internal::WireFormat::SkipField(
+              input, tag, _internal_metadata_.mutable_unknown_fields()));
+        break;
+      }
     }
-    DO_(::google::protobuf::internal::WireFormat::SkipField(
-          input, tag, _internal_metadata_.mutable_unknown_fields()));
   }
 success:
   // @@protoc_insertion_point(parse_success:grpc_admin.ReqLoadChain)
@@ -2949,6 +3043,16 @@ void ReqLoadChain::SerializeWithCachedSizes(
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
+  // string path = 1;
+  if (this->path().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->path().data(), static_cast<int>(this->path().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "grpc_admin.ReqLoadChain.path");
+    ::google::protobuf::internal::WireFormatLite::WriteStringMaybeAliased(
+      1, this->path(), output);
+  }
+
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
     ::google::protobuf::internal::WireFormat::SerializeUnknownFields(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()), output);
@@ -2962,6 +3066,17 @@ void ReqLoadChain::SerializeWithCachedSizes(
   // @@protoc_insertion_point(serialize_to_array_start:grpc_admin.ReqLoadChain)
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
+
+  // string path = 1;
+  if (this->path().size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+      this->path().data(), static_cast<int>(this->path().length()),
+      ::google::protobuf::internal::WireFormatLite::SERIALIZE,
+      "grpc_admin.ReqLoadChain.path");
+    target =
+      ::google::protobuf::internal::WireFormatLite::WriteStringToArray(
+        1, this->path(), target);
+  }
 
   if ((_internal_metadata_.have_unknown_fields() &&  ::google::protobuf::internal::GetProto3PreserveUnknownsDefault())) {
     target = ::google::protobuf::internal::WireFormat::SerializeUnknownFieldsToArray(
@@ -2980,6 +3095,13 @@ size_t ReqLoadChain::ByteSizeLong() const {
       ::google::protobuf::internal::WireFormat::ComputeUnknownFieldsSize(
         (::google::protobuf::internal::GetProto3PreserveUnknownsDefault()   ? _internal_metadata_.unknown_fields()   : _internal_metadata_.default_instance()));
   }
+  // string path = 1;
+  if (this->path().size() > 0) {
+    total_size += 1 +
+      ::google::protobuf::internal::WireFormatLite::StringSize(
+        this->path());
+  }
+
   int cached_size = ::google::protobuf::internal::ToCachedSize(total_size);
   SetCachedSize(cached_size);
   return total_size;
@@ -3007,6 +3129,10 @@ void ReqLoadChain::MergeFrom(const ReqLoadChain& from) {
   ::google::protobuf::uint32 cached_has_bits = 0;
   (void) cached_has_bits;
 
+  if (from.path().size() > 0) {
+
+    path_.AssignWithDefault(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), from.path_);
+  }
 }
 
 void ReqLoadChain::CopyFrom(const ::google::protobuf::Message& from) {
@@ -3033,6 +3159,8 @@ void ReqLoadChain::Swap(ReqLoadChain* other) {
 }
 void ReqLoadChain::InternalSwap(ReqLoadChain* other) {
   using std::swap;
+  path_.Swap(&other->path_, &::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+    GetArenaNoVirtual());
   _internal_metadata_.Swap(&other->_internal_metadata_);
 }
 

--- a/src/plugins/admin_plugin/rpc_services/proto/admin_service.proto
+++ b/src/plugins/admin_plugin/rpc_services/proto/admin_service.proto
@@ -51,7 +51,7 @@ message ResStatus {
 }
 
 message ReqLoadWorld {
-
+    string path = 1;
 }
 
 message ResLoadWorld {
@@ -60,7 +60,7 @@ message ResLoadWorld {
 }
 
 message ReqLoadChain {
-
+    string path = 1;
 }
 
 message ResLoadChain {

--- a/src/plugins/admin_plugin/rpc_services/proto/include/admin_service.pb.h
+++ b/src/plugins/admin_plugin/rpc_services/proto/include/admin_service.pb.h
@@ -1116,10 +1116,25 @@ class ReqLoadWorld : public ::google::protobuf::Message /* @@protoc_insertion_po
 
   // accessors -------------------------------------------------------
 
+  // string path = 1;
+  void clear_path();
+  static const int kPathFieldNumber = 1;
+  const ::std::string& path() const;
+  void set_path(const ::std::string& value);
+  #if LANG_CXX11
+  void set_path(::std::string&& value);
+  #endif
+  void set_path(const char* value);
+  void set_path(const char* value, size_t size);
+  ::std::string* mutable_path();
+  ::std::string* release_path();
+  void set_allocated_path(::std::string* path);
+
   // @@protoc_insertion_point(class_scope:grpc_admin.ReqLoadWorld)
  private:
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::internal::ArenaStringPtr path_;
   mutable ::google::protobuf::internal::CachedSize _cached_size_;
   friend struct ::protobuf_admin_5fservice_2eproto::TableStruct;
 };
@@ -1330,10 +1345,25 @@ class ReqLoadChain : public ::google::protobuf::Message /* @@protoc_insertion_po
 
   // accessors -------------------------------------------------------
 
+  // string path = 1;
+  void clear_path();
+  static const int kPathFieldNumber = 1;
+  const ::std::string& path() const;
+  void set_path(const ::std::string& value);
+  #if LANG_CXX11
+  void set_path(::std::string&& value);
+  #endif
+  void set_path(const char* value);
+  void set_path(const char* value, size_t size);
+  ::std::string* mutable_path();
+  ::std::string* release_path();
+  void set_allocated_path(::std::string* path);
+
   // @@protoc_insertion_point(class_scope:grpc_admin.ReqLoadChain)
  private:
 
   ::google::protobuf::internal::InternalMetadataWithArena _internal_metadata_;
+  ::google::protobuf::internal::ArenaStringPtr path_;
   mutable ::google::protobuf::internal::CachedSize _cached_size_;
   friend struct ::protobuf_admin_5fservice_2eproto::TableStruct;
 };
@@ -1833,6 +1863,59 @@ inline void ResStatus::set_alive(bool value) {
 
 // ReqLoadWorld
 
+// string path = 1;
+inline void ReqLoadWorld::clear_path() {
+  path_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& ReqLoadWorld::path() const {
+  // @@protoc_insertion_point(field_get:grpc_admin.ReqLoadWorld.path)
+  return path_.GetNoArena();
+}
+inline void ReqLoadWorld::set_path(const ::std::string& value) {
+  
+  path_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:grpc_admin.ReqLoadWorld.path)
+}
+#if LANG_CXX11
+inline void ReqLoadWorld::set_path(::std::string&& value) {
+  
+  path_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:grpc_admin.ReqLoadWorld.path)
+}
+#endif
+inline void ReqLoadWorld::set_path(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  path_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:grpc_admin.ReqLoadWorld.path)
+}
+inline void ReqLoadWorld::set_path(const char* value, size_t size) {
+  
+  path_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:grpc_admin.ReqLoadWorld.path)
+}
+inline ::std::string* ReqLoadWorld::mutable_path() {
+  
+  // @@protoc_insertion_point(field_mutable:grpc_admin.ReqLoadWorld.path)
+  return path_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* ReqLoadWorld::release_path() {
+  // @@protoc_insertion_point(field_release:grpc_admin.ReqLoadWorld.path)
+  
+  return path_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void ReqLoadWorld::set_allocated_path(::std::string* path) {
+  if (path != NULL) {
+    
+  } else {
+    
+  }
+  path_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), path);
+  // @@protoc_insertion_point(field_set_allocated:grpc_admin.ReqLoadWorld.path)
+}
+
 // -------------------------------------------------------------------
 
 // ResLoadWorld
@@ -1907,6 +1990,59 @@ inline void ResLoadWorld::set_allocated_info(::std::string* info) {
 // -------------------------------------------------------------------
 
 // ReqLoadChain
+
+// string path = 1;
+inline void ReqLoadChain::clear_path() {
+  path_.ClearToEmptyNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline const ::std::string& ReqLoadChain::path() const {
+  // @@protoc_insertion_point(field_get:grpc_admin.ReqLoadChain.path)
+  return path_.GetNoArena();
+}
+inline void ReqLoadChain::set_path(const ::std::string& value) {
+  
+  path_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), value);
+  // @@protoc_insertion_point(field_set:grpc_admin.ReqLoadChain.path)
+}
+#if LANG_CXX11
+inline void ReqLoadChain::set_path(::std::string&& value) {
+  
+  path_.SetNoArena(
+    &::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::move(value));
+  // @@protoc_insertion_point(field_set_rvalue:grpc_admin.ReqLoadChain.path)
+}
+#endif
+inline void ReqLoadChain::set_path(const char* value) {
+  GOOGLE_DCHECK(value != NULL);
+  
+  path_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), ::std::string(value));
+  // @@protoc_insertion_point(field_set_char:grpc_admin.ReqLoadChain.path)
+}
+inline void ReqLoadChain::set_path(const char* value, size_t size) {
+  
+  path_.SetNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(),
+      ::std::string(reinterpret_cast<const char*>(value), size));
+  // @@protoc_insertion_point(field_set_pointer:grpc_admin.ReqLoadChain.path)
+}
+inline ::std::string* ReqLoadChain::mutable_path() {
+  
+  // @@protoc_insertion_point(field_mutable:grpc_admin.ReqLoadChain.path)
+  return path_.MutableNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline ::std::string* ReqLoadChain::release_path() {
+  // @@protoc_insertion_point(field_release:grpc_admin.ReqLoadChain.path)
+  
+  return path_.ReleaseNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited());
+}
+inline void ReqLoadChain::set_allocated_path(::std::string* path) {
+  if (path != NULL) {
+    
+  } else {
+    
+  }
+  path_.SetAllocatedNoArena(&::google::protobuf::internal::GetEmptyStringAlreadyInited(), path);
+  // @@protoc_insertion_point(field_set_allocated:grpc_admin.ReqLoadChain.path)
+}
 
 // -------------------------------------------------------------------
 

--- a/src/plugins/admin_plugin/rpc_services/rpc_services.cpp
+++ b/src/plugins/admin_plugin/rpc_services/rpc_services.cpp
@@ -7,7 +7,9 @@
 #include "../include/command_delegator.hpp"
 #include "../middlewares/include/admin_middleware.hpp"
 
+#include <boost/filesystem.hpp>
 #include <exception>
+#include <fstream>
 
 // IMPORTANT: This should be located right after `proceed()`
 #define BEFORE_PROCEED(SERVICE_CLASS, SERVICE, COMPLETION_QUEUE, ...)                                                                      \
@@ -34,6 +36,8 @@
 
 namespace gruut {
 namespace admin_plugin {
+
+namespace fs = boost::filesystem;
 
 using namespace appbase;
 using namespace std;
@@ -245,10 +249,18 @@ bool LoginService::checkPassword(const string &enc_sk_pem, const string &pass) {
 void StartService::proceed() {
   BEFORE_PROCEED(StartService, service, completion_queue);
 
+  string info;
+
   if (app().isAppRunning()) {
-    string info = "It's already running as a ";
+    info = "It's already running as a ";
     string mode_type = app().runningMode() == RunningMode::DEFAULT ? "default mode" : "monitor mode";
     info += mode_type;
+  }
+
+  if (!app().isWorldLoaded())
+    info = "World has not be loaded yet.";
+
+  if (!info.empty()) {
     logger::ERROR("[START] {}", info);
 
     res.set_success(false);
@@ -261,7 +273,7 @@ void StartService::proceed() {
 
   auto mode = req.mode();
   if (mode == ReqStart_Mode_DEFAULT && !app().isUserSignedIn()) {
-    string info = "Could not join a network. Please setup & login OR start as a monitoring mode";
+    info = "Could not join a network. Please setup & login OR start as a monitoring mode";
     logger::ERROR("[START] {}", info);
 
     res.set_success(false);
@@ -291,6 +303,42 @@ void StatusService::proceed() {
 
   res.set_alive(app().isAppRunning());
 
+  sendFinishedMsg(res);
+}
+
+void LoadWorldService::proceed() {
+  BEFORE_PROCEED(LoadWorldService, service, completion_queue);
+  SET_MIDDLEWARE(LoadWorldService)
+
+  // TODO : in case of path is `url`, handle it different way
+  fs::path world_info_path = req.path();
+  if (world_info_path.is_relative())
+    world_info_path = fs::current_path() / world_info_path;
+
+  if (!fs::exists(world_info_path)) {
+    string info = "Can not find a world file. path :" + world_info_path.string();
+    logger::ERROR("[LOAD WORLD] {}", info);
+    res.set_info(info);
+    res.set_success(false);
+  } else {
+    ifstream i(world_info_path.make_preferred().string());
+    nlohmann::json world_state;
+
+    i >> world_state;
+
+    auto &chain = dynamic_cast<ChainPlugin *>(app().getPlugin("ChainPlugin"))->chain();
+    try {
+      chain.initWorld(world_state);
+      res.set_success(true);
+      logger::INFO("[LOAD WORLD] Success to load world");
+      app().completeLoadWorld();
+
+    } catch (...) {
+      string info = "Can not load world. please check world json file.";
+      res.set_info(info);
+      res.set_success(false);
+    }
+  }
   sendFinishedMsg(res);
 }
 

--- a/src/plugins/chain_plugin/chain.cpp
+++ b/src/plugins/chain_plugin/chain.cpp
@@ -1,3 +1,4 @@
+#include "../../../lib/appbase/include/application.hpp"
 #include "include/chain.hpp"
 
 namespace gruut {
@@ -6,60 +7,41 @@ class ChainImpl {
 public:
   ChainImpl(Chain &self) : self(self) {}
 
-  void init(nlohmann::json genesis_state) {
-    world_type genesis = unmarshalGenesisState(genesis_state);
+  void initWorld(nlohmann::json &world_state) {
+    world_type world = unmarshalWorldState(world_state);
 
-    self.saveWorld(genesis);
-    self.saveChain(genesis.local_chain_state);
+    appbase::app().setWorldId(world.world_id);
 
-    string tmp_key_test = genesis.world_id + "_cpk";
-    string test_value = self.getValueByKey(DataType::WORLD, tmp_key_test);
-
-    logger::INFO("KV levelDB test... " + test_value);
+    self.saveWorld(world);
   }
 
-  world_type unmarshalGenesisState(nlohmann::json state) {
+  world_type unmarshalWorldState(nlohmann::json &state) {
     try {
-      world_type genesis_state;
+      world_type world_state;
 
-      genesis_state.world_id = state["/world/id"_json_pointer];
-      genesis_state.world_created_time = state["/world/after"_json_pointer];
+      world_state.world_id = state["/world/id"_json_pointer];
+      world_state.world_created_time = state["/world/after"_json_pointer];
 
-      genesis_state.keyc_name = state["/key_currency/name"_json_pointer];
-      genesis_state.initial_amount = state["/key_currency/initial_amount"_json_pointer];
+      world_state.keyc_name = state["/key_currency/name"_json_pointer];
+      world_state.initial_amount = state["/key_currency/initial_amount"_json_pointer];
 
-      genesis_state.allow_mining = state["/mining_policy/allow_mining"_json_pointer];
+      world_state.allow_mining = state["/mining_policy/allow_mining"_json_pointer];
 
-      genesis_state.allow_anonymous_user = state["/user_policy/allow_anonymous_user"_json_pointer];
-      genesis_state.join_fee = state["/user_policy/join_fee"_json_pointer];
+      world_state.allow_anonymous_user = state["/user_policy/allow_anonymous_user"_json_pointer];
+      world_state.join_fee = state["/user_policy/join_fee"_json_pointer];
 
-      genesis_state.local_chain_state.chain_id = state["/eden/chain/id"_json_pointer];
-      genesis_state.local_chain_state.world_id = state["/eden/chain/world"_json_pointer];
-      genesis_state.local_chain_state.chain_created_time = state["/eden/chain/after"_json_pointer];
+      world_state.eden_sig = state["eden_sig"].get<string>();
 
-      genesis_state.local_chain_state.allow_custom_contract = state["/eden/policy/allow_custom_contract"_json_pointer];
-      genesis_state.local_chain_state.allow_oracle = state["/eden/policy/allow_oracle"_json_pointer];
-      genesis_state.local_chain_state.allow_tag = state["/eden/policy/allow_tag"_json_pointer];
-      genesis_state.local_chain_state.allow_heavy_contract = state["/eden/policy/allow_heavy_contract"_json_pointer];
+      world_state.authority_id = state["/authority/id"_json_pointer];
+      world_state.authority_cert = state["authority"]["cert"].get<vector<string>>();
 
-      genesis_state.authority_id = state["/authority/id"_json_pointer];
-      genesis_state.authority_cert = state["authority"]["cert"].get<vector<string>>();
+      world_state.creator_id = state["/creator/id"_json_pointer];
+      world_state.creator_cert = state["creator"]["cert"].get<vector<string>>();
+      world_state.creator_sig = state["/creator/sig"_json_pointer];
 
-      genesis_state.creator_id = state["/creator/id"_json_pointer];
-      genesis_state.local_chain_state.creator_id = state["/creator/id"_json_pointer];
-      genesis_state.creator_cert = state["creator"]["cert"].get<vector<string>>();
-      genesis_state.local_chain_state.creator_cert = state["creator"]["cert"].get<vector<string>>();
-      genesis_state.creator_sig = state["/creator/sig"_json_pointer];
-      genesis_state.local_chain_state.creator_sig = state["/creator/sig"_json_pointer];
-
-      assert(genesis_state.world_id == genesis_state.local_chain_state.world_id);
-      assert(genesis_state.creator_id == genesis_state.local_chain_state.creator_id);
-      assert(genesis_state.creator_cert == genesis_state.local_chain_state.creator_cert);
-      assert(genesis_state.creator_sig == genesis_state.local_chain_state.creator_sig);
-
-      return genesis_state;
+      return world_state;
     } catch (nlohmann::json::parse_error &e) {
-      logger::ERROR("Failed to parse world_create.json: {}", e.what());
+      logger::ERROR("[LOAD WORLD] Failed to parse world_create.json: {}", e.what());
       throw e;
     }
   }
@@ -67,14 +49,14 @@ public:
   Chain &self;
 };
 
+void Chain::initWorld(nlohmann::json &world_state) {
+  impl->initWorld(world_state);
+}
+
 Chain::Chain(string_view dbms, string_view table_name, string_view db_user_id, string_view db_password) {
   impl = make_unique<ChainImpl>(*this);
   rdb_controller = make_unique<RdbController>(dbms, table_name, db_user_id, db_password);
   kv_controller = make_unique<KvController>();
-}
-
-void Chain::startup(nlohmann::json &genesis_state) {
-  impl->init(genesis_state);
 }
 
 Chain::~Chain() {

--- a/src/plugins/chain_plugin/config/storage_type.hpp
+++ b/src/plugins/chain_plugin/config/storage_type.hpp
@@ -44,8 +44,10 @@ using local_chain_type = struct LocalChainState {
 
   // creator
   base58_type creator_id;
-  std::vector<string> creator_cert;
+  vector<string> creator_cert;
   string creator_sig;
+
+  vector<string> tracker_addresses;
 };
 
 using world_type = struct WorldState {
@@ -65,8 +67,6 @@ using world_type = struct WorldState {
   bool allow_anonymous_user;
   string join_fee;
 
-  LocalChainState local_chain_state;
-
   // authority
   string authority_id;
   std::vector<string> authority_cert;
@@ -75,6 +75,8 @@ using world_type = struct WorldState {
   base58_type creator_id;
   std::vector<string> creator_cert;
   string creator_sig;
+
+  string eden_sig;
 };
 
 using proof_type = struct _proof_type {

--- a/src/plugins/chain_plugin/include/chain.hpp
+++ b/src/plugins/chain_plugin/include/chain.hpp
@@ -26,7 +26,7 @@ public:
   Chain(const Chain &&) = delete;
   Chain &operator=(const Chain &) = delete;
 
-  void startup(nlohmann::json &genesis_state);
+  void initWorld(nlohmann::json &world_state);
 
   // RDB functions
   void insertBlockData(Block &block_info);


### PR DESCRIPTION
 ### 수정사항
- AdminService Protobuf 
  - ReqLoadWorld / ReqLoadChain 에 path 추가

- Chain Plugin
  - LocalChainState / WorldState struct 수정
  - unmarshalgenesisState -> unmarshalWorldState (parsing 하는 내용 수정 )
https://thevaulters.atlassian.net/wiki/spaces/SGN/pages/77987903/TP13.+Genesis
 - Application
   - isWorldLoaded() / completeLoadWorld() 추가
   - setWorldId() / getWorldId() 추가 ( worldId의 경우 message를 보낼때
사용할 것)

### 추가사항
- AdminService LoadWorld Service
https://thevaulters.atlassian.net/wiki/spaces/SGN/pages/103350293/TP10.+Administrative+Client+Admin+Console

#### TODO: 
- admin service `LoadChain` 명령어 처리
- chain plugin에서 초기화단계에서 `db`에 참여하려는 world / chain 의 정보가 있다면, load world / load chain 명령어를 실행하지 않아도, 다음단계로 진행할 수 있도록 하여야합니다.  지금 저장하고 있는 `Key = id + ~`형태로 되어있어서 확인하기가 어렵습니다. 이부분 확인해야 합니다.