### PR TITLE
# Fix - result query

### DIFF
--- a/src/plugins/chain_plugin/config/storage_type.hpp
+++ b/src/plugins/chain_plugin/config/storage_type.hpp
@@ -7,7 +7,6 @@
 #include <map>
 #include <string>
 #include <vector>
-#include "../../../contract/include/types.hpp"
 
 using namespace std;
 
@@ -46,6 +45,7 @@ using string = std::string;
 using bytes = std::vector<uint8_t>;
 using hash_t = std::vector<uint8_t>;
 using timestamp_t = uint64_t;
+using block_height_type = uint64_t;
 
 constexpr auto TRANSACTION_ID_TYPE_SIZE = 32;
 constexpr auto ALPHANUMERIC_ID_TYPE_SIZE = 8;
@@ -169,7 +169,8 @@ using user_ledger_type = struct UserLedger {
   bool is_empty{false};
 
   UserLedger() = default;
-  UserLedger(string var_name_, int var_type_, base58_type uid_, string tag_) : var_name(var_name_), var_type(var_type_), uid(uid_), tag(tag_) {
+  UserLedger(string var_name_, int var_type_, base58_type uid_, string tag_)
+      : var_name(var_name_), var_type(var_type_), uid(uid_), tag(tag_) {
     BytesBuilder bytes_builder;
     bytes_builder.append(var_name);
     bytes_builder.appendDec(var_type);

--- a/src/plugins/chain_plugin/config/storage_type.hpp
+++ b/src/plugins/chain_plugin/config/storage_type.hpp
@@ -169,7 +169,7 @@ using user_ledger_type = struct UserLedger {
   bool is_empty{false};
 
   UserLedger() = default;
-  UserLedger(string var_name_, int var_type_, string uid_, string tag_) : var_name(var_name_), var_type(var_type_), uid(uid_), tag(tag_) {
+  UserLedger(string var_name_, int var_type_, base58_type uid_, string tag_) : var_name(var_name_), var_type(var_type_), uid(uid_), tag(tag_) {
     BytesBuilder bytes_builder;
     bytes_builder.append(var_name);
     bytes_builder.appendDec(var_type);

--- a/src/plugins/chain_plugin/include/chain.hpp
+++ b/src/plugins/chain_plugin/include/chain.hpp
@@ -79,7 +79,8 @@ public:
   bool queryTradeVal(UnresolvedBlock &UR_block, nlohmann::json &option, result_query_info_type &result_info);
   bool queryRunQuery(UnresolvedBlock &UR_block, nlohmann::json &option, result_query_info_type &result_info);
   bool queryRunContract(UnresolvedBlock &UR_block, nlohmann::json &option, result_query_info_type &result_info);
-  string calculatePid(string &var_name, int var_type, string &var_owner);
+  string calculatePid(const string &var_name, int var_type, const string &var_owner);
+  string calculatePid(const string &var_name, int var_type, const string &var_owner, const string &tag_varinfo);
   int getVarType(const string &var_owner, const string &var_name, const block_height_type height, const int vec_idx);
   bool checkUniqueVarName(const string &var_owner, const string &var_name, const block_height_type height, const int vec_idx);
 

--- a/src/plugins/chain_plugin/include/chain.hpp
+++ b/src/plugins/chain_plugin/include/chain.hpp
@@ -94,6 +94,9 @@ public:
   search_result_type findUserLedgerFromPoint(const string &pid, block_height_type height, int vec_idx);
   search_result_type findContractLedgerFromPoint(const string &pid, block_height_type height, int vec_idx);
 
+  bool isUserId(const string &id);
+  bool isContractId(const string &id);
+
   // State tree
 private:
   StateTree m_us_tree; // user scope state tree

--- a/src/plugins/chain_plugin/include/chain.hpp
+++ b/src/plugins/chain_plugin/include/chain.hpp
@@ -79,9 +79,7 @@ public:
   bool queryTradeVal(UnresolvedBlock &UR_block, nlohmann::json &option, result_query_info_type &result_info);
   bool queryRunQuery(UnresolvedBlock &UR_block, nlohmann::json &option, result_query_info_type &result_info);
   bool queryRunContract(UnresolvedBlock &UR_block, nlohmann::json &option, result_query_info_type &result_info);
-  string calculatePid(optional<string> &pid, string &var_name, int var_type, string &var_owner, const block_height_type height,
-                      const int vec_idx);
-  string calculatePid(optional<string> &pid, string &var_name, int var_type, string &var_owner, string &tag_varInfo);
+  string calculatePid(string &var_name, int var_type, string &var_owner);
   int getVarType(const string &var_owner, const string &var_name, const block_height_type height, const int vec_idx);
   bool checkUniqueVarName(const string &var_owner, const string &var_name, const block_height_type height, const int vec_idx);
 

--- a/src/plugins/chain_plugin/include/rdb_controller.hpp
+++ b/src/plugins/chain_plugin/include/rdb_controller.hpp
@@ -23,6 +23,8 @@ private:
   soci::connection_pool m_db_pool;
 
   Block rowToBlock(const soci::row &r);
+  bool isUserId(const string &id);
+  bool isContractId(const string &id);
 
 public:
   RdbController(string_view dbms, string_view table_name, string_view db_user_id, string_view db_password);

--- a/src/plugins/chain_plugin/rdb_controller.cpp
+++ b/src/plugins/chain_plugin/rdb_controller.cpp
@@ -407,9 +407,9 @@ int RdbController::getVarTypeFromRDB(const string &var_owner, const string &var_
 
     // clang-format off
     if(isUserId(var_owner))
-      st = (db_session.prepare << "SELECT var_type from user_scope WHERE var_owner = :var_owner AND var_name = :var_name", soci::use(var_owner, "var_owner"), soci::use(var_name, "var_name"), soci::into(result));
+      st = (db_session.prepare << "SELECT var_type from user_scope WHERE var_owner = :var_owner AND var_name = :var_name AND tag is NULL", soci::use(var_owner, "var_owner"), soci::use(var_name, "var_name"), soci::into(result));
     else if(isContractId(var_owner))
-      st = (db_session.prepare << "SELECT var_type from contract_scope WHERE contract_id = :contract_id AND var_name = :var_name", soci::use(var_owner, "contract_id"), soci::use(var_name, "var_name"), soci::into(result));
+      st = (db_session.prepare << "SELECT var_type from contract_scope WHERE contract_id = :contract_id AND var_name = :var_name AND var_info is NULL", soci::use(var_owner, "contract_id"), soci::use(var_name, "var_name"), soci::into(result));
     // clang-format on
     st.execute(true);
 

--- a/src/plugins/chain_plugin/rdb_controller.cpp
+++ b/src/plugins/chain_plugin/rdb_controller.cpp
@@ -1,6 +1,7 @@
 #include "include/rdb_controller.hpp"
 #include "../../../lib/tethys-utils/src/ags.hpp"
 #include "mysql/soci-mysql.h"
+#include <regex>
 
 using namespace std;
 
@@ -405,9 +406,9 @@ int RdbController::getVarTypeFromRDB(const string &var_owner, const string &var_
     soci::statement st(db_session);
 
     // clang-format off
-    if(var_owner.size() > 45)
+    if(isUserId(var_owner))
       st = (db_session.prepare << "SELECT var_type from user_scope WHERE var_owner = :var_owner AND var_name = :var_name", soci::use(var_owner, "var_owner"), soci::use(var_name, "var_name"), soci::into(result));
-    else
+    else if(isContractId(var_owner))
       st = (db_session.prepare << "SELECT var_type from contract_scope WHERE contract_id = :contract_id AND var_name = :var_name", soci::use(var_owner, "contract_id"), soci::use(var_name, "var_name"), soci::into(result));
     // clang-format on
     st.execute(true);
@@ -573,6 +574,24 @@ vector<contract_ledger_type> RdbController::getAllContractLedger() {
     return contract_ledger_list;
   }
   return contract_ledger_list;
+}
+
+bool RdbController::isUserId(const string &id) {
+  const auto BASE58_REGEX = "^[A-HJ-NP-Za-km-z1-9]*$";
+  regex rgx(BASE58_REGEX);
+  if (id.size() != static_cast<int>(44) || !regex_match(id, rgx)) {
+    logger::ERROR("Invalid user ID.");
+    return false;
+  }
+  return true;
+}
+
+bool RdbController::isContractId(const string &id) {
+  // TODO: 검증 추가
+  if (id.size() > 45)
+    return true;
+  else
+    return false;
 }
 
 } // namespace tethys


### PR DESCRIPTION
더 자세한 커밋의 변경사항은 커밋 메시지로 남겨져 있습니다.

### 주요 변경 사항
1. 주어진 id가 user id 인지 contract id인지 구분하는 함수를 추가하였습니다.
contract id의 validation은 추후 추가해야 할 것 같습니다.

2. pid와 tag의 관계를 다시 정확히 이해하고 코드를 리팩토링했습니다.
[관련해서 간략히 confluence에 정리하면서 쓴 내용 링크](https://thevaulters.atlassian.net/wiki/spaces/~3901937/pages/113246218/chain.cpp+getVarType)
queryUserScope 와 queryContractScope는 pid의 존재 여부로 큰 동작의 분기가 갈라지게 됩니다.
따라서 calculatePid 내부에서 pid의 존재에 대해 검증할 필요가 없어졌고, 함수 이름대로의 동작인 pid 계산에만 충실하게 되었습니다. 인자가 세 개일 때의 함수와 네 개일 때의 함수가 있습니다. (tag의 존재 유무)

3. getVarType가 위에서 말한 pid의 존재 여부에 따라 검토해보니, pid가 없을 때만 해당 함수가 필요하여 호출됩니다. 따라서 getVarType의 동작에 tag가 없는 것만을 가져오도록 조건을 추가하였습니다.

4. queryTransfer에서 from의 pid와 to의 pid가 당연히 다르다는 사실을 놓치고 코드를 짜서, to쪽의 코드를 수정하였습니다.

5. checkUniqueVarName, 인자가 네 개인 각 ledger_type의 생성자(구조체를 선언할 때 pid를 계산하여 초기화할 때 쓰였습니다)가 더이상 쓰이는 곳이 없어졌습니다. 우선은 뒀다가, 추후 구현에서도 사용될 일이 없다고 판단되면 그 때 삭제하겠습니다.