### PR TITLE
 # FIX - MSG_RESPONSE1 schema / pack msg cbor / Login command

### DIFF
--- a/src/plugins/net_plugin/include/message_packer.hpp
+++ b/src/plugins/net_plugin/include/message_packer.hpp
@@ -25,9 +25,7 @@ public:
 
 private:
   static string pack(OutNetMsg &out_msg) {
-    string json_dump = out_msg.body.dump();
-
-    auto vec_body = nlohmann::json::to_cbor(json_dump);
+    auto vec_body = nlohmann::json::to_cbor(out_msg.body);
     string serialized_body(vec_body.begin(), vec_body.end());
     string header = makeHeader(serialized_body.size(), out_msg.type, SerializationAlgorithmType::CBOR);
 

--- a/src/plugins/net_plugin/include/msg_schema.hpp
+++ b/src/plugins/net_plugin/include/msg_schema.hpp
@@ -480,7 +480,7 @@ static SchemaMap schema_map = {{MessageType::MSG_PING,
     "time": {
       "type": "string"
     },
-     "sn": {
+     "un": {
       "type": "string"
     },
     "dh": {
@@ -520,7 +520,7 @@ static SchemaMap schema_map = {{MessageType::MSG_PING,
   },
   "required": [
     "time",
-    "sn",
+    "un",
     "dh",
     "user"
   ]

--- a/src/plugins/net_plugin/net_plugin.cpp
+++ b/src/plugins/net_plugin/net_plugin.cpp
@@ -380,10 +380,8 @@ public:
 
     switch (control_type) {
     case ControlType::LOGIN: {
-      if (!app().isUserSignedIn()) {
-        app().completeUserSignedIn();
-        user_pool_manager->setSelfKeyInfo(control_info);
-      }
+      user_pool_manager->setSelfKeyInfo(control_info);
+
       break;
     }
     case ControlType::LOAD_CHAIN: {


### PR DESCRIPTION
- MSG_RESPONSE1 json schema 수정 ( sn -> un )
- pack msg 시 cbor로 serialize 시키는 과정에서 json object를 넘겨줘야
했으나, json object를 dump 한 string을 넘겨줘서 문제 발생 json object를
넘겨주도록 수정

- Login command를 net에서 받았을때,userpool에 selfKey를 setting 해야하는데,
app에서 이미 setkey가 되어있을때, 하지 않는 조건문때문에 userpool에
key를 setting 하지 않는 문제가 있었음.
 (조건문 삭제. 및 app().compleUserSignIn() 삭제  
 app().completeUserSignIn은  AdminService의 Login Service에서 이미 호출 되도록 되어있음 )