### PR TITLE
# FEATURE  - Handle load chain command

### DIFF
--- a/lib/appbase/application.cpp
+++ b/lib/appbase/application.cpp
@@ -99,7 +99,7 @@ void Application::initializePlugins() {
 }
 
 void Application::start() {
-  thread proactor([this](){io_context_ptr->run();});
+  thread proactor([this]() { io_context_ptr->run(); });
 
   startInitializedPlugins();
 
@@ -111,10 +111,10 @@ void Application::start() {
 }
 
 void Application::startInitializedPlugins() {
-  while(!app().isAppRunning());
+  while (!app().isAppRunning());
 
   for (auto &[_, plugin_ptr] : app_plugins_map) {
-    if(plugin_ptr->getState() == AbstractPlugin::plugin_state::initialized) {
+    if (plugin_ptr->getState() == AbstractPlugin::plugin_state::initialized) {
       plugin_ptr->start();
     }
   }
@@ -123,23 +123,23 @@ void Application::startInitializedPlugins() {
 void Application::registerErrorSignalHandlers() {
   shared_ptr<boost::asio::signal_set> sigint_set(new boost::asio::signal_set(*io_context_ptr, SIGINT));
   sigint_set->async_wait([sigint_set, this](const boost::system::error_code &err, int num) {
-      logger::ERROR("SIGINT Received: {}", err.message());
-      sigint_set->cancel();
-      quit();
+    logger::ERROR("SIGINT Received: {}", err.message());
+    sigint_set->cancel();
+    quit();
   });
 
   shared_ptr<boost::asio::signal_set> sigterm_set(new boost::asio::signal_set(*io_context_ptr, SIGTERM));
   sigterm_set->async_wait([sigterm_set, this](const boost::system::error_code &err, int num) {
-      logger::ERROR("SIGTERM Received: {}", err.message());
-      sigterm_set->cancel();
-      quit();
+    logger::ERROR("SIGTERM Received: {}", err.message());
+    sigterm_set->cancel();
+    quit();
   });
 
   shared_ptr<boost::asio::signal_set> sigpipe_set(new boost::asio::signal_set(*io_context_ptr, SIGPIPE));
   sigpipe_set->async_wait([sigpipe_set, this](const boost::system::error_code &err, int num) {
-      logger::ERROR("SIGPIPE Received: {}", err.message());
-      sigpipe_set->cancel();
-      quit();
+    logger::ERROR("SIGPIPE Received: {}", err.message());
+    sigpipe_set->cancel();
+    quit();
   });
 }
 
@@ -154,23 +154,27 @@ void Application::shutdown() {
   io_context_ptr->reset();
 }
 
-AbstractPlugin* Application::getPlugin(const string &name) const {
+AbstractPlugin *Application::getPlugin(const string &name) const {
   auto itr = app_plugins_map.find(name);
   if (itr == app_plugins_map.end())
     throw(std::runtime_error("unable to find plugin: " + name));
 
-  if(itr->second->getState() == AbstractPlugin::plugin_state::initialized) {
+  if (itr->second->getState() == AbstractPlugin::plugin_state::initialized) {
     return itr->second.get();
   } else {
     throw(std::runtime_error("The plugin had been registered, but not initialized: " + name));
   }
 }
 
-void Application::setWorldId(string_view _id){
+void Application::setWorldId(string_view _id) {
   world_id = _id;
 }
 
-void Application::setId(string_view _id){
+void Application::setChainId(string_view _id) {
+  chain_id = _id;
+}
+
+void Application::setId(string_view _id) {
   id = _id;
 }
 
@@ -178,11 +182,15 @@ const string &Application::getWorldId() const {
   return world_id;
 }
 
+const string &Application::getChainId() const {
+  return chain_id;
+}
+
 const string &Application::getId() const {
   return id;
 }
 
-void Application::setRunFlag(){
+void Application::setRunFlag() {
   running = true;
 }
 
@@ -198,8 +206,16 @@ bool Application::isWorldLoaded() {
   return application_status.load_world;
 }
 
+bool Application::isChainLoaded() {
+  return application_status.load_chain;
+}
+
 void Application::completeLoadWorld() {
   application_status.load_world = true;
+}
+
+void Application::completeLoadChain() {
+  application_status.load_chain = true;
 }
 
 void Application::completeUserSetup() {

--- a/lib/appbase/include/application.hpp
+++ b/lib/appbase/include/application.hpp
@@ -26,12 +26,13 @@ enum class RunningMode : int { NONE = -1, DEFAULT = 0, MONITOR = 1 };
 
 struct ApplicationStatus {
   bool load_world;
+  bool load_chain;
   bool user_setup;
   bool user_login;
 
   RunningMode run_mode;
 
-  ApplicationStatus() : load_world(false), user_setup(false), user_login(false), run_mode(RunningMode::NONE) {}
+  ApplicationStatus() : load_world(false), load_chain(false), user_setup(false), user_login(false), run_mode(RunningMode::NONE) {}
 };
 
 class Application {
@@ -90,9 +91,11 @@ public:
   }
 
   void setWorldId(string_view _id);
+  void setChainId(string_view _id);
   void setId(string_view _id);
 
   const string &getWorldId() const;
+  const string &getChainId() const;
   const string &getId() const;
 
   void setRunFlag();
@@ -100,8 +103,10 @@ public:
   bool isAppRunning();
   bool isUserSignedIn();
   bool isWorldLoaded();
+  bool isChainLoaded();
 
   void completeLoadWorld();
+  void completeLoadChain();
   void completeUserSetup();
   void completeUserSignedIn();
 
@@ -148,6 +153,7 @@ private:
   unique_ptr<ProgramOptions> program_options;
 
   string world_id;
+  string chain_id;
   string id;
 
   bool running = false;

--- a/src/plugins/admin_plugin/admin_plugin.cpp
+++ b/src/plugins/admin_plugin/admin_plugin.cpp
@@ -43,6 +43,7 @@ public:
     new StartService(&admin_service, completion_queue.get());
     new StatusService(&admin_service, completion_queue.get());
     new LoadWorldService(&admin_service, completion_queue.get());
+    new LoadChainService(&admin_service, completion_queue.get());
   }
 
   void start() {}
@@ -71,7 +72,7 @@ public:
 
         auto queue_state = completion_queue->AsyncNext(&tag, &ok, deadline);
         if (ok && queue_state == CompletionQueue::NextStatus::GOT_EVENT) {
-          static_cast <CallService *>(tag)->proceed();
+          static_cast<CallService *>(tag)->proceed();
         }
       } else {
         logger::ERROR("Error from admin_req_check_timer: {}", ec.message());

--- a/src/plugins/admin_plugin/middlewares/include/admin_middleware.hpp
+++ b/src/plugins/admin_plugin/middlewares/include/admin_middleware.hpp
@@ -25,7 +25,7 @@ public:
   }
 };
 
-template<>
+template <>
 class AdminMiddleware<SetupService> {
 public:
   pair<bool, error_message> next() {
@@ -46,4 +46,16 @@ public:
     return make_pair(true, "");
   }
 };
+
+template <>
+class AdminMiddleware<LoadChainService> {
+public:
+  pair<bool, error_message> next() {
+    if (app().isAppRunning())
+      return make_pair(false, "If you want to join a different local chain, stop node and then load different local chain");
+
+    return make_pair(true, "");
+  }
+};
 } // namespace tethys::admin_plugin
+

--- a/src/plugins/admin_plugin/rpc_services/include/rpc_services.hpp
+++ b/src/plugins/admin_plugin/rpc_services/include/rpc_services.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "../../../net_plugin/rpc_services/protos/include/user_service.grpc.pb.h"
 #include "../../../chain_plugin/include/chain.hpp"
+#include "../../../net_plugin/rpc_services/protos/include/user_service.grpc.pb.h"
 #include "../../include/admin_type.hpp"
 #include "../proto/include/admin_service.grpc.pb.h"
 #include <atomic>
@@ -129,6 +129,16 @@ class LoadWorldService final : public AdminService<ReqLoadWorld, ResLoadWorld> {
 public:
   LoadWorldService(TethysAdminService::AsyncService *admin_service, ServerCompletionQueue *cq) : super(admin_service, cq) {
     service->RequestLoadWorld(&context, &req, &responder, completion_queue, completion_queue, this);
+  }
+  void proceed() override;
+};
+
+class LoadChainService final : public AdminService<ReqLoadChain, ResLoadChain> {
+  using super = AdminService<ReqLoadChain, ResLoadChain>;
+
+public:
+  LoadChainService(TethysAdminService::AsyncService *admin_service, ServerCompletionQueue *cq) : super(admin_service, cq) {
+    service->RequestLoadChain(&context, &req, &responder, completion_queue, completion_queue, this);
   }
   void proceed() override;
 };

--- a/src/plugins/admin_plugin/rpc_services/rpc_services.cpp
+++ b/src/plugins/admin_plugin/rpc_services/rpc_services.cpp
@@ -284,7 +284,7 @@ void StartService::proceed() {
 
   if (!app().isWorldLoaded())
     info = "World has not be loaded yet.";
-  else if(!app().isChainLoaded())
+  else if (!app().isChainLoaded())
     info = "Local chain has not be loaded yet.";
 
   if (!info.empty()) {
@@ -412,11 +412,21 @@ void LoadChainService::proceed() {
 
   auto &chain = dynamic_cast<ChainPlugin *>(app().getPlugin("ChainPlugin"))->chain();
   try {
-    auto tracker_address = chain.initChain(chain_state.value());
-    //TODO : send tracker info to Net Plugin.
-    res.set_success(true);
-    logger::INFO("[LOAD CHAIN] Success to load chain");
-    app().completeLoadChain();
+    auto chain_info = chain.initChain(chain_state.value());
+    if (!chain_info.has_value()) {
+      string info = "This local chain is in another world. Please check World ID";
+      res.set_info(info);
+      res.set_success(false);
+
+      logger::ERROR("[LOAD CHAIN] Fail to load local chain");
+
+    } else {
+      auto tracker_addresses = chain_info.value();
+      // TODO : send tracker info to Net Plugin.
+      res.set_success(true);
+      logger::INFO("[LOAD CHAIN] Success to load chain");
+      app().completeLoadChain();
+    }
   } catch (...) {
     string info = "Can not load local chain. please check local chain json file.";
     res.set_info(info);

--- a/src/plugins/chain_plugin/chain.cpp
+++ b/src/plugins/chain_plugin/chain.cpp
@@ -15,8 +15,11 @@ public:
     self.saveWorld(world);
   }
 
-  vector<string> initChain(nlohmann::json &chain_state) {
+  optional<vector<string>> initChain(nlohmann::json &chain_state) {
     local_chain_type chain = unmarshalChainState(chain_state);
+
+    if (appbase::app().getWorldId() != chain.world_id)
+      return {};
 
     appbase::app().setChainId(chain.chain_id);
 
@@ -92,7 +95,7 @@ void Chain::initWorld(nlohmann::json &world_state) {
   impl->initWorld(world_state);
 }
 
-vector<string> Chain::initChain(nlohmann::json &chain_state) {
+optional<vector<string>> Chain::initChain(nlohmann::json &chain_state) {
   return impl->initChain(chain_state);
 }
 

--- a/src/plugins/chain_plugin/include/chain.hpp
+++ b/src/plugins/chain_plugin/include/chain.hpp
@@ -10,6 +10,7 @@
 
 #include <boost/program_options/variables_map.hpp>
 #include <memory>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -27,7 +28,7 @@ public:
   Chain &operator=(const Chain &) = delete;
 
   void initWorld(nlohmann::json &world_state);
-  vector<string> initChain(nlohmann::json &chain_state);
+  optional<vector<string>> initChain(nlohmann::json &chain_state);
 
   // RDB functions
   void insertBlockData(Block &block_info);

--- a/src/plugins/chain_plugin/include/chain.hpp
+++ b/src/plugins/chain_plugin/include/chain.hpp
@@ -27,6 +27,7 @@ public:
   Chain &operator=(const Chain &) = delete;
 
   void initWorld(nlohmann::json &world_state);
+  vector<string> initChain(nlohmann::json &chain_state);
 
   // RDB functions
   void insertBlockData(Block &block_info);

--- a/src/plugins/chain_plugin/kv_store.cpp
+++ b/src/plugins/chain_plugin/kv_store.cpp
@@ -109,6 +109,13 @@ bool KvController::saveChain(local_chain_type &chain_info) {
   bool tmp_ahc = chain_info.allow_heavy_contract;
   addBatch(DataType::CHAIN, tmp_chid + "_ahc", to_string(tmp_ahc));
 
+  string tk_addr_list;
+  string delimiter = ",";
+  for(auto &tracker_addr : chain_info.tracker_addresses)
+    tk_addr_list += (tracker_addr + delimiter);
+  tk_addr_list.pop_back();
+  addBatch(DataType::CHAIN, tmp_chid + "_tk_addr", tk_addr_list);
+
   commitBatchAll();
 
   return true;

--- a/src/plugins/net_plugin/config/include/network_config.hpp
+++ b/src/plugins/net_plugin/config/include/network_config.hpp
@@ -10,8 +10,5 @@ namespace net_plugin {
 constexpr unsigned int PARALLELISM_ALPHA = 3;
 constexpr auto GENERAL_SERVICE_TIMEOUT = std::chrono::milliseconds(100);
 
-// TODO : LOCAL CHAIN ID / WORLD ID 에 대해서 정해진 바가 없어 임시 사용 수정될 것.
-const std::string LOCAL_CHAIN_ID = "LCHAINID"; // 8bytes
-const std::string WORLD_ID = "WORLD-ID";       // 8bytes
 } // namespace net_plugin
 } // namespace tethys

--- a/src/plugins/net_plugin/include/message_packer.hpp
+++ b/src/plugins/net_plugin/include/message_packer.hpp
@@ -49,8 +49,12 @@ private:
 
     auto total_length = TypeConverter::integerToBytes(HEADER_LENGTH + serialized_json_size);
     serialized_header.insert(serialized_header.end(), begin(total_length), end(total_length));
-    serialized_header.insert(serialized_header.end(), begin(WORLD_ID), end(WORLD_ID));
-    serialized_header.insert(serialized_header.end(), begin(LOCAL_CHAIN_ID), end(LOCAL_CHAIN_ID));
+
+    auto &world_id = app().getWorldId();
+    serialized_header.insert(serialized_header.end(), world_id.begin(), world_id.end());
+
+    auto &chain_id = app().getChainId();
+    serialized_header.insert(serialized_header.end(), chain_id.begin(), chain_id.end());
 
     auto &my_id = app().getId();
     serialized_header.insert(serialized_header.end(), my_id.begin(), my_id.end());


### PR DESCRIPTION
### 추가 및 수정사항
- Chain plugin
  - unmarshalChainState () : local chain  json parsing
  - initChain() : parsing한 local chain 내용으 db(leveldb)에 저장, tracker 주소 반환
  - Local Chain load 시 담겨있는 tracker의 주소를 leveldb 에 저장하도록
함. (tracker의 주소는 하나가 아닐 수있으므로 delimiter(",")를 이용하여
붙여서 저장함)

- Application
  - setChainId() / getChainId() 추가
  - completeLoadChain / isChainLoaded() 추가

- AdminPlugin
  - LoadChainService 추가
  - LoadChainService & LoadWorldService 에서 .json을 load하는 부분이 중복코드이므로, 이를 처리하는 함수를 추가


- NetPlugin
  - NetPlugin에서 WORLD_ID / CHAIN_ID를 사용하는 부분 수정

### TODO
- 최근에 load했던 World/chain 정보를 leveldb에 추가로 저장하고, 해당 정보를 이용해 load chain / load world 명령어를 하지 않아도 start가 가능하도록 하게해야함.

- localchain의 Tracker의 정보를 netplugin에 전달하여야함.