### PR TITLE
 # ADD - Get blocks from unresolved longest chain

### DIFF
--- a/src/plugins/chain_plugin/chain.cpp
+++ b/src/plugins/chain_plugin/chain.cpp
@@ -1368,6 +1368,24 @@ search_result_type Chain::findContractLedgerFromPoint(const string &pid, block_h
   }
 }
 
+vector<Block> Chain::getBlocksFromUnresolvedLongestChain() {
+  auto latest_height = m_longest_chain_info.block_height;
+  auto latest_block_id = m_longest_chain_info.block_id;
+
+  auto chain_path = unresolved_block_pool->getPath(latest_block_id, latest_height);
+
+  vector<Block> blocks;
+  for (int i = 0; i < chain_path.size(); i++) {
+    int deq_idx = i;
+    int vec_idx = chain_path[i];
+    auto unresolved_block = unresolved_block_pool->getUnresolvedBlock(deq_idx, vec_idx);
+
+    blocks.push_back(unresolved_block.block);
+  }
+
+  return blocks;
+}
+
 Block &Chain::getLowestUnprocessedBlock() {
   // 가장 긴 chain에서의 처리되지 않은 블록 중 가장 낮은 height block을 return
   return unresolved_block_pool->getLowestUnprocessedBlock(m_longest_chain_info);

--- a/src/plugins/chain_plugin/include/chain.hpp
+++ b/src/plugins/chain_plugin/include/chain.hpp
@@ -82,6 +82,7 @@ public:
   bool applyUserCertToRDB(const map<base58_type, user_cert_type> &user_cert_list);
   bool applyContractToRDB(const map<base58_type, contract_type> &contract_list);
 
+  vector<Block> getBlocksFromUnresolvedLongestChain();
   vector<Block> getBlocksByHeight(int from, int to);
   block_height_type getLatestResolvedHeight();
 


### PR DESCRIPTION
- unresolved block pool 에서 가장 긴 chain 으로 연결된 block들을 가지고
올 수 있는 함수 추가.

 #### TODO:
  - 현재 Block Publishing time을 계산하는데 resolved 된 block들을
이용하여 계산 함.
  - longest chain info(Unresolved) 가 가리키고 있는 곳 부터 시작해서 block을 차례로
가져와서 계산하여야함.