### PR TITLE
 # FEATURE - Built-in standard contract initialization

### DIFF
--- a/builtin_contracts/value_transfer.xml
+++ b/builtin_contracts/value_transfer.xml
@@ -1,0 +1,25 @@
+<contract>
+    <head>
+        <cid>VALUE-TRANSFER::{{WORLD.CREATOR}}::{{CHAIN.NAME}}::{{WORLD.NAME}}</cid>
+        <after>{{CHAIN.AFTER}}</after>
+        <desc>Official standardcontract for transfering v-type variable</desc>
+    </head>
+    <body>
+        <input>
+            <option name="amount" type="PINT" desc="amount of v-type variable for transfer" />
+            <option name="unit" type="TINYTEXT" desc="unit type of v-type variable for transfer" />
+            <option name="pid" type="BASE64" desc="id of v-type variable for transfer" />
+            <option name="tag" type="XML" desc="condition for use of this v-type value" />
+        </input>
+        <set type="v.transfer" from="user">
+            <option name="to" value="$receiver" />
+            <option name="amount" value="$0.amount" />
+            <option name="unit" value="$0.unit" />
+            <option name="pid" value="$0.pid" />
+            <option name="tag" value="$0.condition" />
+        </set>
+    </body>
+    <fee>
+        <pay from="user" value="$fee" />
+    </fee>
+</contract>

