### PR TITLE
# ADD -  verify user cert

### DIFF
--- a/lib/appbase/application.cpp
+++ b/lib/appbase/application.cpp
@@ -166,6 +166,10 @@ AbstractPlugin *Application::getPlugin(const string &name) const {
   }
 }
 
+void Application::setAuthCert(string_view _auth_cert) {
+  auth_cert = _auth_cert;
+}
+
 void Application::setWorldId(string_view _id) {
   world_id = _id;
 }
@@ -176,6 +180,10 @@ void Application::setChainId(string_view _id) {
 
 void Application::setId(string_view _id) {
   id = _id;
+}
+
+const string &Application::getAuthCert() const {
+  return auth_cert;
 }
 
 const string &Application::getWorldId() const {

--- a/lib/appbase/application.cpp
+++ b/lib/appbase/application.cpp
@@ -218,6 +218,10 @@ bool Application::isChainLoaded() {
   return application_status.load_chain;
 }
 
+void Application::resetLoadChainState() {
+  application_status.load_chain = false;
+}
+
 void Application::completeLoadWorld() {
   application_status.load_world = true;
 }

--- a/lib/appbase/include/application.hpp
+++ b/lib/appbase/include/application.hpp
@@ -90,10 +90,12 @@ public:
     }
   }
 
+  void setAuthCert(string_view _auth_cert);
   void setWorldId(string_view _id);
   void setChainId(string_view _id);
   void setId(string_view _id);
 
+  const string &getAuthCert() const;
   const string &getWorldId() const;
   const string &getChainId() const;
   const string &getId() const;
@@ -152,6 +154,7 @@ private:
 
   unique_ptr<ProgramOptions> program_options;
 
+  string auth_cert;
   string world_id;
   string chain_id;
   string id;

--- a/lib/appbase/include/application.hpp
+++ b/lib/appbase/include/application.hpp
@@ -107,6 +107,8 @@ public:
   bool isWorldLoaded();
   bool isChainLoaded();
 
+  void resetLoadChainState();
+
   void completeLoadWorld();
   void completeLoadChain();
   void completeUserSetup();

--- a/src/plugins/admin_plugin/rpc_services/rpc_services.cpp
+++ b/src/plugins/admin_plugin/rpc_services/rpc_services.cpp
@@ -383,6 +383,7 @@ void LoadWorldService::proceed() {
     chain.initWorld(world_state.value());
     res.set_success(true);
     logger::INFO("[LOAD WORLD] Success to load world");
+    app().resetLoadChainState();
     app().completeLoadWorld();
   } catch (...) {
     string info = "Can not load world. please check world json file.";

--- a/src/plugins/chain_plugin/chain.cpp
+++ b/src/plugins/chain_plugin/chain.cpp
@@ -12,6 +12,16 @@ public:
 
     appbase::app().setWorldId(world.world_id);
 
+    string auth_cert;
+    int multiline_size = world.authority_cert.size() - 1;
+    for (int i = 0; i <= multiline_size; ++i) {
+      auth_cert += world.authority_cert[i];
+      if (i != multiline_size)
+        auth_cert += "\n";
+    }
+
+    appbase::app().setAuthCert(auth_cert);
+
     self.saveWorld(world);
     self.saveLatestWorldId(world.world_id);
   }

--- a/src/plugins/chain_plugin/chain_plugin.cpp
+++ b/src/plugins/chain_plugin/chain_plugin.cpp
@@ -152,6 +152,10 @@ public:
     auto world_id = chain->getValueByKey(DataType::WORLD, "latest_world_id");
     if (!world_id.empty()) {
       app().setWorldId(world_id);
+
+      auto auth_cert = chain->getValueByKey(DataType::WORLD, world_id + "_apk");
+      app().setAuthCert(auth_cert);
+
       app().completeLoadWorld();
     }
 


### PR DESCRIPTION
 ### 추가사항
- Application::setAuthCert(), getAuthCert() 추가
- `Load World  명령` 시 World 정보에서 auth cert를 set하도록 함
- `MSG_RESPONSE1` 을 확인 할 때 Auth cert를 이용해 해당 user cert가 유효한지 확인

 #### 기타 수정
- Start 명령어 전에는 `Load World` 명령이 다시 호출 될 수 있음.
이때, 다른 world가 호출 되면, 해당 world에 밑에 있는 local chain이 세팅 되어야 함. 
따라서, `load world` 명령이 불러지면, `resetLoadChainState()` 를 호출하여 
`application 의 load chain state = false` 로 수정하여 반드시 `load chain`을 다시 부르도록 함.