### PR TITLE
 # ADD - Fee process

### DIFF
--- a/src/contract/query_composer.cpp
+++ b/src/contract/query_composer.cpp
@@ -21,8 +21,8 @@ namespace tethys::tsce {
         //res.erase("fee");
         res.erase("queries");
 
-        res["fee"]["author"] = 0;
-        res["fee"]["user"] = MIN_USER_FEE;
+        res["fee"]["author"] = to_string(0);
+        res["fee"]["user"] = to_string(MIN_USER_FEE);
       }
       result["results"].emplace_back(res);
     }

--- a/src/plugins/chain_plugin/config/storage_type.hpp
+++ b/src/plugins/chain_plugin/config/storage_type.hpp
@@ -156,11 +156,11 @@ using result_query_info_type = struct ResultQueryInfoType {
   base58_type tx_id;
   bool status;
   string info;
-  base58_type author;
-  base58_type user;
-  base58_type receiver;
-  contract_id_type self;
-  std::vector<contract_id_type> friends;
+  optional<base58_type> author;
+  optional<base58_type> user;
+  optional<base58_type> receiver;
+  optional<contract_id_type> self;
+  vector<contract_id_type> friends;
   int fee_author;
   int fee_user;
 

--- a/src/plugins/chain_plugin/include/chain.hpp
+++ b/src/plugins/chain_plugin/include/chain.hpp
@@ -26,6 +26,8 @@ private:
   unique_ptr<KvController> kv_controller;
   unique_ptr<UnresolvedBlockPool> unresolved_block_pool;
 
+  string m_keyc_name;
+
 public:
   Chain(string_view dbms, string_view table_name, string_view db_user_id, string_view db_password);
   ~Chain();
@@ -38,6 +40,7 @@ public:
   void initBuiltInContracts();
   void initWorld(nlohmann::json &world_state);
   optional<vector<string>> initChain(nlohmann::json &chain_state);
+  void setKeycName(const string &keyc_name);
 
   // KV functions
   const nlohmann::json queryWorldGet();
@@ -68,7 +71,7 @@ public:
   const nlohmann::json queryUserInfoGet(const nlohmann::json &where_json);
   const nlohmann::json queryUserScopeGet(const nlohmann::json &where_json);
   const nlohmann::json queryContractScopeGet(const nlohmann::json &where_json);
-  //const nlohmann::json queryBlockGet(const nlohmann::json &where_json);
+  // const nlohmann::json queryBlockGet(const nlohmann::json &where_json);
   const nlohmann::json queryTxGet(const nlohmann::json &where_json);
   const nlohmann::json queryBlockScan(const nlohmann::json &where_json);
   const nlohmann::json queryTxScan(const nlohmann::json &where_json);
@@ -103,6 +106,8 @@ public:
   string calculatePid(const string &var_name, int var_type, const string &var_owner, const string &tag_varinfo);
   int getVarType(const string &var_owner, const string &var_name, const block_height_type height, const int vec_idx);
   bool checkUniqueVarName(const string &var_owner, const string &var_name, const block_height_type height, const int vec_idx);
+  bool withdrawFee(UnresolvedBlock &UR_block, const base58_type &user_id, const int fee);
+  bool distributeFee(UnresolvedBlock &UR_block, const uint64_t block_total_fee);
 
   block_push_result_type pushBlock(Block &new_block);
   UnresolvedBlock getUnresolvedBlock(const base58_type &block_id, const block_height_type block_height);

--- a/src/plugins/chain_plugin/rdb_controller.cpp
+++ b/src/plugins/chain_plugin/rdb_controller.cpp
@@ -983,7 +983,7 @@ vector<contract_ledger_type> RdbController::getAllContractLedger() {
 bool RdbController::isUserId(const string &id) {
   const auto BASE58_REGEX = "^[A-HJ-NP-Za-km-z1-9]*$";
   regex rgx(BASE58_REGEX);
-  if (id.size() != static_cast<int>(44) || !regex_match(id, rgx)) {
+  if (id.size() != !regex_match(id, rgx)) {
     logger::ERROR("Invalid user ID.");
     return false;
   }

--- a/src/plugins/chain_plugin/structure/block.hpp
+++ b/src/plugins/chain_plugin/structure/block.hpp
@@ -1,14 +1,14 @@
 #ifndef TETHYS_PUBLIC_MERGER_BLOCK_HPP
 #define TETHYS_PUBLIC_MERGER_BLOCK_HPP
 
+#include "../../../../lib/appbase/include/application.hpp"
+#include "../../../../lib/json/include/json.hpp"
+
 #include "../config/storage_type.hpp"
 #include "../include/static_merkle_tree.hpp"
 #include "certificate.hpp"
 #include "signature.hpp"
 #include "transaction.hpp"
-
-#include "../../../../lib/appbase/include/application.hpp"
-#include "../../../../lib/json/include/json.hpp"
 
 using namespace std;
 

--- a/src/plugins/chain_plugin/structure/block.hpp
+++ b/src/plugins/chain_plugin/structure/block.hpp
@@ -7,6 +7,7 @@
 #include "signature.hpp"
 #include "transaction.hpp"
 
+#include "../../../../lib/appbase/include/application.hpp"
 #include "../../../../lib/json/include/json.hpp"
 
 using namespace std;
@@ -153,12 +154,14 @@ public:
   bool setTransaction(std::vector<txagg_cbor_b64> &txagg) {
     m_transactions.clear();
     for (auto &each_txagg : txagg) {
-      nlohmann::json each_txs_json;
-      each_txs_json = nlohmann::json::from_cbor(TypeConverter::decodeBase<64>(each_txagg));
+      nlohmann::json each_txaggs_json;
+      each_txaggs_json = nlohmann::json::from_cbor(TypeConverter::decodeBase<64>(each_txagg));
 
       Transaction each_tx;
+      each_tx.setWorld(appbase::app().getWorldId());
+      each_tx.setChain(appbase::app().getChainId());
       block_info_type block_info(each_txagg, getBlockId());
-      each_tx.inputMsgTxAgg(each_txs_json, block_info);
+      each_tx.inputMsgTxAgg(each_txaggs_json, block_info);
       m_transactions.emplace_back(each_tx);
     }
     return true;

--- a/src/plugins/chain_plugin/structure/transaction.hpp
+++ b/src/plugins/chain_plugin/structure/transaction.hpp
@@ -60,10 +60,8 @@ public:
       m_tx_user_pk = extractPubKeyIfUnauthorized(msg_tx_json);
       m_tx_user_sig = msg_tx_json["/user/sig"_json_pointer];
 
-      if (!setEndorsers(msg_tx_json["endorser"])) {
-        return false;
-      }
-      return true;
+      return setEndorsers(msg_tx_json["endorser"]);
+
     } catch (nlohmann::json::parse_error &e) {
       logger::ERROR("Failed to parse transaction json: {}", e.what());
       return false;
@@ -114,10 +112,8 @@ public:
       m_tx_user_agga = json::get<string>(tx_json["user"], "a").value();
       m_tx_user_aggz = json::get<string>(tx_json["user"], "z").value();
 
-      if (!setEndorsers(tx_json["endorser"])) {
-        return false;
-      }
-      return true;
+      return setEndorsers(tx_json["endorser"]);
+
     } catch (nlohmann::json::parse_error &e) {
       logger::ERROR("Failed to parse transaction json: {}", e.what());
       return false;


### PR DESCRIPTION
fee를 처리하는 로직을 추가했습니다.
transfer와 비슷하게 user ledger쪽의 값을 변경하는 작업입니다. fee만 처리되고 transaction은 처리되지 않는다거나 하는식의 atomic한 연산이 필요할 수 있습니다.

tx의 status가 실패할 시 fee를 징수하는 정도, fee의 signer와 merger의 분배 비율과 같이 운영 정책에 관련된 사항은 추후 수정될 수 있습니다.