### PR TITLE
# EDIT - MSG_TX parsing 할 때, /user/pk 가 null 인 경우 처리

### DIFF
--- a/src/plugins/chain_plugin/structure/transaction.hpp
+++ b/src/plugins/chain_plugin/structure/transaction.hpp
@@ -57,7 +57,7 @@ public:
       setTxInputCbor(msg_tx_json["body"]["input"]);
 
       m_tx_user_id = msg_tx_json["/user/id"_json_pointer];
-      m_tx_user_pk = msg_tx_json["/user/pk"_json_pointer];
+      m_tx_user_pk = extractPubKeyIfUnauthorized(msg_tx_json);
       m_tx_user_sig = msg_tx_json["/user/sig"_json_pointer];
 
       if (!setEndorsers(msg_tx_json["endorser"])) {
@@ -68,8 +68,18 @@ public:
       logger::ERROR("Failed to parse transaction json: {}", e.what());
       return false;
     } catch (std::exception &e) {
-      logger::ERROR("Unexpected error {}", e.what());
+      logger::ERROR("Unexpected error at `Transaction#inputMsgTx`: {}", e.what());
       return false;
+    }
+  }
+
+  string extractPubKeyIfUnauthorized(const nlohmann::json &msg) {
+    auto pk = msg["user"]["pk"];
+
+    if (pk.is_null()) {
+      return "";
+    } else {
+      return pk;
     }
   }
 


### PR DESCRIPTION
## 수정 이유
- MSG_TX에서 User가 실명 User 인 경우 /user/pk 가 null인 경우가 있다. 하지만, 코드에서는 null 인 case를 처리하지 않기 때문에 exception이 발생함

## 수정 사항
- 의도를 분명하게 하기 위해 `extractPubKeyIfUnauthorized` 함수를 생성해서 null 인 경우와 아닌 경우에 다르게 처리하도록 했음