--- a/src/plugins/admin_plugin/rpc_services/rpc_services.cpp
+++ b/src/plugins/admin_plugin/rpc_services/rpc_services.cpp
@@ -449,8 +449,11 @@ void LoadChainService::proceed() {
       delegator.delegate();
 
       res.set_success(true);
-      logger::INFO("[LOAD CHAIN] Success to load chain");
+
       app().completeLoadChain();
+      chain.initBuiltInContracts();
+
+      logger::INFO("[LOAD CHAIN] Success to load chain");
     }
   } catch (...) {
     const string info = "Cannot load the local chain.";

--- a/src/plugins/chain_plugin/CMakeLists.txt
+++ b/src/plugins/chain_plugin/CMakeLists.txt
@@ -43,7 +43,7 @@ endif (SOCI_FOUND)
 set(LIB_PREFIX "/usr/local/lib")
 set(BOTAN_LIB "${LIB_PREFIX}/libbotan-2.a")
 
-target_link_libraries(chain_plugin appbase log
+target_link_libraries(chain_plugin appbase log tinyxml
         ${Boost_LIBRARIES}
         ${BOTAN_LIB}
         )
@@ -57,4 +57,5 @@ target_include_directories(
         "${CMAKE_CURRENT_SOURCE_DIR}/../../../lib/appbase"
         "${CMAKE_CURRENT_SOURCE_DIR}/../../../lib/log"
         "${CMAKE_CURRENT_SOURCE_DIR}/../../../lib/tethys-utils/src"
+        "${CMAKE_CURRENT_SOURCE_DIR}/../../../lib/tinyxml"
         )

--- a/src/plugins/chain_plugin/chain_plugin.cpp
+++ b/src/plugins/chain_plugin/chain_plugin.cpp
@@ -138,6 +138,8 @@ public:
 
   string block_input_path;
 
+  string builtin_contracts_path;
+
   nlohmann::json genesis_state;
 
   incoming::channels::transaction::channel_type::Handle incoming_transaction_subscription;
@@ -169,6 +171,8 @@ public:
       app().setId(self_id);
       app().completeUserSetup();
     }
+
+    chain->loadBuiltInContracts(builtin_contracts_path);
   }
 
   void pushTransaction(const nlohmann::json &transaction_json) {
@@ -544,6 +548,12 @@ void ChainPlugin::pluginInitialize(const boost::program_options::variables_map &
     throw std::invalid_argument("the input of block input path is empty"s);
   }
 
+  if (options.count("builtin-contracts-path")) {
+    impl->builtin_contracts_path = options.at("builtin-contracts-path").as<string>();
+  } else {
+    throw std::invalid_argument("the input of built-in contracts path is empty"s);
+  }
+
   auto &transaction_channel = app().getChannel<incoming::channels::transaction>();
   impl->incoming_transaction_subscription =
       transaction_channel.subscribe([this](const nlohmann::json &transaction) { impl->pushTransaction(transaction); });
@@ -563,7 +573,8 @@ void ChainPlugin::setProgramOptions(options_description &cfg) {
   cfg.add_options()("dbms", boost::program_options::value<string>()->composing(), "DBMS (MYSQL)")("table-name", boost::program_options::value<string>()->composing(), "table name")
   ("database-user", boost::program_options::value<string>()->composing(), "database user id")
   ("database-password", boost::program_options::value<string>()->composing(), "database password")
-  ("block-input-path", boost::program_options::value<string>()->composing(), "block input json path");
+  ("block-input-path", boost::program_options::value<string>()->composing(), "block input json path")
+  ("builtin-contracts-path", boost::program_options::value<string>()->composing(), "built-in standard contracts directory path");
 }
 // clang-format on
 

--- a/src/plugins/chain_plugin/config/storage_config.hpp
+++ b/src/plugins/chain_plugin/config/storage_config.hpp
@@ -41,6 +41,7 @@ namespace config {
         static vector<string> keyValueDBNames() {
           vector<string> names;
 
+          names.emplace_back(DataType::BUILT_IN_CONTRACT);
           names.emplace_back(DataType::WORLD);
           names.emplace_back(DataType::CHAIN);
           names.emplace_back(DataType::BACKUP_BLOCK);

--- a/src/plugins/chain_plugin/config/storage_type.hpp
+++ b/src/plugins/chain_plugin/config/storage_type.hpp
@@ -26,7 +26,11 @@ enum class QueryType : int { INSERT = 0, UPDATE = 1, DELETE = 2 };
 //  CONTRACT_LIST
 //};
 
+const vector<string> BuiltInContractList{// TODO : add more types
+                                         "VALUE-TRANSFER"};
+
 struct DataType {
+  inline static const string BUILT_IN_CONTRACT = "built_in_contract";
   inline static const string WORLD = "world";
   inline static const string CHAIN = "chain";
   inline static const string BACKUP_BLOCK = "backup_block";

--- a/src/plugins/chain_plugin/include/chain.hpp
+++ b/src/plugins/chain_plugin/include/chain.hpp
@@ -9,6 +9,7 @@
 #include "unresolved_block_pool.hpp"
 
 #include <boost/program_options/variables_map.hpp>
+#include <map>
 #include <memory>
 #include <optional>
 #include <utility>
@@ -33,6 +34,8 @@ public:
   Chain(const Chain &&) = delete;
   Chain &operator=(const Chain &) = delete;
 
+  void loadBuiltInContracts(const string &contracts_dir_path);
+  void initBuiltInContracts();
   void initWorld(nlohmann::json &world_state);
   optional<vector<string>> initChain(nlohmann::json &chain_state);
 
@@ -47,6 +50,7 @@ public:
   bool applyContractToRDB(const map<base58_type, contract_type> &contract_list);
 
   // KV functions
+  void saveBuiltInContracts(map<string, string> &contracts);
   void saveLatestWorldId(const alphanumeric_type &world_id);
   void saveLatestChainId(const alphanumeric_type &chain_id);
   void saveWorld(world_type &world_info);

--- a/src/plugins/chain_plugin/include/kv_store.hpp
+++ b/src/plugins/chain_plugin/include/kv_store.hpp
@@ -35,6 +35,7 @@ public:
   KvController();
   ~KvController();
 
+  bool saveBuiltInContracts(map<string, string> &contracts);
   bool saveLatestWorldId(const alphanumeric_type &world_id);
   bool saveLatestChainId(const alphanumeric_type &chain_id);
   bool saveWorld(world_type &world_info);

--- a/src/plugins/chain_plugin/kv_store.cpp
+++ b/src/plugins/chain_plugin/kv_store.cpp
@@ -38,6 +38,16 @@ bool KvController::errorOnCritical(const leveldb::Status &status) {
   }
 }
 
+bool KvController::saveBuiltInContracts(map<string, string> &contracts) {
+  for (auto &contract : contracts) {
+    addBatch(DataType::BUILT_IN_CONTRACT, contract.first, contract.second);
+  }
+
+  commitBatchAll();
+
+  return true;
+}
+
 bool KvController::saveLatestWorldId(const alphanumeric_type &world_id) {
   addBatch(DataType::WORLD, "latest_world_id", world_id);
 

--- a/src/plugins/chain_plugin/rdb_controller.cpp
+++ b/src/plugins/chain_plugin/rdb_controller.cpp
@@ -340,7 +340,7 @@ bool RdbController::applyContractToRDB(const map<base58_type, contract_type> &co
 
       // clang-format off
       if (query_type == QueryType::INSERT) {
-        st = (db_session.prepare << "INSERT INTO contracts (cid, after, before, author, friends, contract, desc, sigma) VALUES (:cid, :after, :before, :author, :friends, :contract, :desc, :sigma)",
+        st = (db_session.prepare << "INSERT INTO contracts (cid, after, `before`, author, friends, contract, `desc`, sigma) VALUES (:cid, :after, :before, :author, :friends, :contract, :desc, :sigma)",
             soci::use(cid, "cid"), soci::use(after, "after"), soci::use(before, "before"),
             soci::use(author, "author"), soci::use(friends, "friends"), soci::use(contract, "contract"),
             soci::use(desc, "desc"), soci::use(sigma, "sigma"),


### PR DESCRIPTION
 ### 추가사항
- chain plugin 초기화 단계서 built-in contract xml 을 읽어 string 형태로 key-value store에 저장하도록 함.
- `Load Chain` 명령어 실행 시 Built-in contract의 예약어 부분을 수정하여
RDB에 저장 하도록 함.
 - 참고 : 
   -  https://thevaulters.atlassian.net/wiki/spaces/SGN/pages/78479361/SC5.+Built-in+StandardContracts

 ### 기타 버그 수정
- applyContractToRDB() 에서 query문에서 `before` 및 `desc` 가 sql 에서
예약어로 사용되어 이를 해결하기 위해 ` 문자를 사용하여 해결