### PR TITLE
Fix/result query

### DIFF
--- a/src/plugins/chain_plugin/config/storage_type.hpp
+++ b/src/plugins/chain_plugin/config/storage_type.hpp
@@ -40,6 +40,8 @@ struct DataType {
   inline static const string SELF_INFO = "self_info";
 };
 
+enum class UniqueCheck : int { NO_VALUE = -1, NOT_UNIQUE = -2 };
+
 using string = std::string;
 using bytes = std::vector<uint8_t>;
 using hash_t = std::vector<uint8_t>;

--- a/src/plugins/chain_plugin/include/chain.hpp
+++ b/src/plugins/chain_plugin/include/chain.hpp
@@ -45,8 +45,6 @@ public:
   bool applyUserAttributeToRDB(const map<base58_type, user_attribute_type> &user_attribute_list);
   bool applyUserCertToRDB(const map<base58_type, user_cert_type> &user_cert_list);
   bool applyContractToRDB(const map<base58_type, contract_type> &contract_list);
-  bool findUserFromRDB(const string &key, user_ledger_type &user_ledger);
-  bool findContractFromRDB(const string &key, contract_ledger_type &contract_ledger);
 
   // KV functions
   void saveLatestWorldId(const alphanumeric_type &world_id);
@@ -81,10 +79,9 @@ public:
   bool queryTradeVal(UnresolvedBlock &UR_block, nlohmann::json &option, result_query_info_type &result_info);
   bool queryRunQuery(UnresolvedBlock &UR_block, nlohmann::json &option, result_query_info_type &result_info);
   bool queryRunContract(UnresolvedBlock &UR_block, nlohmann::json &option, result_query_info_type &result_info);
-  base58_type setUserScopePid(optional<string> &pid, string &var_name, int var_type, string &var_owner);
-  contract_id_type setContractScopePid(optional<string> &pid, string &var_name, int var_type, string &var_owner);
-  int getVarType(const string &var_owner, const string &var_name);
-  bool checkUniqueVarName(const string &var_owner, const string &var_name);
+  string calculatePid(optional<string> &pid, string &var_name, int var_type, string &var_owner, const block_height_type height, const int vec_idx);
+  int getVarType(const string &var_owner, const string &var_name, const block_height_type height, const int vec_idx);
+  bool checkUniqueVarName(const string &var_owner, const string &var_name, const block_height_type height, const int vec_idx);
 
   block_push_result_type pushBlock(Block &block);
   UnresolvedBlock findBlock(const base58_type &block_id, const block_height_type block_height);

--- a/src/plugins/chain_plugin/include/chain.hpp
+++ b/src/plugins/chain_plugin/include/chain.hpp
@@ -81,8 +81,7 @@ public:
   bool queryRunContract(UnresolvedBlock &UR_block, nlohmann::json &option, result_query_info_type &result_info);
   string calculatePid(optional<string> &pid, string &var_name, int var_type, string &var_owner, const block_height_type height,
                       const int vec_idx);
-  string calculatePid(optional<string> &pid, string &var_name, int var_type, string &var_owner, string &tag_varInfo,
-                      const block_height_type height, const int vec_idx);
+  string calculatePid(optional<string> &pid, string &var_name, int var_type, string &var_owner, string &tag_varInfo);
   int getVarType(const string &var_owner, const string &var_name, const block_height_type height, const int vec_idx);
   bool checkUniqueVarName(const string &var_owner, const string &var_name, const block_height_type height, const int vec_idx);
 

--- a/src/plugins/chain_plugin/include/chain.hpp
+++ b/src/plugins/chain_plugin/include/chain.hpp
@@ -45,10 +45,8 @@ public:
   bool applyUserAttributeToRDB(const map<base58_type, user_attribute_type> &user_attribute_list);
   bool applyUserCertToRDB(const map<base58_type, user_cert_type> &user_cert_list);
   bool applyContractToRDB(const map<base58_type, contract_type> &contract_list);
