### PR TITLE
 # EDIT - determine broadcast msg id

### DIFF
--- a/src/plugins/net_plugin/net_plugin.cpp
+++ b/src/plugins/net_plugin/net_plugin.cpp
@@ -117,6 +117,7 @@ public:
   void start() {
     monitorCompletionQueue();
     startConnectionMonitors();
+    monitorBroadcastMsgTable();
     getPeersFromTracker();
   }
 
@@ -320,9 +321,7 @@ public:
       grpc_merger::MsgStatus msg_status;
 
       if (is_broadcast) {
-        // TODO : broadcast 확인을 위한 msg id를 정하는 방법이 없어 현재 임시.
-        int random_num = RandomNumGenerator::getRange(0, 1000);
-        auto vec_msg_id = Sha256::hash(TimeUtil::now() + to_string(random_num));
+        auto vec_msg_id = Sha256::hash(packed_msg);
         string str_hash_msg_id(vec_msg_id.begin(), vec_msg_id.end());
 
         broadcast_check_table->insert({str_hash_msg_id, TimeUtil::nowBigInt()});


### PR DESCRIPTION
- broadcast msg 를 확인하기 위해 사용할 msg-id를 만드는 방법 수정
- Sha256(random number + current time) -> Sha256(packed-msg)
- netplugin start 시 주기적으로 broadcast msg table을 refresh 하는 부분
추가