### PR TITLE
 # ADD - Send tracker address to Netplugin

### DIFF
--- a/src/plugins/admin_plugin/include/admin_type.hpp
+++ b/src/plugins/admin_plugin/include/admin_type.hpp
@@ -3,7 +3,7 @@
 namespace tethys {
 namespace admin_plugin {
 
-enum class ControlType : int { LOGIN = 1, START = 2 };
+enum class ControlType : int { LOGIN = 1, START = 2, LOAD_CHAIN = 3 };
 
 } // namespace admin_plugin
 } // namespace tethys

--- a/src/plugins/admin_plugin/include/command_delegator.hpp
+++ b/src/plugins/admin_plugin/include/command_delegator.hpp
@@ -81,5 +81,30 @@ private:
   RunningMode net_mode;
 };
 
+class LoadChainCommandDelegator : public CommandDelegator<ReqLoadChain> {
+public:
+  LoadChainCommandDelegator(vector<string> &&_tracker_addresses) : tracker_addresses(move(_tracker_addresses)) {}
+
+private:
+  nlohmann::json createControlCommand() override {
+    nlohmann::json control_command;
+
+    control_command["type"] = getControlType();
+    control_command["trackers"] = nlohmann::json(tracker_addresses);
+
+    return control_command;
+  }
+
+  void sendCommand(nlohmann::json control_command) override {
+    app().getChannel<incoming::channels::net_control>().publish(control_command);
+  }
+
+  void setControlType() override {
+    control_type = static_cast<int>(ControlType::LOAD_CHAIN);
+  }
+
+  vector<string> tracker_addresses;
+};
+
 } // namespace admin_plugin
-}
+} // namespace tethys

--- a/src/plugins/admin_plugin/rpc_services/rpc_services.cpp
+++ b/src/plugins/admin_plugin/rpc_services/rpc_services.cpp
@@ -422,7 +422,9 @@ void LoadChainService::proceed() {
 
     } else {
       auto tracker_addresses = chain_info.value();
-      // TODO : send tracker info to Net Plugin.
+      LoadChainCommandDelegator delegator(move(tracker_addresses));
+      delegator.delegate();
+
       res.set_success(true);
       logger::INFO("[LOAD CHAIN] Success to load chain");
       app().completeLoadChain();


### PR DESCRIPTION
- `LoadChain command`를 수행할때, Chain json을 parsing후 Tracker address
정보를 Netplugin 에게 전달 하도록 함.

#### 추가사항
- Admin Plugin
  - LoadChain Delegator 추가

- Net plugin
  - controlNet()에 LOAD_CHAIN case 추가
  - Tracker는 여러개가 존재할 수 있으므로 알고있는 tracker 모두에게
접속하여 node 주소를 받아오도록 getPeerFromTracker() 수정