-
-  bool findUserFromRDB(string key, user_ledger_type &user_ledger);
-  bool findContractFromRDB(string key, contract_ledger_type &contract_ledger);
-  int getVarType(string &key);
+  bool findUserFromRDB(const string &key, user_ledger_type &user_ledger);
+  bool findContractFromRDB(const string &key, contract_ledger_type &contract_ledger);
 
   // KV functions
   void saveLatestWorldId(const alphanumeric_type &world_id);
@@ -83,15 +81,19 @@ public:
   bool queryTradeVal(UnresolvedBlock &UR_block, nlohmann::json &option, result_query_info_type &result_info);
   bool queryRunQuery(UnresolvedBlock &UR_block, nlohmann::json &option, result_query_info_type &result_info);
   bool queryRunContract(UnresolvedBlock &UR_block, nlohmann::json &option, result_query_info_type &result_info);
-  string pidCheck(optional<string> pid, string var_name, int var_type, string var_owner);
-  search_result_type findUserLedgerFromPoint(string key, block_height_type height, int vec_idx);
-  search_result_type findContractLedgerFromPoint(string key, block_height_type height, int vec_idx);
+  base58_type setUserScopePid(optional<string> &pid, string &var_name, int var_type, string &var_owner);
+  contract_id_type setContractScopePid(optional<string> &pid, string &var_name, int var_type, string &var_owner);
+  int getVarType(const string &var_owner, const string &var_name);
+  bool checkUniqueVarName(const string &var_owner, const string &var_name);
 
   block_push_result_type pushBlock(Block &block);
   UnresolvedBlock findBlock(const base58_type &block_id, const block_height_type block_height);
   bool resolveBlock(Block &block, UnresolvedBlock &resolved_result);
   void setPool(const base64_type &last_block_id, block_height_type last_height, timestamp_t last_time, const base64_type &last_hash,
                const base64_type &prev_block_id);
+
+  search_result_type findUserLedgerFromPoint(const string &pid, block_height_type height, int vec_idx);
+  search_result_type findContractLedgerFromPoint(const string &pid, block_height_type height, int vec_idx);
 
   // State tree
 private:
@@ -107,8 +109,8 @@ public:
   void updateStateTree(const UnresolvedBlock &unresolved_block);
   void revertStateTree(const UnresolvedBlock &unresolved_block);
 
-  user_ledger_type findUserLedgerFromHead(string key);
-  contract_ledger_type findContractLedgerFromHead(string key);
+  user_ledger_type findUserLedgerFromHead(const string &pid);
+  contract_ledger_type findContractLedgerFromHead(const string &pid);
   void moveHead(const base58_type &target_block_id, const block_height_type target_block_height);
   base58_type getCurrentHeadId();
   block_height_type getCurrentHeadHeight();

--- a/src/plugins/chain_plugin/include/chain.hpp
+++ b/src/plugins/chain_plugin/include/chain.hpp
@@ -79,7 +79,10 @@ public:
   bool queryTradeVal(UnresolvedBlock &UR_block, nlohmann::json &option, result_query_info_type &result_info);
   bool queryRunQuery(UnresolvedBlock &UR_block, nlohmann::json &option, result_query_info_type &result_info);
   bool queryRunContract(UnresolvedBlock &UR_block, nlohmann::json &option, result_query_info_type &result_info);
-  string calculatePid(optional<string> &pid, string &var_name, int var_type, string &var_owner, const block_height_type height, const int vec_idx);
+  string calculatePid(optional<string> &pid, string &var_name, int var_type, string &var_owner, const block_height_type height,
+                      const int vec_idx);
+  string calculatePid(optional<string> &pid, string &var_name, int var_type, string &var_owner, string &tag_varInfo,
+                      const block_height_type height, const int vec_idx);
   int getVarType(const string &var_owner, const string &var_name, const block_height_type height, const int vec_idx);
   bool checkUniqueVarName(const string &var_owner, const string &var_name, const block_height_type height, const int vec_idx);
 

