### PR TITLE
 # FEATURE - prepare to use contract engine in chain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ target_link_libraries(tethys
         net_plugin
         block_producer_plugin
         chain_plugin
+        contract
         )
 
 target_include_directories(tethys

--- a/include/date.hpp
+++ b/include/date.hpp
@@ -3862,7 +3862,7 @@ public:
   CONSTCD11 bool in_conventional_range() const NOEXCEPT
   {
     using namespace std;
-    return !neg_ && h_ < days{1} && m_ < chrono::hours{1} &&
+    return !neg_ && h_ < days{1} && m_ < std::chrono::hours{1} &&
         s_.in_conventional_range();
   }
 
@@ -3877,10 +3877,10 @@ private:
     using namespace std;
     if (tod.is_negative())
       os << '-';
-    if (tod.h_ < chrono::hours{10})
+    if (tod.h_ < std::chrono::hours{10})
       os << '0';
     os << tod.h_.count() << ':';
-    if (tod.m_ < chrono::minutes{10})
+    if (tod.m_ < std::chrono::minutes{10})
       os << '0';
     os << tod.m_.count() << ':' << tod.s_;
     return os;

--- a/src/plugins/chain_plugin/chain_plugin.cpp
+++ b/src/plugins/chain_plugin/chain_plugin.cpp
@@ -1,4 +1,5 @@
 #include "include/chain_plugin.hpp"
+#include "../../contract/include/engine.hpp"
 
 namespace tethys {
 
@@ -130,6 +131,7 @@ class ChainPluginImpl {
 public:
   unique_ptr<Chain> chain;
   unique_ptr<TransactionPool> transaction_pool;
+  unique_ptr<tsce::ContractEngine> contract_engine;
 
   string dbms;
   string table_name;
@@ -149,6 +151,9 @@ public:
   void initialize() {
     chain = make_unique<Chain>(dbms, table_name, db_user_id, db_password);
     transaction_pool = make_unique<TransactionPool>();
+    contract_engine = make_unique<tsce::ContractEngine>();
+
+    contract_engine->attachReadInterface([this](const nlohmann::json &req_query) { return processRequestQuery(req_query); });
 
     auto world_id = chain->getValueByKey(DataType::WORLD, "latest_world_id");
     if (!world_id.empty()) {


### PR DESCRIPTION
- ContractEngine 의 attachReadInterFace에 request query를 처리 할 수
있도록 `processRequestQuery`를 등록

 #### 기타수정
- include/data.hpp 에서 `std::chrono` 와 `boost::asio::chrono`가  ambiguous 한 문제로
std:: 가 빠진부분 추가

 #### TODO:
- ContractEngine의 procBlock() 을 이용 하여 block의 tx를 처리 하는 부분
작성 필요