### PR TITLE
  # FEATURE - make MSG_BLOCK

### DIFF
--- a/src/plugins/block_producer_plugin/include/ssig_pool.hpp
+++ b/src/plugins/block_producer_plugin/include/ssig_pool.hpp
@@ -9,10 +9,12 @@ namespace tethys {
 using namespace std;
 using base58_id_type = string;
 using signature_type = string;
+using cert_type = string;
 
 struct SupportSigInfo {
-  base58_id_type supporter_id;
+  base58_id_type id;
   signature_type sig;
+  cert_type cert;
 };
 
 class SupportSigPool {

--- a/src/plugins/block_producer_plugin/ssig_pool.cpp
+++ b/src/plugins/block_producer_plugin/ssig_pool.cpp
@@ -4,7 +4,7 @@
 namespace tethys {
 void SupportSigPool::add(const SupportSigInfo &ssig_info) {
   unique_lock<shared_mutex> lock(pool_mutex);
-  ssig_pool.emplace(ssig_info.supporter_id, ssig_info);
+  ssig_pool.emplace(ssig_info.id, ssig_info);
 }
 
 vector<SupportSigInfo> SupportSigPool::fetchAll() {


### PR DESCRIPTION
 #### 추가사항
 - MSG_BLOCK을 만들 함수 추가 ( makeMsgBlock )
 - MSG_BLOCK에 서명을 하는 함수 추가 (signMsgBlock)
 - https://thevaulters.atlassian.net/wiki/spaces/SGN/pages/86638675/Block+Messages

 #### 수정사항
 - MSG_REQ_SSIG & MSG_BLOCK 에서 내부의 block 필드를 만드는데 동일한
내용을 사용하므로 이를 함수로 바꿈( makeBaseMsgBlock)
 - ssig_pool에 supporter(signer)의 cert도 가지고 있도록 수정사항
   - MSG_BLOCK을 만드는 과정에서 certificate 필드에 signer의 cert를
추가하여야함.