### PR TITLE
 # FIX - result query, rdb

### DIFF
--- a/src/plugins/chain_plugin/chain.cpp
+++ b/src/plugins/chain_plugin/chain.cpp
@@ -1053,17 +1053,29 @@ void Chain::revertStateTree(const UnresolvedBlock &unresolved_block) {
 }
 
 user_ledger_type Chain::findUserLedgerFromHead(UnresolvedBlock &UR_block, const string &pid) {
-  if (m_us_tree.getMerkleNode(pid) == nullptr)
-    return UR_block.user_ledger_list[pid];
-  else
-    return m_us_tree.getMerkleNode(pid)->getUserLedger();
+  user_ledger_type return_ledger;
+  return_ledger = UR_block.user_ledger_list[pid];
+
+  if (return_ledger.is_empty) {
+    shared_ptr<StateNode> node = m_us_tree.getMerkleNode(pid);
+    if (node == nullptr)
+      return return_ledger;
+    else
+      return node->getUserLedger();
+  }
 }
 
 contract_ledger_type Chain::findContractLedgerFromHead(UnresolvedBlock &UR_block, const string &pid) {
-  if (m_cs_tree.getMerkleNode(pid) == nullptr)
-    return UR_block.contract_ledger_list[pid];
-  else
-    return m_cs_tree.getMerkleNode(pid)->getContractLedger();
+  contract_ledger_type return_ledger;
+  return_ledger = UR_block.contract_ledger_list[pid];
+
+  if (return_ledger.is_empty) {
+    shared_ptr<StateNode> node = m_cs_tree.getMerkleNode(pid);
+    if (node == nullptr)
+      return return_ledger;
+    else
+      return node->getContractLedger();
+  }
 }
 
 void Chain::moveHead(const base58_type &target_block_id, const block_height_type target_block_height) {

--- a/src/plugins/chain_plugin/chain.cpp
+++ b/src/plugins/chain_plugin/chain.cpp
@@ -243,7 +243,7 @@ void Chain::restorePool() {
     restored_block.initialize(block_msg);
     block_push_result_type push_result = unresolved_block_pool->pushBlock(restored_block);
 
-    UnresolvedBlock restored_unresolved_block = unresolved_block_pool->findBlock(restored_block.getBlockId(), push_result.height);
+    UnresolvedBlock restored_unresolved_block = unresolved_block_pool->getUnresolvedBlock(restored_block.getBlockId(), push_result.height);
 
     nlohmann::json user_ledger_list_json = nlohmann::json::from_cbor(kv_controller->loadBackupUserLedgers(block_id));
     nlohmann::json contract_ledger_list_json = nlohmann::json::from_cbor(kv_controller->loadBackupContractLedgers(block_id));
@@ -927,8 +927,12 @@ block_push_result_type Chain::pushBlock(Block &block) {
   return unresolved_block_pool->pushBlock(block);
 }
 
-UnresolvedBlock Chain::findBlock(const base58_type &block_id, const block_height_type block_height) {
-  return unresolved_block_pool->findBlock(block_id, block_height);
+UnresolvedBlock Chain::getUnresolvedBlock(const base58_type &block_id, const block_height_type block_height) {
+  return unresolved_block_pool->getUnresolvedBlock(block_id, block_height);
+}
+
+void Chain::setUnresolvedBlock(const UnresolvedBlock &unresolved_block) {
+  unresolved_block_pool->setUnresolvedBlock(unresolved_block);
 }
 
 bool Chain::resolveBlock(Block &block, UnresolvedBlock &resolved_result) {

--- a/src/plugins/chain_plugin/chain_plugin.cpp
+++ b/src/plugins/chain_plugin/chain_plugin.cpp
@@ -233,7 +233,7 @@ public:
     base58_type block_id = json::get<string>(result["block"], "id").value();
     block_height_type block_height = static_cast<block_height_type>(stoi(json::get<string>(result["block"], "height").value()));
     // TODO: updated_UR_block로 갱신한 값이 unresolved block pool에 직접 반영되는 부분이 없음. 수정 필요
-    UnresolvedBlock updated_UR_block = chain->findBlock(block_id, block_height);
+    UnresolvedBlock updated_UR_block = chain->getUnresolvedBlock(block_id, block_height);
 
     if (updated_UR_block.block.getBlockId() != chain->getCurrentHeadId()) {
       chain->moveHead(updated_UR_block.block.getPrevBlockId(), updated_UR_block.block.getHeight() - 1);
@@ -294,7 +294,7 @@ public:
         }
       }
     }
-
+    chain->setUnresolvedBlock(updated_UR_block);
     chain->updateStateTree(updated_UR_block);
     chain->saveBackupResult(updated_UR_block);
   }

--- a/src/plugins/chain_plugin/chain_plugin.cpp
+++ b/src/plugins/chain_plugin/chain_plugin.cpp
@@ -232,6 +232,7 @@ public:
     // TODO: state tree lock 필요. head가 달라지면서 state tree가 반영되면 정확한 값이 아니게 될 수 있다
     base58_type block_id = json::get<string>(result["block"], "id").value();
     block_height_type block_height = static_cast<block_height_type>(stoi(json::get<string>(result["block"], "height").value()));
+    // TODO: updated_UR_block로 갱신한 값이 unresolved block pool에 직접 반영되는 부분이 없음. 수정 필요
     UnresolvedBlock updated_UR_block = chain->findBlock(block_id, block_height);
 
     if (updated_UR_block.block.getBlockId() != chain->getCurrentHeadId()) {

--- a/src/plugins/chain_plugin/config/storage_type.hpp
+++ b/src/plugins/chain_plugin/config/storage_type.hpp
@@ -166,7 +166,7 @@ using user_ledger_type = struct UserLedger {
   string tag;
   string pid;
   QueryType query_type;
-  bool is_empty{false};
+  bool is_empty{true};
 
   UserLedger() = default;
   UserLedger(string var_name_, int var_type_, base58_type uid_, string tag_)
@@ -184,13 +184,13 @@ using contract_ledger_type = struct ContractLedger {
   string var_name;
   string var_val;
   int var_type;
-  string cid;
+  contract_id_type cid;
   timestamp_t up_time;
   block_height_type up_block;
   string var_info;
   string pid;
   QueryType query_type;
-  bool is_empty{false};
+  bool is_empty{true};
 
   ContractLedger() = default;
   ContractLedger(string var_name_, int var_type_, string cid_, string var_info_)
@@ -239,6 +239,7 @@ using contract_type = struct Contract {
   string contract;
   string desc;
   string sigma;
+  QueryType query_type;
 };
 
 // using which_type = struct WhichData {

--- a/src/plugins/chain_plugin/include/chain.hpp
+++ b/src/plugins/chain_plugin/include/chain.hpp
@@ -110,8 +110,8 @@ public:
   void updateStateTree(const UnresolvedBlock &unresolved_block);
   void revertStateTree(const UnresolvedBlock &unresolved_block);
 
-  user_ledger_type findUserLedgerFromHead(const string &pid);
-  contract_ledger_type findContractLedgerFromHead(const string &pid);
+  user_ledger_type findUserLedgerFromHead(UnresolvedBlock &UR_block, const string &pid);
+  contract_ledger_type findContractLedgerFromHead(UnresolvedBlock &UR_block, const string &pid);
   void moveHead(const base58_type &target_block_id, const block_height_type target_block_height);
   base58_type getCurrentHeadId();
   block_height_type getCurrentHeadHeight();

--- a/src/plugins/chain_plugin/include/chain.hpp
+++ b/src/plugins/chain_plugin/include/chain.hpp
@@ -85,7 +85,8 @@ public:
   bool checkUniqueVarName(const string &var_owner, const string &var_name, const block_height_type height, const int vec_idx);
 
   block_push_result_type pushBlock(Block &block);
-  UnresolvedBlock findBlock(const base58_type &block_id, const block_height_type block_height);
+  UnresolvedBlock getUnresolvedBlock(const base58_type &block_id, const block_height_type block_height);
+  void setUnresolvedBlock(const UnresolvedBlock &unresolved_block);
   bool resolveBlock(Block &block, UnresolvedBlock &resolved_result);
   void setPool(const base64_type &last_block_id, block_height_type last_height, timestamp_t last_time, const base64_type &last_hash,
                const base64_type &prev_block_id);

--- a/src/plugins/chain_plugin/include/unresolved_block_pool.hpp
+++ b/src/plugins/chain_plugin/include/unresolved_block_pool.hpp
@@ -64,7 +64,7 @@ public:
   bool resolveBlock(Block &block, UnresolvedBlock &resolved_result, vector<base58_type> &dropped_block_id);
 
   UnresolvedBlock findBlock(const base58_type &block_id, const block_height_type block_height);
-  UnresolvedBlock getBlock(int pool_deq_idx, int pool_vec_idx);
+  UnresolvedBlock getUnresolvedBlock(int pool_deq_idx, int pool_vec_idx);
   vector<int> getLine(const base58_type &block_id, const block_height_type block_height);
 
   void invalidateCaches();

--- a/src/plugins/chain_plugin/include/unresolved_block_pool.hpp
+++ b/src/plugins/chain_plugin/include/unresolved_block_pool.hpp
@@ -63,8 +63,9 @@ public:
   block_push_result_type pushBlock(Block &block);
   bool resolveBlock(Block &block, UnresolvedBlock &resolved_result, vector<base58_type> &dropped_block_id);
 
-  UnresolvedBlock findBlock(const base58_type &block_id, const block_height_type block_height);
+  UnresolvedBlock getUnresolvedBlock(const base58_type &block_id, const block_height_type block_height);
   UnresolvedBlock getUnresolvedBlock(int pool_deq_idx, int pool_vec_idx);
+  void setUnresolvedBlock(const UnresolvedBlock &unresolved_block);
   vector<int> getLine(const base58_type &block_id, const block_height_type block_height);
 
   void invalidateCaches();

--- a/src/plugins/chain_plugin/unresolved_block_pool.cpp
+++ b/src/plugins/chain_plugin/unresolved_block_pool.cpp
@@ -225,7 +225,7 @@ void UnresolvedBlockPool::updateTotalNumSSig() {
   }
 }
 
-UnresolvedBlock UnresolvedBlockPool::findBlock(const base58_type &block_id, const block_height_type block_height) {
+UnresolvedBlock UnresolvedBlockPool::getUnresolvedBlock(const base58_type &block_id, const block_height_type block_height) {
   // TODO: Refactoring. height와 cur_vec_idx를 이용하면 순회 안 하고도 찾을 수 있음
   for (auto &each_level : m_block_pool) {
     for (auto &each_block : each_level) {
@@ -240,6 +240,13 @@ UnresolvedBlock UnresolvedBlockPool::findBlock(const base58_type &block_id, cons
 
 UnresolvedBlock UnresolvedBlockPool::getUnresolvedBlock(int pool_deq_idx, int pool_vec_idx) {
   return m_block_pool[pool_deq_idx][pool_vec_idx];
+}
+
+void UnresolvedBlockPool::setUnresolvedBlock(const UnresolvedBlock &unresolved_block) {
+  int pool_deq_idx= static_cast<int>(unresolved_block.block.getHeight() - m_latest_confirmed_height) - 1;
+  int pool_vec_idx = unresolved_block.cur_vec_idx;
+
+  m_block_pool[pool_deq_idx][pool_vec_idx] = unresolved_block;
 }
 
 vector<int> UnresolvedBlockPool::getLine(const base58_type &block_id, const block_height_type block_height) {

--- a/src/plugins/chain_plugin/unresolved_block_pool.cpp
+++ b/src/plugins/chain_plugin/unresolved_block_pool.cpp
@@ -238,7 +238,7 @@ UnresolvedBlock UnresolvedBlockPool::findBlock(const base58_type &block_id, cons
   return UnresolvedBlock{};
 }
 
-UnresolvedBlock UnresolvedBlockPool::getBlock(int pool_deq_idx, int pool_vec_idx) {
+UnresolvedBlock UnresolvedBlockPool::getUnresolvedBlock(int pool_deq_idx, int pool_vec_idx) {
   return m_block_pool[pool_deq_idx][pool_vec_idx];
 }
 


### PR DESCRIPTION
### 변경 사항
1. 현재 처리중인 블럭에 head가 위치해있을 때 state tree에서 조회하여 ledger를 바로 검색하는 함수인 findXXXLedgerFromHead 함수가 현재 처리중인 블럭을 찾지 않는다는 사실을 발견하여, 해당 과정을 추가하였습니다.
이 문제는 result의 처리값들을 바로바로 state tree에 반영하지 않고, 해당 블럭의 모든 처리를 끝낸 후 한꺼번에 반영해서 생깁니다. 자세한 사항은 맨 아래에 따로 쓰겠습니다.

2. 1의 과정에서 ledger_type의 is_empty의 기본 생성값을 true로 변경하여, ledger_list[pid] 에서 pid에 대응하는 ledger가 존재하지 않아도 빈 ledger를 생성합니다. 따라서 is_empty가 true로 생성되어 존재하지 않는다는 리턴을 줄 수 있게 하였습니다.

3. ledger에서 동일 블럭에서 insert였던 ledger를 또다시 수정할 경우 update로 바꿔버리던 문제를 해결하였습니다.
up_block을 조회하여 해당 ledger가 현 블럭에서 생성된 경우, insert를 유지하도록 합니다.

4. getBlock이 블록 자체를 접근하는지 UnresolvedBlock을 접근하는지가 애매해서 정확하게 이름을 바꿨습니다.

5. user ledger, contract ledger, user cert, user attribute, contract 테이블의 insert, update 문을 정확히 수정하였습니다.
ledger에서 insert와 update가 혼재되는 경우가 있어서 ON DUPLICATE KEY UPDATE 문을 사용할까 했는데, 중복되는 unique key가 잘못 들어왔을 경우에도 오류를 내지 않고 수정해버리는 위험성이 존재할 것 같아서 querytype으로 sql문을 분기하였습니다.
user attribute는 현재로서는 모든 사항이 다 주어져야 작동 하는 것으로 스펙이 명시되어있어서 위험성이 없다고 판단되어 ON DUPLICATE KEY UPDATE를 사용하고 있습니다. 여기 또한 문제가 된다면 추후 query type를 명시해서 분기할 예정입니다.


~~TODO : 수정하다보니 chain_plugin의 result query를 처리하는 processTxResult 함수에서 unresolved block을 수정한 후 pool에 반영하는 부분이 없는것으로 보여, 수정이 필요합니다.~~


 - #### result의 처리값들을 바로바로 state tree에 반영하지 않고, 해당 블럭의 모든 처리를 끝낸 후 한꺼번에 반영하는 문제에 대하여
 - 지금처럼 한꺼번에 처리할 경우: 한 블록에서 한 ledger에 여러 번의 변경이 있을 경우, 같은 pid에 대하여 여러 번의 state tree 갱신을 할 필요가 없습니다. 그 대신, ledger의 이전 값을 찾기 위해 이번 변경처럼 findXXXLedgerFromHead 함수에 현 블록의 ledger에 접근하는 동작이 추가됩니다.
 - 쿼리마다 갱신할 경우: 같은 pid를 갖는 ledger가 여러 번 변경될 수 있습니다. 따라서 state tree에 그만큼 더 많이 접근합니다. 대신 findHead 함수가 state tree만 검색하면 되도록 간단해집니다.

 + 참고사항 : state tree(binary tree)와 현 블록 ledger list 접근(map)의 오버헤드를 비교하려면 state tree는 모든 데이터를 가지고 있어야 하므로 블록 ledger list보다는 사이즈가 훨씬 커지는 것을 고려하세요.

|  | 즉시 갱신 | 일괄 갱신 |
|:--------:|:--------:|:--------:|
| 과거 내용 없음 | state tree 확인 | 현 블록 ledger 확인,<br>state tree 확인 |
| 이전 블록에 과거 내용 존재 | state tree 확인 | 현 블록 ledger 확인,<br>state tree 확인 |
| 현재 블록에 과거 내용 존재 | state tree 확인 | 현 블록 ledger 확인 |
| 갱신 횟수 | 쿼리의 수만큼 | 쿼리들 중 서로 다른 pid의 수만큼 |
| ex) 쿼리 100개 중 unique pid 90개씩<br>3블럭 |  state tree 확인 * 300 | 현 블록 ledger 확인 * 300,<br>state tree 확인 * 270 |

어느 쪽이건 잘못된 구현은 아닙니다. 현재 구현은 일괄 갱신입니다.