### PR TITLE
 # ADD - store latest world & chain id in leveldb

### DIFF
--- a/src/plugins/chain_plugin/chain.cpp
+++ b/src/plugins/chain_plugin/chain.cpp
@@ -13,6 +13,7 @@ public:
     appbase::app().setWorldId(world.world_id);
 
     self.saveWorld(world);
+    self.saveLatestWorldId(world.world_id);
   }
 
   optional<vector<string>> initChain(nlohmann::json &chain_state) {
@@ -24,6 +25,7 @@ public:
     appbase::app().setChainId(chain.chain_id);
 
     self.saveChain(chain);
+    self.saveLatestChainId(chain.chain_id);
 
     return chain.tracker_addresses;
   }
@@ -142,6 +144,14 @@ string Chain::getUserCert(const base58_type &user_id) {
 }
 
 // KV functions
+void Chain::saveLatestWorldId(const alphanumeric_type &world_id) {
+  kv_controller->saveLatestWorldId(world_id);
+}
+
+void Chain::saveLatestChainId(const alphanumeric_type &chain_id) {
+  kv_controller->saveLatestChainId(chain_id);
+}
+
 void Chain::saveWorld(world_type &world_info) {
   kv_controller->saveWorld(world_info);
 }

--- a/src/plugins/chain_plugin/chain_plugin.cpp
+++ b/src/plugins/chain_plugin/chain_plugin.cpp
@@ -149,13 +149,23 @@ public:
     transaction_pool = make_unique<TransactionPool>();
     unresolved_block_pool = make_unique<UnresolvedBlockPool>();
 
-    // TODO : If storage(leveldb) have world and local chain info,
-    // set world id and local chain id.
-    // Now, cannot load info(world/chain) from level db because no way to know `key`
+    auto world_id = chain->getValueByKey(DataType::WORLD, "latest_world_id");
+    if (!world_id.empty()) {
+      app().setWorldId(world_id);
+      app().completeLoadWorld();
+    }
+
+    auto chain_id = chain->getValueByKey(DataType::CHAIN, "latest_chain_id");
+    if (!chain_id.empty()) {
+      app().setChainId(chain_id);
+      app().completeLoadChain();
+    }
 
     auto self_id = chain->getValueByKey(DataType::SELF_INFO, "self_id");
-    if (!self_id.empty())
+    if (!self_id.empty()) {
       app().setId(self_id);
+      app().completeUserSetup();
+    }
   }
 
   void pushTransaction(const nlohmann::json &transaction_json) {

--- a/src/plugins/chain_plugin/include/chain.hpp
+++ b/src/plugins/chain_plugin/include/chain.hpp
@@ -36,6 +36,8 @@ public:
   string getUserCert(const base58_type &user_id);
 
   // KV functions
+  void saveLatestWorldId(const alphanumeric_type &world_id);
+  void saveLatestChainId(const alphanumeric_type &chain_id);
   void saveWorld(world_type &world_info);
   void saveChain(local_chain_type &chain_info);
   void saveBackup(UnresolvedBlock &block_info);

--- a/src/plugins/chain_plugin/include/kv_store.hpp
+++ b/src/plugins/chain_plugin/include/kv_store.hpp
@@ -35,6 +35,8 @@ public:
   KvController();
   ~KvController();
 
+  bool saveLatestWorldId(const alphanumeric_type &world_id);
+  bool saveLatestChainId(const alphanumeric_type &chain_id);
   bool saveWorld(world_type &world_info);
   bool saveChain(local_chain_type &chain_info);
   bool saveBackup(UnresolvedBlock &block_info);

--- a/src/plugins/chain_plugin/kv_store.cpp
+++ b/src/plugins/chain_plugin/kv_store.cpp
@@ -38,6 +38,16 @@ bool KvController::errorOnCritical(const leveldb::Status &status) {
   }
 }
 
+bool KvController::saveLatestWorldId(const alphanumeric_type &world_id) {
+  addBatch(DataType::WORLD, "latest_world_id", world_id);
+  return true;
+}
+
+bool KvController::saveLatestChainId(const alphanumeric_type &chain_id) {
+  addBatch(DataType::CHAIN, "latest_chain_id", chain_id);
+  return true;
+}
+
 bool KvController::saveWorld(world_type &world_info) {
   // TODO: 리팩토링 필요
   alphanumeric_type tmp_wid = world_info.world_id;
@@ -111,7 +121,7 @@ bool KvController::saveChain(local_chain_type &chain_info) {
 
   string tk_addr_list;
   string delimiter = ",";
-  for(auto &tracker_addr : chain_info.tracker_addresses)
+  for (auto &tracker_addr : chain_info.tracker_addresses)
     tk_addr_list += (tracker_addr + delimiter);
   tk_addr_list.pop_back();
   addBatch(DataType::CHAIN, tmp_chid + "_tk_addr", tk_addr_list);


### PR DESCRIPTION
#### 추가사항
- 최근에 load 했던 chain / world 의 id를 leveldb에 저장하도록 함.
- Chain plugin initialize stage에서 Chain / world id의 정보가 있다면,
`load chain` , `load world` 명령어를 실행하지 않고, 진행이 가능하도록
함. (`completeLoadChain()`  / `completeLoadWorld()` 호출 )

#### 수정사항
- Chain plugin initialize stage에서 Self - info ( id ) 가 있다면 `setup` 명령어를 실행하지 않고 진행이 가능하도록 함 ( `completeUserSetup()` 호출)