### PR TITLE
 # FIX - save self-info & latest chain/world

### DIFF
--- a/src/plugins/admin_plugin/rpc_services/include/rpc_services.hpp
+++ b/src/plugins/admin_plugin/rpc_services/include/rpc_services.hpp
@@ -86,6 +86,8 @@ private:
   bool isAlreadySetup(Chain &chain);
   optional<nlohmann::json> waitForUserKeyInfo();
 
+  bool saveSelfInfo(Chain &chain, const string &enc_sk, const string &cert);
+
   string default_setup_port;
 };
 

--- a/src/plugins/chain_plugin/kv_store.cpp
+++ b/src/plugins/chain_plugin/kv_store.cpp
@@ -40,11 +40,17 @@ bool KvController::errorOnCritical(const leveldb::Status &status) {
 
 bool KvController::saveLatestWorldId(const alphanumeric_type &world_id) {
   addBatch(DataType::WORLD, "latest_world_id", world_id);
+
+  commitBatchAll();
+
   return true;
 }
 
 bool KvController::saveLatestChainId(const alphanumeric_type &chain_id) {
   addBatch(DataType::CHAIN, "latest_chain_id", chain_id);
+
+  commitBatchAll();
+
   return true;
 }
 


### PR DESCRIPTION
 #### 수정사항

- saveLatestChainId / saveLatestWorldId 에서 addBatch() 만 호출하고,
commit하지 않아서 db에 저장되지 않았었던 부분 수정

- AdminService Setup 에서 `self_info.id` 에 값을 넣기 전에 save하여 id
값이 db에 저장되지 않았던부분 수정
  - saveSelfInfo() 함수를 만들어 해당 부분 처리하도록 함.
  - exception 발생할 수 있는 부분 처리하도록 수정