--- a/src/plugins/chain_plugin/include/mem_ledger.hpp
+++ b/src/plugins/chain_plugin/include/mem_ledger.hpp
@@ -109,9 +109,9 @@ public:
   template <typename T>
   void insertNode(const T &ledger);   // TODO: user_ledger_type과 contract_ledger_type 두 가지로 template를 제한
   void modifyNode(shared_ptr<StateNode> old_node, shared_ptr<StateNode> new_node);
-  void removeNode(string &pid);
-  shared_ptr<StateNode> getMerkleNode(string &pid);
-  vector<vector<uint8_t>> getSiblings(string &pid);
+  void removeNode(const string &pid);
+  shared_ptr<StateNode> getMerkleNode(const string &pid);
+  vector<vector<uint8_t>> getSiblings(const string &pid);
 
   void printTreePostOrder();
 

--- a/src/plugins/chain_plugin/include/rdb_controller.hpp
+++ b/src/plugins/chain_plugin/include/rdb_controller.hpp
@@ -39,15 +39,16 @@ public:
   Block getBlock(const string &condition);
   string getUserCert(const base58_type &user_id);
 
-//  bool queryRunQuery(std::vector<LedgerRecord> &mem_ledger, nlohmann::json &option, result_query_info_type &result_info);
-//  bool queryRunContract(std::vector<LedgerRecord> &mem_ledger, nlohmann::json &option, result_query_info_type &result_info);
+  //  bool queryRunQuery(std::vector<LedgerRecord> &mem_ledger, nlohmann::json &option, result_query_info_type &result_info);
+  //  bool queryRunContract(std::vector<LedgerRecord> &mem_ledger, nlohmann::json &option, result_query_info_type &result_info);
 
-  bool checkUnique(const string &pid);
-  bool findUserFromRDB(string pid, user_ledger_type &user_ledger);
-  bool findContractFromRDB(string pid, contract_ledger_type &contract_ledger);
+  bool checkUniqueVarNameFromRDB(const string &var_owner, const string &var_name);
+  bool findUserFromRDB(const string &pid, user_ledger_type &user_ledger);
+  bool findContractFromRDB(const string &pid, contract_ledger_type &contract_ledger);
+  int getVarTypeFromRDB(const string &pid);
+
   vector<user_ledger_type> getAllUserLedger();
   vector<contract_ledger_type> getAllContractLedger();
-  int getVarType(string &key);
 };
 } // namespace tethys
 #endif

--- a/src/plugins/chain_plugin/include/rdb_controller.hpp
+++ b/src/plugins/chain_plugin/include/rdb_controller.hpp
@@ -43,7 +43,6 @@ public:
   //  bool queryRunContract(std::vector<LedgerRecord> &mem_ledger, nlohmann::json &option, result_query_info_type &result_info);
 
   int getVarTypeFromRDB(const string &var_owner, const string &var_name);
-  int checkUniqueVarNameFromRDB(const string &var_owner, const string &var_name);
   bool findUserScopeFromRDB(const string &pid, user_ledger_type &user_ledger);
   bool findContractScopeFromRDB(const string &pid, contract_ledger_type &contract_ledger);
 

--- a/src/plugins/chain_plugin/include/rdb_controller.hpp
+++ b/src/plugins/chain_plugin/include/rdb_controller.hpp
@@ -42,10 +42,10 @@ public:
   //  bool queryRunQuery(std::vector<LedgerRecord> &mem_ledger, nlohmann::json &option, result_query_info_type &result_info);
   //  bool queryRunContract(std::vector<LedgerRecord> &mem_ledger, nlohmann::json &option, result_query_info_type &result_info);
 
-  bool checkUniqueVarNameFromRDB(const string &var_owner, const string &var_name);
-  bool findUserFromRDB(const string &pid, user_ledger_type &user_ledger);
-  bool findContractFromRDB(const string &pid, contract_ledger_type &contract_ledger);
-  int getVarTypeFromRDB(const string &pid);
+  int getVarTypeFromRDB(const string &var_owner, const string &var_name);
+  int checkUniqueVarNameFromRDB(const string &var_owner, const string &var_name);
+  bool findUserScopeFromRDB(const string &pid, user_ledger_type &user_ledger);
+  bool findContractScopeFromRDB(const string &pid, contract_ledger_type &contract_ledger);
 
   vector<user_ledger_type> getAllUserLedger();
   vector<contract_ledger_type> getAllContractLedger();

