### PR TITLE
 # ADD - Support signature pool

### DIFF
--- a/src/plugins/block_producer_plugin/CMakeLists.txt
+++ b/src/plugins/block_producer_plugin/CMakeLists.txt
@@ -1,22 +1,30 @@
 cmake_minimum_required(VERSION 3.10)
 
+file(GLOB HEADERS
+        "include/*.hpp"
+        )
+
+file(GLOB SOURCES
+        "*.cpp"
+        )
+
 add_library(block_producer_plugin
-        block_producer_plugin.cpp
-        include/block_producer_plugin.hpp)
+        ${HEADERS}
+        ${SOURCES})
 
 find_package(Soci)
 if (SOCI_FOUND)
-	target_link_libraries(block_producer_plugin ${SOCI_LIBRARY} ${SOCI_mysql_PLUGIN})
+    target_link_libraries(block_producer_plugin ${SOCI_LIBRARY} ${SOCI_mysql_PLUGIN})
 else ()
-	message(WARNING "SOCI NOT FOUND")
+    message(WARNING "SOCI NOT FOUND")
 endif ()
 
 target_link_libraries(block_producer_plugin appbase log)
 target_include_directories(block_producer_plugin PUBLIC
-		"/usr/local/include/mysql"
+        "/usr/local/include/mysql"
         "/usr/include/mysql"
-		"${SOCI_INCLUDE_DIR}"
-		
+        "${SOCI_INCLUDE_DIR}"
+
         "${CMAKE_CURRENT_SOURCE_DIR}/../../../lib/appbase"
         "${CMAKE_CURRENT_SOURCE_DIR}/../../../lib/log"
         )

--- a/src/plugins/block_producer_plugin/include/ssig_pool.hpp
+++ b/src/plugins/block_producer_plugin/include/ssig_pool.hpp
@@ -1,0 +1,29 @@
+#pragma once
+#include <shared_mutex>
+#include <unordered_map>
+#include <vector>
+#include <string>
+
+using namespace std;
+
+using base58_id_type = string;
+using signature_type = string;
+
+struct SupportSigInfo {
+  base58_id_type supporter_id;
+  signature_type sig;
+};
+
+class SupportSigPool {
+public:
+  SupportSigPool() = default;
+
+  void add(const SupportSigInfo &ssig_info);
+  vector<SupportSigInfo> fetchAll();
+  int size();
+  void clear();
+
+private:
+  std::shared_mutex pool_mutex;
+  unordered_map<base58_id_type, SupportSigInfo> ssig_pool;
+};

--- a/src/plugins/block_producer_plugin/ssig_pool.cpp
+++ b/src/plugins/block_producer_plugin/ssig_pool.cpp
@@ -1,0 +1,27 @@
+#include "include/ssig_pool.hpp"
+#include <algorithm>
+
+void SupportSigPool::add(const SupportSigInfo &ssig_info) {
+  unique_lock<shared_mutex> lock(pool_mutex);
+  ssig_pool.emplace(ssig_info.supporter_id, ssig_info);
+}
+
+vector<SupportSigInfo> SupportSigPool::fetchAll() {
+  vector<SupportSigInfo> v;
+  {
+    shared_lock<shared_mutex> lock(pool_mutex);
+    transform(ssig_pool.begin(), ssig_pool.end(), back_inserter(v), [](auto &kv) { return kv.second; });
+  }
+  clear();
+  return v;
+}
+
+int SupportSigPool::size() {
+  shared_lock<shared_mutex> lock(pool_mutex);
+  return ssig_pool.size();
+}
+
+void SupportSigPool::clear() {
+  unique_lock<shared_mutex> lock(pool_mutex);
+  ssig_pool.clear();
+}

--- a/src/plugins/channel_interface/include/channel_interface.hpp
+++ b/src/plugins/channel_interface/include/channel_interface.hpp
@@ -17,6 +17,7 @@ using transaction = ChannelTypeTemplate<struct transaction_tag, nlohmann::json>;
 using block = ChannelTypeTemplate<struct block_tag, nlohmann::json>;
 using SCE_result = ChannelTypeTemplate<struct SCE_result_tag, nlohmann::json>;
 using transaction_pool = ChannelTypeTemplate<struct tx_pool_tag, vector<tethys::Transaction>>;
+using ssig = ChannelTypeTemplate<struct ssig_tag, nlohmann::json>;
 }; // namespace channels
 } // namespace appbase::incoming
 

--- a/src/plugins/net_plugin/rpc_services/rpc_services.cpp
+++ b/src/plugins/net_plugin/rpc_services/rpc_services.cpp
@@ -252,7 +252,9 @@ private:
     case MessageType::MSG_SUCCESS:
       return user_pool_manager->handleMsg(msg);
     case MessageType::MSG_SSIG:
-      // TODO : ssig message must be sent to `block producer`
+      app().getChannel<incoming::channels::ssig>().publish(msg.body);
+      return {};
+
     case MessageType::MSG_REQ_TX_CHECK:
     case MessageType::MSG_QUERY:
     case MessageType::MSG_REQ_BONE:


### PR DESCRIPTION
- block producer에서 block을 만들기 위한 support signature 를 모으기위한
pool 추가

 #### 추가사항
- SupportSigPool 추가
- MSG_SSIG가 왔을때 해당 내용을 보내기위한 channel 추가

 #### 수정사항
- Netplugin의 userPool getSigner() 함수 수정 (getCloseSigner 로 명칭
수정
  - signer를 뽑을때는 optimal signer와 hamming distance가 가까운
signer부터 뽑아야 하므로 이를 수정

 #### 기타사항
- `selected_signer` 는 MSG_REQ_SSIG를 보낼때 사용할 signer 목록입니다.