### PR TITLE
 # FIX - fix checkEntry() in MessageValidator

### DIFF
--- a/src/plugins/net_plugin/rpc_services/rpc_services.cpp
+++ b/src/plugins/net_plugin/rpc_services/rpc_services.cpp
@@ -57,9 +57,9 @@ private:
   template <typename T>
   bool checkEntry(const string &key, T &val) {
     auto entry_type = getEntryType(key);
-    if (is_same<string, T>::value)
+    if (val.is_string())
       return validateEntry(entry_type, val);
-    else if (is_same<bool, T>::value)
+    else if (val.is_boolean())
       return true;
     return false;
   }


### PR DESCRIPTION
 #### 문제점
- 기존에 checkEntry() 에서 `T` 의 type을 확인할때, 
std::is_same<string,T> std::is_same<bool, T> 으로 하였으나, `T`가 json type 이기때문에
제대로 검사가 되지 않는 문제점이 있었음

 #### 해결
- val.is_string(), val.is_boolean() 을 활용하게 확인하도록 수정