--- a/src/plugins/chain_plugin/mem_ledger.cpp
+++ b/src/plugins/chain_plugin/mem_ledger.cpp
@@ -445,7 +445,7 @@ void StateTree::modifyNode(shared_ptr<StateNode> old_node, shared_ptr<StateNode>
   }
 }
 
-void StateTree::removeNode(string &pid) {
+void StateTree::removeNode(const string &pid) {
   shared_ptr<StateNode> node;
   shared_ptr<StateNode> parent, left, right;
 
@@ -502,7 +502,7 @@ void StateTree::removeNode(string &pid) {
   --m_size;
 }
 
-shared_ptr<StateNode> StateTree::getMerkleNode(string &pid) {
+shared_ptr<StateNode> StateTree::getMerkleNode(const string &pid) {
   shared_ptr<StateNode> ret = nullptr;
   path_type path = ret->calPathFromPid(pid);
 
@@ -533,7 +533,7 @@ shared_ptr<StateNode> StateTree::getMerkleNode(string &pid) {
   return ret;
 }
 
-vector<vector<uint8_t>> StateTree::getSiblings(string &pid) {
+vector<vector<uint8_t>> StateTree::getSiblings(const string &pid) {
   shared_ptr<StateNode> node = getMerkleNode(pid);
 
   vector<vector<uint8_t>> siblings;

--- a/src/plugins/chain_plugin/rdb_controller.cpp
+++ b/src/plugins/chain_plugin/rdb_controller.cpp
@@ -431,11 +431,6 @@ int RdbController::getVarTypeFromRDB(const string &var_owner, const string &var_
   }
 }
 
-int RdbController::checkUniqueVarNameFromRDB(const string &var_owner, const string &var_name) {
-  // 위 함수와 같은 동작을 하는데, 함수 명에서 혼동이 있을 수 있을 것 같아서 별개로 선언
-  return getVarTypeFromRDB(var_owner, var_name);
-}
-
 bool RdbController::findUserScopeFromRDB(const string &pid, user_ledger_type &user_ledger) {
   try {
     string var_name, var_value, var_owner, tag, pid;


### PR DESCRIPTION
### 주요 변경 내용
1. findUserScopeFromeRDB, findContractScopeFromRDB의 chain에서의
wrapper를 삭제하였습니다. chain.cpp 외부에서 사용하지 않는 함수이므로
굳이 유지할 필요가 없습니다.

2. setUserScopePid, setContractScopePid를 calculatePid로 통합하였습니다.
다만, tag/var_info가 존재할 때의 처리를 아직 덜 고려해서 이 함수는 추후
수정될 수 있습니다.

3. queryUserScope를 전반적으로 수정하였습니다.
생성할 때만 var_type이 주어지며, 그로 인하여 기존의 수정일 때는
var_type을 찾는 연산이 필요합니다.
이런 분기 사항들을 고려하지 않고 뼈대만 만들어두고 올려뒀는데, 설계상의
구현에 가깝게 수정하였습니다.

4. 위의 함수에 사용되는 getVarType과, 기타 다른 쿼리 처리에서도 사용되는
scope에서의 var_owner와 var_name의 unique함을 체크하는 함수를
구현하였습니다.
두 함수는 var_owner와 var_name을 가지고 var_type이 여러 개 존재하지
않는지를 체크하는 행동은 똑같이 수행하며, 단지 getVarType는 결과로써
true/false가 아니라 얻어낸 var_type 정보를 리턴하는 것이므로 두 함수를
통일해서 구현했습니다. 다만, 쓰이는 장소와 상황이 다르므로 함수명은 따로
구현하여 처리할 때 혼동이 없도록 하였습니다.

TODO : queryUserScope 외에도 Contract와 특히 transfer를 고쳐야 합니다.