### PR TITLE
# ADD - Insert node routing table

### DIFF
--- a/src/contract/certificate_handler.cpp
+++ b/src/contract/certificate_handler.cpp
@@ -5,6 +5,7 @@
 #include <botan-2/botan/x509cert.h>
 #include <botan-2/botan/ecdsa.h>
 #include "include/config.hpp"
+#include "../../lib/tethys-utils/src/cert_verifier.hpp"
 
 namespace tethys::tsce {
 
@@ -38,32 +39,6 @@ namespace tethys::tsce {
 
     //TODO : may be handled by type ( `PEM` / `DER` )
     //now just check `PEM`
-    try {
-      Botan::DataSource_Memory by_cert_datasource(by_val);
-      Botan::DataSource_Memory cert_datasource(pk);
-
-      Botan::X509_Certificate by_cert(by_cert_datasource);
-      Botan::X509_Certificate cert(cert_datasource);
-
-      std::string algo_name = Botan::OIDS::oid2str(by_cert.subject_public_key_algo().get_oid());
-
-      if (algo_name.size() < 3) {
-        return false;
-      }
-
-      ssize_t pos;
-      if ((pos = algo_name.find("RSA")) != std::string::npos && pos == 0) {
-        Botan::RSA_PublicKey by_pk(by_cert.subject_public_key_algo(), by_cert.subject_public_key_bitstring());
-        return cert.check_signature(by_pk);
-      } else if ((pos = algo_name.find("ECDSA")) != std::string::npos && pos == 0) {
-        Botan::ECDSA_PublicKey by_pk(by_cert.subject_public_key_algo(), by_cert.subject_public_key_bitstring());
-        return cert.check_signature(by_pk);
-      } else {
-        return false; // not supported!
-      }
-    }
-    catch (...) {
-      return false;
-    }
+    return CertVerifier::doVerify(pk, by_val);
   }
 }

--- a/src/plugins/net_plugin/net_plugin.cpp
+++ b/src/plugins/net_plugin/net_plugin.cpp
@@ -86,7 +86,10 @@ public:
   void initializeServer() {
     ServerBuilder builder;
 
-    builder.AddListeningPort(p2p_address, grpc::InsecureServerCredentials());
+    auto [_, port] = getHostAndPort(p2p_address);
+    string listening_addr = "0.0.0.0:" + port;
+
+    builder.AddListeningPort(listening_addr, grpc::InsecureServerCredentials());
     builder.RegisterService(&user_service);
     builder.RegisterService(&merger_service);
     builder.RegisterService(&kademlia_service);

--- a/src/plugins/net_plugin/rpc_services/rpc_services.cpp
+++ b/src/plugins/net_plugin/rpc_services/rpc_services.cpp
@@ -600,6 +600,14 @@ void FindNode::proceed() {
       node->set_port(n.getEndpoint().port);
       node->set_node_id(n.getId());
     }
+
+    string sender_id = m_request.sender_id();
+    string sender_ip_addr = m_request.sender_address();
+    string sender_port = m_request.sender_port();
+
+    Node node(Hash<160>::sha1(sender_id), sender_id, sender_ip_addr, sender_port);
+    m_routing_table->addPeer(move(node));
+
     m_reply.set_time_stamp(TimeUtil::nowBigInt());
 
     Status rpc_status = Status::OK;


### PR DESCRIPTION
 #### 추가사항
- FindNode Rpc 요청을 받았을 때, 요청자를 자신의 Routing table에
삽입하도록함.

 #### 수정사항
- Netplugin rpc server가 실행 될 때, 확인 하고 있어야 하는 주소는 하나가
아닌 모두 이므로 `0.0.0.0` 으로 수정

 ##### 기타 수정
- certificate handler 에서 certificate를 검증하는 부분을 tethys-utill의
CertVerifier를 사용하여 하도록 수정